### PR TITLE
Assemble private-evaluation RC1 artifacts

### DIFF
--- a/.github/workflows/build-installers.yml
+++ b/.github/workflows/build-installers.yml
@@ -15,6 +15,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - "**/*.txt"
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -15,6 +15,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - "**/*.txt"
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/managed-ui-validation-linux.yml
+++ b/.github/workflows/managed-ui-validation-linux.yml
@@ -15,6 +15,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - "**/*.txt"
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/native-release-readiness.yml
+++ b/.github/workflows/native-release-readiness.yml
@@ -2,6 +2,7 @@ name: Native Release Readiness
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/rc-candidate-assembly.yml
+++ b/.github/workflows/rc-candidate-assembly.yml
@@ -1,0 +1,145 @@
+name: Assemble RC1 Evaluation Candidate
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_tag:
+        description: Exact immutable RC tag to assemble
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate-candidate:
+    name: Validate exact RC1 tag and commit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Fail closed outside the immutable RC1 tag
+        shell: bash
+        env:
+          COPPERFIN_CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+        run: |
+          set -euo pipefail
+          expected_tag="v0.1.0-rc.1"
+          if [[ "$COPPERFIN_CANDIDATE_TAG" != "$expected_tag" ]]; then
+            echo "candidate_tag must be exactly $expected_tag" >&2
+            exit 1
+          fi
+          if [[ "$GITHUB_REF_TYPE" != "tag" || "$GITHUB_REF_NAME" != "$expected_tag" ]]; then
+            echo "Run this workflow from the exact $expected_tag tag, not $GITHUB_REF." >&2
+            exit 1
+          fi
+          checked_out_revision="$(git rev-parse HEAD)"
+          tagged_revision="$(git rev-parse "refs/tags/$expected_tag^{commit}")"
+          if [[ "$checked_out_revision" != "$GITHUB_SHA" || "$tagged_revision" != "$GITHUB_SHA" ]]; then
+            echo "The checkout, workflow revision, and annotated tag target must be identical." >&2
+            exit 1
+          fi
+          if [[ ! "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "GitHub did not provide a lowercase full commit ID." >&2
+            exit 1
+          fi
+
+  native-release-readiness:
+    needs: validate-candidate
+    uses: ./.github/workflows/native-release-readiness.yml
+
+  managed-ui:
+    needs: validate-candidate
+    uses: ./.github/workflows/managed-ui-validation-linux.yml
+
+  installers:
+    needs: validate-candidate
+    uses: ./.github/workflows/build-installers.yml
+
+  visual-studio-vsix:
+    needs: validate-candidate
+    uses: ./.github/workflows/build-vsix.yml
+
+  security-and-sbom:
+    needs: validate-candidate
+    uses: ./.github/workflows/security-supply-chain.yml
+
+  assemble-evaluation-bundle:
+    name: Assemble verified RC1 evaluation bundle
+    needs:
+      - validate-candidate
+      - native-release-readiness
+      - managed-ui
+      - installers
+      - visual-studio-vsix
+      - security-and-sbom
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact candidate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Create authoritative exact Corresponding Source archive
+        uses: ./.github/actions/create-release-source
+        with:
+          revision: ${{ github.sha }}
+          output-directory: rc-inputs/copperfin-release-source
+
+      - name: Download Windows installers
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: copperfin-windows-installers
+          path: rc-inputs/copperfin-windows-installers
+
+      - name: Download macOS installers
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: copperfin-macos-installers
+          path: rc-inputs/copperfin-macos-installers
+
+      - name: Download Linux installers
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: copperfin-linux-installers
+          path: rc-inputs/copperfin-linux-installers
+
+      - name: Download Visual Studio VSIX
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: copperfin-visualstudio-vsix
+          path: rc-inputs/copperfin-visualstudio-vsix
+
+      - name: Download CycloneDX SBOM
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: cyclonedx-sbom
+          path: rc-inputs/cyclonedx-sbom
+
+      - name: Assemble and verify candidate
+        shell: bash
+        env:
+          COPPERFIN_CANDIDATE_TAG: ${{ inputs.candidate_tag }}
+        run: |
+          set -euo pipefail
+          python3 scripts/assemble-rc-candidate.py \
+            --input-root rc-inputs \
+            --output-dir copperfin-v0.1.0-rc.1 \
+            --repository-root . \
+            --candidate-tag "$COPPERFIN_CANDIDATE_TAG" \
+            --revision "$GITHUB_SHA" \
+            --repository "$GITHUB_REPOSITORY" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --server-url "$GITHUB_SERVER_URL"
+
+      - name: Upload single evaluation bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: copperfin-v0.1.0-rc.1-evaluation-bundle
+          path: copperfin-v0.1.0-rc.1
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/security-supply-chain.yml
+++ b/.github/workflows/security-supply-chain.yml
@@ -15,6 +15,7 @@ on:
       - "docs/**"
       - "**/*.md"
       - "**/*.txt"
+  workflow_call:
 
 jobs:
   cve-sbom-gate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+- 2026-08-07: Added the fail-closed private-evaluation RC1 assembly path under
+  #4907. Manual workflow dispatch accepts only exact tag `v0.1.0-rc.1` at its
+  peeled 40-character commit, then requires hosted Linux/macOS/Windows native
+  release readiness, Linux managed UI, all platform installers, the Visual
+  Studio VSIX, and the security/SBOM gate. One final job assembles the verified
+  NSIS/ZIP, productbuild/TGZ, DEB/RPM/TGZ, VSIX, authoritative exact
+  Corresponding Source, CycloneDX SBOM, license metadata, tester guide,
+  non-secret validation manifest, and SHA-256 manifest into a single 90-day
+  GitHub Actions artifact. The workflow has read-only permissions, uses
+  immutable action pins, consumes no repository secrets, publishes no GitHub
+  Release, and does not claim Windows launcher release-trust approval or
+  macOS/Linux platform signing. Static and executable regressions cover the
+  workflow contract, real hosted artifact layout, private-key block rejection, and
+  deterministic bundle metadata. No runtime, VFP9, localization catalog,
+  package/debug schema, xAsset, report/label, IDE, stack, or platform product
+  behavior changed.
+
 - 2026-08-07: Hardened GPL-exception and release-license compliance under
   #4904. The exception now distinguishes automatically emitted Standard
   Support Material in permitted application output from separately distributed

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ License documents:
   — exception scope, offline evidence, and release-review rationale
 - [`docs/34-human-authorship-and-assisted-development.md`](docs/34-human-authorship-and-assisted-development.md)
   — human direction, review, provenance, and assisted-development evidence
+- [`docs/35-rc1-evaluation-guide.md`](docs/35-rc1-evaluation-guide.md)
+  — private RC1 artifact verification, test scope, limitations, and feedback
 - [`docs/archive/commercial-licensing-2026/`](docs/archive/commercial-licensing-2026/README.md)
   — inactive, preserved commercial/source-available planning documents
 - [`SECURITY.md`](SECURITY.md)

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -2,6 +2,28 @@
 
 ## Current State
 
+#4907 adds a private-evaluation RC1 assembly lane without weakening the
+official-release gates. `.github/workflows/rc-candidate-assembly.yml` is manual,
+read-only, and accepts only tag `v0.1.0-rc.1` when its peeled target, checkout,
+and GitHub workflow SHA are identical. Reusable hosted gates cover native
+Linux/macOS/Windows release readiness, Linux managed UI, all platform
+installers, Visual Studio VSIX behavior, and security/SBOM. The final Ubuntu
+job creates one authoritative exact-revision source archive and uses
+`scripts/assemble-rc-candidate.py` to verify the real nested artifact layout,
+reject secret-like names and complete private-key blocks, compare SBOM licensing
+companions with the tagged repository, and emit one 90-day evaluation bundle
+with SHA-256 and non-secret validation manifests. The tester guide states that
+this is not an official release, Windows launcher release-trust remains a
+separate protected approval, macOS/Linux signing is unsupported, translations
+retain review limits, and GitHub artifacts expire. Focused local contracts pass
+`6/6`; the complete local suite passes `323/323` with only the two documented
+POSIX launcher-process skips; a rehearsal against real hosted
+installer/VSIX/SBOM artifacts and its checksum verification succeeds; and
+workflow YAML parses. Hosted exact-head review, merge, immutable tagging,
+candidate execution, artifact inspection, and creation of `v1-development`
+remain before #4907 closes. No local Windows/macOS host or inter-agent channel
+is required for those GitHub-hosted gates.
+
 #4904 hardens the GPL exception and release-license compliance surface. The
 operative exception now distinguishes automatically emitted Standard Support
 Material in Permitted Output from separately distributed Copperfin Code, while
@@ -23,9 +45,11 @@ installer lanes, and the security/SBOM evidence are covered. The repository
 also has a trusted-base pull-request DCO check, and GitHub web commit sign-off
 is enabled. The launcher-key generator and its permission regression select
 GNU `stat -c` or BSD `stat -f` explicitly, preserving the same current-user and
-mode-0600 boundary on Linux and macOS. Focused Linux contracts pass; hosted
-macOS rerun and final artifact validation remain for the slice. No runtime,
-VFP9, localization, package/debug schema, xAsset, report/label, IDE, stack, or
+mode-0600 boundary on Linux and macOS. Focused Linux contracts pass, and PR
+#4906 completed all 22 hosted checks at final source head `18067e646`, including
+macOS Native `31231177152` and Windows Native `31231177171`; the rebase merge
+landed on `main` at `05eac7952`. #4904 is closed. No runtime, VFP9,
+localization, package/debug schema, xAsset, report/label, IDE, stack, or
 platform product behavior changes.
 
 #4903 completes the repository community-health and contributor-licensing

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -297,17 +297,22 @@ Individual native, VSIX `30550923339`, Linux managed-UI `30550923344`,
 installer `30550923408`, and security/SBOM `30550923513` workflows also pass.
 The final release-validation regressions #4891, #4892, and #4893 are closed.
 
-This is implementation-complete RC readiness, not authority to publish the RC.
-The complete RC release evidence gate remains open until #4403 receives genuine
+This is implementation-complete RC readiness, not authority to publish an
+official release. Private RC1 evaluation may proceed through the fail-closed
+GitHub Actions artifact workflow without a GitHub Release, protected signing,
+or a claim that the external release authorities are satisfied. The complete
+official-release evidence gate remains open until #4403 receives genuine
 arm's-length safety sign-off, closes, and passes strict validation, and until
-#4409 receives the approved protected launcher-trust signer/registry secrets and
-passes enforced Windows validation. Permissive primary-hazard safety run
+#4409 receives the approved protected launcher-trust signer/registry secrets
+and passes enforced Windows validation. Permissive primary-hazard safety run
 `30555972170` is green but cannot substitute for that strict closure. The
 hosted Deep runner also lacked VFP9;
 accepted installed-VFP9, mounted-sample, RuntimePackage/xAsset/Report/Menu, and
 live Visual Studio evidence remains the closed #4621 baseline because the final
-changes were catalog/managed/test-only. The v1 roadmap below is prepared and
-remains queued behind those two external release authorities.
+changes were catalog/managed/test-only. After the immutable RC1 artifact passes,
+the long-lived v1 development branch may begin at that exact tag while RC
+stabilization remains isolated. Neither lane may reinterpret this parallel work
+as closure of #4403 or #4409 or as authority for an official 1.0 release.
 
 The #4873 Studio-host JSON-control-escape child is closed at exact product/test
 head `4a75d3273`. Focused shared-platform JSON and real Studio-host diagnostic

--- a/docs/26-localization-and-release-readiness.md
+++ b/docs/26-localization-and-release-readiness.md
@@ -41,7 +41,11 @@ test-owned process readiness. The final local `test_managed_compile` and full
 `316/316` CTest suite pass. The production-language warning below remains:
 Spanish and Portuguese still require qualified linguistic review.
 
-Implementation is RC-ready, but release authorization remains open. Permissive
+Implementation is RC-ready, but official-release authorization remains open.
+Private RC1 evaluation is permitted through the manual exact-tag GitHub Actions
+artifact workflow. That path records the English source-of-truth and preserves
+the Spanish/Portuguese human-review warning, but it neither publishes a GitHub
+Release nor claims protected signing or independent safety approval. Permissive
 #4403 primary-hazard safety run `30555972170` passes; genuine arm's-length
 review, formal issue closure, and strict validation remain required. #4409
 cannot run its enforced trust gate because no protected repository
@@ -50,8 +54,10 @@ implementation: the protected signer now signs a finalized inventory and the
 actual enforced guard records valid launch and stable exit-code-4 failures
 without exposing private material. That implementation does not replace the
 missing approved signer/registry or its required protected Windows run. Do not
-present the MVP RC as released or advance the active queue into v1 until those
-external authorities are satisfied.
+present the MVP RC as an official release. Once the immutable RC1 artifact
+passes, v1 development may proceed on its dedicated branch from the exact RC1
+commit while those external authorities and the RC stabilization lane remain
+separate.
 
 The corrected mechanics are platform-validated at exact head `f0c9e06e2`:
 Windows native run `30559930672` passes `315/315` after compiling the fixture

--- a/docs/35-rc1-evaluation-guide.md
+++ b/docs/35-rc1-evaluation-guide.md
@@ -1,0 +1,79 @@
+# Project Copperfin RC1 Evaluation Guide
+
+Project Copperfin `v0.1.0-rc.1` is a private-evaluation release candidate. It
+is not an official Project Copperfin release and is not distributed through a
+published GitHub Release. The bundle is produced by a manually dispatched,
+fail-closed GitHub Actions workflow from the exact tagged commit.
+
+## Verify Before Testing
+
+1. Download the single `copperfin-v0.1.0-rc.1-evaluation-bundle` workflow
+   artifact while signed in to GitHub.
+2. Extract it into a new directory.
+3. Compare the tag and 40-character revision in
+   `rc-validation-manifest.json` with the workflow page.
+4. Verify every entry in `SHA256SUMS.txt` before opening or installing a
+   payload. On Windows, use `Get-FileHash -Algorithm SHA256`; on macOS or
+   Linux, use `shasum -a 256` or `sha256sum`.
+5. Retain the artifact name and digest with the test report. GitHub workflow
+   artifacts expire; this bundle requests 90-day retention, which remains
+   subject to repository and GitHub retention policy.
+
+## Payloads
+
+- `installers/windows/` contains the NSIS installer and portable ZIP.
+- `installers/macos/` contains the productbuild package and portable TGZ.
+- `installers/linux/` contains DEB, RPM, and portable TGZ packages.
+- `ide/visual-studio/` contains the Visual Studio VSIX.
+- `source/` contains the exact Corresponding Source archive for the tagged
+  revision.
+- `sbom/` contains the CycloneDX software bill of materials.
+- `licensing/` contains the GPLv3 license, Copperfin exception, plain-language
+  explanation, Corresponding Source contract, release metadata, and
+  third-party notices.
+
+Choose only the installer or archive appropriate to the test operating system.
+Use disposable or backed-up test environments for legacy applications and
+data. Do not submit customer, employer, proprietary, personal, credential, or
+other restricted material to Project Copperfin or to a public issue.
+
+## Signing And Review Limits
+
+This evaluation workflow does not claim completion of the protected Windows
+launcher release-trust approval. Unless that separate protected process has
+been completed and directly evidenced, treat generated Windows launchers as
+evaluation output rather than approved release-trusted inventory. The Windows
+installer also does not claim Authenticode signing. Project Copperfin does not
+currently support Apple platform signing/notarization or Linux distribution
+package signing.
+
+English is the authoritative reviewed documentation and UI source for RC1.
+Shipped non-English and pseudo-localized catalogs remain subject to the
+documented machine-translation and human-review limits in
+`docs/26-localization-and-release-readiness.md` from the Corresponding Source.
+
+## What To Exercise
+
+Prioritize real Visual FoxPro projects and representative copies of their
+assets: project open/build/run/debug flows, PRG compatibility, reports and
+labels, menus, xAssets, runtime packages, database/index behavior, Visual
+Studio integration, standalone Studio workflows, diagnostics, and migration
+outputs. Keep originals and test copies separate.
+
+## Report A Finding
+
+A useful report identifies:
+
+- RC tag and exact commit;
+- operating system and version;
+- artifact filename and SHA-256 digest;
+- concise reproduction steps;
+- expected and actual behavior;
+- whether customer or proprietary material was involved, without attaching
+  that material; and
+- logs or a minimal non-confidential reproducer when safe.
+
+Security vulnerabilities and suspected secret exposure must follow
+`SECURITY.md`; do not place them in a public issue. Ordinary findings may be
+reported through the repository's structured issue forms after removing
+restricted content.

--- a/scripts/assemble-rc-candidate.py
+++ b/scripts/assemble-rc-candidate.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# Copyright © 2026 Richard M. Hamilton.
+# SPDX-License-Identifier: GPL-3.0-only
+# Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+"""Assemble and verify the immutable Copperfin RC1 evaluation bundle."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import BinaryIO
+
+
+RC1_TAG = "v0.1.0-rc.1"
+RETENTION_DAYS = 90
+SOURCE_PREFIX = "Project-Copperfin-source-"
+PRIVATE_BOUNDARIES = (
+    (b"-----BEGIN PRIVATE KEY-----", b"-----END PRIVATE KEY-----"),
+    (b"-----BEGIN OPENSSH PRIVATE KEY-----", b"-----END OPENSSH PRIVATE KEY-----"),
+    (b"-----BEGIN ENCRYPTED PRIVATE KEY-----", b"-----END ENCRYPTED PRIVATE KEY-----"),
+)
+
+
+class AssemblyError(RuntimeError):
+    """Raised when an RC input violates the fail-closed assembly contract."""
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def stream_contains_private_key(stream: BinaryIO) -> bool:
+    tail = b""
+    for block in iter(lambda: stream.read(1024 * 1024), b""):
+        candidate = tail + block
+        for begin, end in PRIVATE_BOUNDARIES:
+            begin_offset = candidate.find(begin)
+            if begin_offset != -1 and candidate.find(end, begin_offset + len(begin)) != -1:
+                return True
+        tail = candidate[-(128 * 1024) :]
+    return False
+
+
+def contains_private_key(path: Path) -> bool:
+    with path.open("rb") as stream:
+        return stream_contains_private_key(stream)
+
+
+def require_zip_without_private_markers(path: Path, description: str) -> None:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            for member in archive.infolist():
+                if member.is_dir():
+                    continue
+                with archive.open(member) as stream:
+                    if stream_contains_private_key(stream):
+                        raise AssemblyError(
+                            f"{description} contains private-key material in {member.filename}"
+                        )
+    except zipfile.BadZipFile as error:
+        raise AssemblyError(f"{description} is not a valid ZIP container: {path}") from error
+
+
+def require_regular(path: Path, description: str) -> Path:
+    if path.is_symlink() or not path.is_file():
+        raise AssemblyError(f"{description} is missing or is not a regular file: {path}")
+    lowered = path.name.lower()
+    if "private" in lowered or "secret" in lowered or path.suffix.lower() == ".pem":
+        raise AssemblyError(f"{description} has a forbidden secret-like filename: {path.name}")
+    if contains_private_key(path):
+        raise AssemblyError(f"{description} contains private-key material: {path}")
+    if path.suffix.lower() in {".zip", ".vsix"}:
+        require_zip_without_private_markers(path, description)
+    return path
+
+
+def require_one(root: Path, pattern: str, description: str) -> Path:
+    matches = sorted(root.rglob(pattern))
+    if len(matches) != 1:
+        raise AssemblyError(
+            f"{description} must match exactly one regular file; found {len(matches)} below {root} for {pattern}"
+        )
+    return require_regular(matches[0], description)
+
+
+def copy_verified(source: Path, destination: Path, description: str) -> None:
+    require_regular(source, description)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, destination)
+
+
+def relative_file_records(bundle_root: Path) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for path in sorted(bundle_root.rglob("*")):
+        if path.is_symlink():
+            raise AssemblyError(f"Evaluation bundle contains a symbolic link: {path}")
+        if not path.is_file():
+            continue
+        relative = path.relative_to(bundle_root).as_posix()
+        if relative in {"rc-validation-manifest.json", "SHA256SUMS.txt"}:
+            continue
+        records.append(
+            {
+                "path": relative,
+                "sha256": sha256(path),
+                "size_bytes": path.stat().st_size,
+            }
+        )
+    return records
+
+
+def assemble(args: argparse.Namespace) -> Path:
+    if args.candidate_tag != RC1_TAG:
+        raise AssemblyError(f"candidate tag must be exactly {RC1_TAG}")
+    if not re.fullmatch(r"[0-9a-f]{40}", args.revision):
+        raise AssemblyError("revision must be a lowercase 40-character Git object ID")
+    if not re.fullmatch(r"[1-9][0-9]*", args.run_id):
+        raise AssemblyError("run ID must be a positive integer")
+    if not re.fullmatch(r"[1-9][0-9]*", args.run_attempt):
+        raise AssemblyError("run attempt must be a positive integer")
+
+    input_root = args.input_root.resolve()
+    repository_root = args.repository_root.resolve()
+    output_root = args.output_dir.resolve()
+    if output_root.exists():
+        if not output_root.is_dir() or output_root.is_symlink() or any(output_root.iterdir()):
+            raise AssemblyError(f"output directory must be absent or an empty regular directory: {output_root}")
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    producer_roots = {
+        "windows": input_root / "copperfin-windows-installers",
+        "macos": input_root / "copperfin-macos-installers",
+        "linux": input_root / "copperfin-linux-installers",
+        "vsix": input_root / "copperfin-visualstudio-vsix",
+        "sbom": input_root / "cyclonedx-sbom",
+        "source": input_root / "copperfin-release-source",
+    }
+    for name, root in producer_roots.items():
+        if root.is_symlink() or not root.is_dir():
+            raise AssemblyError(f"required {name} artifact directory is missing or unsafe: {root}")
+        for candidate in root.rglob("*"):
+            if candidate.is_symlink():
+                raise AssemblyError(f"required {name} artifact directory contains a symbolic link: {candidate}")
+
+    payloads = (
+        ("windows", "copperfin-*-Windows.exe", "installers/windows"),
+        ("windows", "copperfin-*-Windows.zip", "installers/windows"),
+        ("macos", "copperfin-*-Darwin.pkg", "installers/macos"),
+        ("macos", "copperfin-*-Darwin.tar.gz", "installers/macos"),
+        ("linux", "copperfin-*-Linux.deb", "installers/linux"),
+        ("linux", "copperfin-*-Linux.rpm", "installers/linux"),
+        ("linux", "copperfin-*-Linux.tar.gz", "installers/linux"),
+        ("vsix", "*.vsix", "ide/visual-studio"),
+    )
+    for producer, pattern, relative_directory in payloads:
+        source = require_one(producer_roots[producer], pattern, f"{producer} RC payload")
+        copy_verified(source, output_root / relative_directory / source.name, f"{producer} RC payload")
+
+    source_name = f"{SOURCE_PREFIX}{args.revision}.zip"
+    source_archive = require_one(
+        producer_roots["source"], source_name, "authoritative Corresponding Source"
+    )
+    copy_verified(source_archive, output_root / "source" / source_name, "Corresponding Source")
+
+    sbom = require_one(producer_roots["sbom"], "sbom.cdx.json", "CycloneDX SBOM")
+    copy_verified(sbom, output_root / "sbom" / sbom.name, "CycloneDX SBOM")
+
+    license_paths = (
+        "LICENSE",
+        "LICENSE.md",
+        "SOURCE.md",
+        "THIRD_PARTY_NOTICES.md",
+        "LICENSES/LicenseRef-Copperfin-Application-Runtime-Toolchain-Exception-1.0.txt",
+        "docs/contracts/release-license-metadata.json",
+    )
+    for relative in license_paths:
+        source = require_regular(repository_root / relative, f"release license document {relative}")
+        copy_verified(source, output_root / "licensing" / relative, f"release license document {relative}")
+
+    for relative in (
+        "THIRD_PARTY_NOTICES.md",
+        "LICENSES/LicenseRef-Copperfin-Application-Runtime-Toolchain-Exception-1.0.txt",
+        "docs/contracts/release-license-metadata.json",
+    ):
+        artifact_copy = require_regular(producer_roots["sbom"] / relative, f"SBOM license companion {relative}")
+        repository_copy = require_regular(repository_root / relative, f"repository license companion {relative}")
+        if sha256(artifact_copy) != sha256(repository_copy):
+            raise AssemblyError(f"SBOM license companion differs from the tagged repository: {relative}")
+
+    tester_guide = require_regular(
+        repository_root / "docs/35-rc1-evaluation-guide.md", "RC1 tester guide"
+    )
+    copy_verified(tester_guide, output_root / "RC1-TESTER-README.md", "RC1 tester guide")
+
+    manifest = {
+        "schema_version": 1,
+        "kind": "copperfin-private-evaluation-release-candidate",
+        "candidate_tag": args.candidate_tag,
+        "revision": args.revision,
+        "repository": args.repository,
+        "official_release": False,
+        "workflow_run": {
+            "id": int(args.run_id),
+            "attempt": int(args.run_attempt),
+            "url": f"{args.server_url.rstrip('/')}/{args.repository}/actions/runs/{args.run_id}",
+        },
+        "validation": {
+            "exact_tag_and_revision": "passed",
+            "native_release_readiness": "passed",
+            "managed_ui": "passed",
+            "installers": "passed",
+            "visual_studio_vsix": "passed",
+            "security_and_sbom": "passed",
+        },
+        "signing": {
+            "windows_launcher_release_trust": "not claimed by this evaluation workflow",
+            "macos_platform_signing": "unsupported",
+            "linux_platform_signing": "unsupported",
+        },
+        "limitations": {
+            "translations": "machine-generated catalogs retain documented human-review limits",
+            "workflow_artifact_retention_days": RETENTION_DAYS,
+        },
+        "files": relative_file_records(output_root),
+    }
+    manifest_path = output_root / "rc-validation-manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    checksum_lines = []
+    for path in sorted(output_root.rglob("*")):
+        if path.is_file() and path.name != "SHA256SUMS.txt":
+            checksum_lines.append(f"{sha256(path)}  {path.relative_to(output_root).as_posix()}")
+    (output_root / "SHA256SUMS.txt").write_text("\n".join(checksum_lines) + "\n", encoding="utf-8")
+    return output_root
+
+
+def self_test() -> None:
+    revision = "a" * 40
+    with tempfile.TemporaryDirectory(prefix="copperfin-rc-assembly-") as temporary:
+        root = Path(temporary)
+        inputs = root / "inputs"
+        repository = root / "repository"
+        for name in (
+            "copperfin-windows-installers",
+            "copperfin-macos-installers",
+            "copperfin-linux-installers",
+            "copperfin-visualstudio-vsix",
+            "cyclonedx-sbom",
+            "copperfin-release-source",
+        ):
+            (inputs / name).mkdir(parents=True)
+        fixture_files = {
+            "copperfin-windows-installers/copperfin-0.1.0-Windows.exe": b"exe",
+            "copperfin-windows-installers/copperfin-0.1.0-Windows.zip": b"winzip",
+            "copperfin-macos-installers/copperfin-0.1.0-Darwin.pkg": b"pkg",
+            "copperfin-macos-installers/copperfin-0.1.0-Darwin.tar.gz": b"mactgz",
+            "copperfin-linux-installers/copperfin-0.1.0-Linux.deb": b"deb",
+            "copperfin-linux-installers/copperfin-0.1.0-Linux.rpm": b"rpm",
+            "copperfin-linux-installers/copperfin-0.1.0-Linux.tar.gz": b"linuxtgz",
+            "copperfin-visualstudio-vsix/Copperfin.VisualStudio.vsix": b"vsix",
+            "cyclonedx-sbom/sbom.cdx.json": b"{}\n",
+        }
+        for relative, data in fixture_files.items():
+            path = inputs / relative
+            if path.suffix in {".zip", ".vsix"}:
+                with zipfile.ZipFile(path, "w") as archive:
+                    archive.writestr("payload.bin", data)
+            else:
+                path.write_bytes(data)
+        source_name = f"{SOURCE_PREFIX}{revision}.zip"
+        for producer in (
+            "copperfin-release-source",
+        ):
+            with zipfile.ZipFile(inputs / producer / source_name, "w") as archive:
+                archive.writestr(f"Project-Copperfin-{revision}/README.md", b"exact-source")
+
+        licenses = {
+            "LICENSE": b"GPL\n",
+            "LICENSE.md": b"Plain language\n",
+            "SOURCE.md": b"Corresponding Source\n",
+            "THIRD_PARTY_NOTICES.md": b"Notices\n",
+            "LICENSES/LicenseRef-Copperfin-Application-Runtime-Toolchain-Exception-1.0.txt": b"Exception\n",
+            "docs/contracts/release-license-metadata.json": b"{}\n",
+            "docs/35-rc1-evaluation-guide.md": b"# RC1\n",
+        }
+        for relative, data in licenses.items():
+            path = repository / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(data)
+        for relative in (
+            "THIRD_PARTY_NOTICES.md",
+            "LICENSES/LicenseRef-Copperfin-Application-Runtime-Toolchain-Exception-1.0.txt",
+            "docs/contracts/release-license-metadata.json",
+        ):
+            destination = inputs / "cyclonedx-sbom" / relative
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes((repository / relative).read_bytes())
+
+        arguments = argparse.Namespace(
+            input_root=inputs,
+            output_dir=root / "bundle",
+            repository_root=repository,
+            candidate_tag=RC1_TAG,
+            revision=revision,
+            repository="example/Project-Copperfin",
+            run_id="123",
+            run_attempt="1",
+            server_url="https://github.example",
+        )
+        bundle = assemble(arguments)
+        expected_bundle_files = {
+            "RC1-TESTER-README.md",
+            "SHA256SUMS.txt",
+            "ide/visual-studio/Copperfin.VisualStudio.vsix",
+            "installers/linux/copperfin-0.1.0-Linux.deb",
+            "installers/linux/copperfin-0.1.0-Linux.rpm",
+            "installers/linux/copperfin-0.1.0-Linux.tar.gz",
+            "installers/macos/copperfin-0.1.0-Darwin.pkg",
+            "installers/macos/copperfin-0.1.0-Darwin.tar.gz",
+            "installers/windows/copperfin-0.1.0-Windows.exe",
+            "installers/windows/copperfin-0.1.0-Windows.zip",
+            "licensing/LICENSE",
+            "licensing/LICENSE.md",
+            "licensing/SOURCE.md",
+            "licensing/LICENSES/LicenseRef-Copperfin-Application-Runtime-Toolchain-Exception-1.0.txt",
+            "licensing/THIRD_PARTY_NOTICES.md",
+            "licensing/docs/contracts/release-license-metadata.json",
+            "rc-validation-manifest.json",
+            "sbom/sbom.cdx.json",
+            f"source/{source_name}",
+        }
+        actual_bundle_files = {
+            path.relative_to(bundle).as_posix() for path in bundle.rglob("*") if path.is_file()
+        }
+        if actual_bundle_files != expected_bundle_files:
+            raise AssemblyError("self-test produced an unexpected evaluation bundle layout")
+        manifest = json.loads((bundle / "rc-validation-manifest.json").read_text(encoding="utf-8"))
+        if manifest["revision"] != revision or manifest["official_release"] is not False:
+            raise AssemblyError("self-test validation manifest is invalid")
+
+        bad_inputs = root / "bad-inputs"
+        shutil.copytree(inputs, bad_inputs)
+        with zipfile.ZipFile(
+            bad_inputs / "copperfin-visualstudio-vsix/Copperfin.VisualStudio.vsix", "w"
+        ) as archive:
+            archive.writestr(
+                "private.pem",
+                PRIVATE_BOUNDARIES[0][0]
+                + b"\nQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB\n"
+                + PRIVATE_BOUNDARIES[0][1],
+            )
+        bad_arguments = argparse.Namespace(**vars(arguments))
+        bad_arguments.input_root = bad_inputs
+        bad_arguments.output_dir = root / "bad-bundle"
+        try:
+            assemble(bad_arguments)
+        except AssemblyError as error:
+            if "private-key material" not in str(error):
+                raise
+        else:
+            raise AssemblyError("self-test accepted private-key material")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--input-root", type=Path)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--repository-root", type=Path)
+    parser.add_argument("--candidate-tag")
+    parser.add_argument("--revision")
+    parser.add_argument("--repository")
+    parser.add_argument("--run-id")
+    parser.add_argument("--run-attempt")
+    parser.add_argument("--server-url", default="https://github.com")
+    args = parser.parse_args(argv)
+    if args.self_test:
+        return args
+    required = (
+        "input_root",
+        "output_dir",
+        "repository_root",
+        "candidate_tag",
+        "revision",
+        "repository",
+        "run_id",
+        "run_attempt",
+    )
+    missing = [name.replace("_", "-") for name in required if getattr(args, name) in (None, "")]
+    if missing:
+        parser.error("the following arguments are required: " + ", ".join(missing))
+    return args
+
+
+def main(argv: list[str]) -> int:
+    try:
+        args = parse_args(argv)
+        if args.self_test:
+            self_test()
+            print("Copperfin RC candidate assembly self-test passed.")
+        else:
+            output = assemble(args)
+            print(f"Assembled verified RC evaluation bundle at {output}")
+        return 0
+    except AssemblyError as error:
+        print(f"RC candidate assembly failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -308,8 +308,22 @@ add_test(
         -P ${CMAKE_CURRENT_SOURCE_DIR}/run_release_licensing_contract_check.cmake
 )
 
+add_test(
+    NAME test_rc_candidate_workflow_contract
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/run_rc_candidate_workflow_contract_check.cmake
+)
+
 find_program(COPPERFIN_PYTHON3_EXECUTABLE NAMES python3 python)
 if(COPPERFIN_PYTHON3_EXECUTABLE)
+    add_test(
+        NAME test_rc_candidate_assembly
+        COMMAND ${COPPERFIN_PYTHON3_EXECUTABLE}
+            ${CMAKE_SOURCE_DIR}/scripts/assemble-rc-candidate.py
+            --self-test
+    )
+
     add_test(
         NAME test_contributor_signoff_contract
         COMMAND ${COPPERFIN_PYTHON3_EXECUTABLE}

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -311,6 +311,30 @@ function(copperfin_configure_native_test_isolation)
         AUDIT complete
     )
 
+    copperfin_set_test_isolation(test_rc_candidate_workflow_contract
+        PARALLEL_SAFE
+        FILESYSTEM read-only
+        ENVIRONMENT none
+        CHILD_PROCESSES none
+        NETWORK none
+        SAMPLES none
+        PLATFORM portable
+        AUDIT complete
+    )
+
+    if(TEST test_rc_candidate_assembly)
+        copperfin_set_test_isolation(test_rc_candidate_assembly
+            PARALLEL_SAFE
+            FILESYSTEM process-owned
+            ENVIRONMENT none
+            CHILD_PROCESSES bounded
+            NETWORK none
+            SAMPLES none
+            PLATFORM configured
+            AUDIT complete
+        )
+    endif()
+
     if(TEST test_contributor_signoff_contract)
         copperfin_set_test_isolation(test_contributor_signoff_contract
             PARALLEL_SAFE

--- a/tests/run_rc_candidate_workflow_contract_check.cmake
+++ b/tests/run_rc_candidate_workflow_contract_check.cmake
@@ -1,0 +1,84 @@
+# Copyright © 2026 Richard M. Hamilton.
+# SPDX-License-Identifier: GPL-3.0-only
+# Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+cmake_minimum_required(VERSION 3.20)
+
+if(NOT DEFINED SOURCE_DIR OR "${SOURCE_DIR}" STREQUAL "")
+    message(FATAL_ERROR "SOURCE_DIR is required")
+endif()
+
+set(workflow_path "${SOURCE_DIR}/.github/workflows/rc-candidate-assembly.yml")
+if(NOT EXISTS "${workflow_path}")
+    message(FATAL_ERROR "RC candidate assembly workflow is missing")
+endif()
+file(READ "${workflow_path}" workflow)
+
+function(require_text expected description)
+    string(FIND "${workflow}" "${expected}" offset)
+    if(offset EQUAL -1)
+        message(FATAL_ERROR "RC candidate workflow is missing ${description}: ${expected}")
+    endif()
+endfunction()
+
+function(require_text_count expected expected_count description)
+    string(LENGTH "${expected}" expected_length)
+    string(LENGTH "${workflow}" original_length)
+    string(REPLACE "${expected}" "" stripped "${workflow}")
+    string(LENGTH "${stripped}" stripped_length)
+    math(EXPR removed_length "${original_length} - ${stripped_length}")
+    math(EXPR actual_count "${removed_length} / ${expected_length}")
+    if(NOT actual_count EQUAL expected_count)
+        message(FATAL_ERROR
+            "RC candidate workflow must contain ${expected_count} ${description}; found ${actual_count}")
+    endif()
+endfunction()
+
+require_text("workflow_dispatch:" "manual-only dispatch")
+require_text("candidate_tag:" "explicit candidate tag input")
+require_text("expected_tag=\"v0.1.0-rc.1\"" "exact RC1 tag guard")
+require_text("GITHUB_REF_TYPE\" != \"tag" "tag-ref guard")
+require_text("git rev-parse \"refs/tags/$expected_tag^{commit}\"" "peeled tag target check")
+require_text("checked_out_revision\" != \"$GITHUB_SHA" "checkout revision check")
+require_text("permissions:\n  contents: read" "read-only workflow permissions")
+require_text("uses: ./.github/workflows/native-release-readiness.yml" "native release matrix")
+require_text("uses: ./.github/workflows/managed-ui-validation-linux.yml" "managed UI validation")
+require_text("uses: ./.github/workflows/build-installers.yml" "installer build matrix")
+require_text("uses: ./.github/workflows/build-vsix.yml" "Visual Studio VSIX build")
+require_text("uses: ./.github/workflows/security-supply-chain.yml" "security and SBOM gate")
+require_text("scripts/assemble-rc-candidate.py" "fail-closed bundle assembler")
+require_text("uses: ./.github/actions/create-release-source" "authoritative Corresponding Source generation")
+require_text("output-directory: rc-inputs/copperfin-release-source" "isolated Corresponding Source input")
+require_text("name: copperfin-v0.1.0-rc.1-evaluation-bundle" "stable evaluation artifact name")
+require_text("retention-days: 90" "explicit artifact expiry")
+require_text("if-no-files-found: error" "fail-closed artifact upload")
+require_text_count("uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8"
+    5 "immutable download-artifact pins")
+require_text_count("uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"
+    1 "authoritative RC bundle upload")
+
+foreach(reusable_workflow IN ITEMS
+        build-installers.yml
+        build-vsix.yml
+        managed-ui-validation-linux.yml
+        native-release-readiness.yml
+        security-supply-chain.yml)
+    set(reusable_path "${SOURCE_DIR}/.github/workflows/${reusable_workflow}")
+    file(READ "${reusable_path}" reusable_contents)
+    string(FIND "${reusable_contents}" "workflow_call:" workflow_call_offset)
+    if(workflow_call_offset EQUAL -1)
+        message(FATAL_ERROR "${reusable_workflow} is not callable from the RC workflow")
+    endif()
+endforeach()
+
+foreach(forbidden_text IN ITEMS
+        "secrets."
+        "environment: release"
+        "gh release create"
+        "softprops/action-gh-release"
+        "BEGIN PRIVATE KEY")
+    string(FIND "${workflow}" "${forbidden_text}" forbidden_offset)
+    if(NOT forbidden_offset EQUAL -1)
+        message(FATAL_ERROR "RC candidate workflow contains forbidden release/secret text: ${forbidden_text}")
+    endif()
+endforeach()


### PR DESCRIPTION
Closes #4907 after the exact-tag candidate run, artifact inspection, evidence update, and v1-development branch creation complete.

This slice adds a manual fail-closed `v0.1.0-rc.1` assembly workflow, makes the existing hosted validation/build workflows reusable, verifies and combines platform installers, VSIX, Corresponding Source, SBOM, license metadata, tester guidance, validation metadata, and SHA-256 checksums into one expiring GitHub Actions artifact. It consumes no repository secrets and publishes no GitHub Release.

Local evidence:
- focused release/workflow/isolation contracts: 7/7 passed
- complete native CTest: 323/323 passed; two documented POSIX launcher-process skips
- real hosted installer/VSIX/SBOM artifact-layout rehearsal and checksum verification: passed
- workflow YAML parse and `git diff --check`: passed

The PR intentionally does not claim #4403 or #4409 closure, Windows launcher release-trust approval, or macOS/Linux platform signing.