### PR TITLE
Record accepted RC2 baseline and v1 lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+- 2026-08-08: Produced and independently inspected the corrected private
+  evaluation candidate `v0.1.0-rc.2` under #4907. The protected annotated tag
+  peels exactly to reviewed commit `fd6bd94f8`; all exact-main native, package,
+  IDE, managed-UI, path, ABI, security, and permissive safety lanes passed.
+  Exact-tag run `31244558839` then passed 12/12 jobs and uploaded artifact
+  `9018695984`, `copperfin-v0.1.0-rc.2-evaluation-bundle`, with GitHub digest
+  `sha256:501ba26642af4fb58c69e3c69ca0f29b7eb5e242a4980ea31770e83bd84605df`
+  and 90-day retention. Downloaded verification passed all 18 checksums, all
+  17 validation-manifest file records, the complete 19-file payload inventory,
+  1,404 exact Corresponding Source Git blobs, installer/VSIX/SBOM/license
+  structures, and symlink/private-key/secret-name boundaries. No GitHub Release
+  was created. Long-lived `v1-development` begins exactly at the peeled RC2
+  commit and has active no-bypass deletion/non-fast-forward protection, keeping
+  v1 feature work separate from immutable RC stabilization. Human RC2 testing
+  and the documented signing, launcher-trust, localization-review, and official
+  release gates remain open. No runtime, VFP9, localization catalog,
+  package/debug schema, xAsset, report/label, IDE, stack, or platform product
+  behavior changed.
+
 - 2026-08-08: Preserved failed immutable candidate tag `v0.1.0-rc.1` and
   corrected the final evaluation-bundle scanner under #4907. Exact-tag run
   `31236596422` passed native Linux/macOS/Windows release readiness, managed

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -2,31 +2,45 @@
 
 ## Current State
 
-#4907 maintains a private-evaluation RC assembly lane without weakening the
-official-release gates. Immutable tag `v0.1.0-rc.1` peels to `a4459e64a`.
-Exact-tag run `31236596422` passed native Linux/macOS/Windows release readiness,
-Linux managed UI, all platform installers, Visual Studio VSIX behavior, and
-security/SBOM, then failed closed in final assembly: the source scanner found
-its own literal private-key sentinel inside the authoritative Corresponding
-Source archive. No secret was present, no final bundle was uploaded, and no
-GitHub Release exists. The tag remains unchanged.
+#4907 now has a complete private-evaluation RC artifact lane without weakening
+the official-release gates. Failed immutable tag `v0.1.0-rc.1` still peels to
+`a4459e64a`; exact-tag run `31236596422` passed every native/package prerequisite
+but failed closed when the source scanner matched its own literal private-key
+sentinel. No secret or final bundle was published from RC1, and the tag remains
+unchanged.
 
-The corrective lane constructs the sentinel bytes without embedding a complete
-sentinel in its own source and puts the real scanner source inside the
-executable source-ZIP regression while retaining private-key rejection across
-arbitrarily large envelopes and common PKCS#8, RSA, EC, DSA, OpenSSH,
-canonical SSH2, PGP, and PuTTY PPK v2/v3 encodings. Absolute marker positions
-prevent an end marker before the corresponding begin marker from satisfying
-the envelope.
-`.github/workflows/rc-candidate-assembly.yml` remains manual and read-only, but
-now accepts only sequential `v0.1.0-rc.N` tags when the requested tag, checkout
-ref, peeled target, and GitHub workflow SHA are identical. This permits an
-immutable RC2 and later human-review candidates without rewriting the workflow.
-The final Ubuntu job still verifies nested artifact layout, secret-like names,
-complete private-key blocks, SBOM licensing companions, and emits one 90-day
-evaluation bundle with SHA-256 and non-secret validation manifests. Correction
-review, exact-main hosted evidence, RC2 tagging/execution, deep bundle
-inspection, and creation of `v1-development` remain before #4907 closes.
+The corrected immutable tag `v0.1.0-rc.2` has annotated tag object `910903198f`
+and peels exactly to reviewed release-content commit `fd6bd94f8`. All exact-main
+push lanes at that commit passed (`31242362021`, `31242362022`, `31242362031`,
+`31242362035`, `31242362037`, `31242362038`, `31242362040`, `31242362046`,
+`31242362049`, and `31242362052`). Non-closure safety run `31242383363` also
+passed against #4403 with primary hazards required and issue closure not
+required; artifact `9017433329` has digest
+`sha256:b944081a0df36d302416fde633161b8a15498031de13b1e44e41e2d1512d0b73`,
+reports one validated issue with zero failures/errors, and expires 2026-11-06.
+A later `.agent-channel`-only check-in advanced `main`; it is intentionally not
+part of the already validated RC2 release content.
+
+Exact-tag run `31244558839` passed 12/12 jobs, including exact tag/ref/peeled
+commit/workflow-SHA equality, Linux/macOS/Windows native release readiness,
+managed UI, every installer, Visual Studio VSIX, security/SBOM, and final
+assembly. Final artifact `9018695984`,
+`copperfin-v0.1.0-rc.2-evaluation-bundle`, has GitHub digest
+`sha256:501ba26642af4fb58c69e3c69ca0f29b7eb5e242a4980ea31770e83bd84605df`,
+size 59,511,519 bytes, and expiry 2026-11-06. Downloaded inspection verified
+the 19-file/18-checksum bundle, all 17 manifest records, 1,404 exact Git blobs
+in Corresponding Source, license/SBOM companions, installer/VSIX structures,
+and the symlink/private-key/secret-name boundaries. No GitHub Release exists.
+
+The scanner now recognizes arbitrarily large PKCS#8, RSA, EC, DSA, OpenSSH,
+canonical SSH2, PGP, and PuTTY PPK v2/v3 records without matching its own
+source, and absolute marker positions enforce begin-before-end ordering.
+`v1-development` begins exactly at the peeled RC2 commit and active no-bypass
+ruleset `20582609` prevents branch deletion and non-fast-forward updates. RC
+stabilization and v1 feature development are therefore separate. Human tester
+evaluation remains pending, and the bundle continues to disclaim Windows
+launcher release trust, Authenticode, Apple signing/notarization, Linux package
+signing, and completed human review of generated translations.
 
 #4904 hardens the GPL exception and release-license compliance surface. The
 operative exception now distinguishes automatically emitted Standard Support

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -298,26 +298,29 @@ installer `30550923408`, and security/SBOM `30550923513` workflows also pass.
 The final release-validation regressions #4891, #4892, and #4893 are closed.
 
 This is implementation-complete RC readiness, not authority to publish an
-official release. Private RC evaluation may proceed through the fail-closed
-GitHub Actions artifact workflow without a GitHub Release, protected signing,
-or a claim that the external release authorities are satisfied. Immutable
-`v0.1.0-rc.1` run `31236596422` passed every platform and package prerequisite
-but published no final bundle because the scanner detected its own literal
-private-key sentinel in the exact source archive. No secret was present. The
-tag remains immutable, the scanner regression is corrected for sequential
-`v0.1.0-rc.N` candidates, and RC2 is the next candidate. The complete
-official-release evidence gate remains open until #4403 receives genuine
-arm's-length safety sign-off, closes, and passes strict validation, and until
-#4409 receives the approved protected launcher-trust signer/registry secrets
-and passes enforced Windows validation. Permissive primary-hazard safety run
-`30555972170` is green but cannot substitute for that strict closure. The
-hosted Deep runner also lacked VFP9;
-accepted installed-VFP9, mounted-sample, RuntimePackage/xAsset/Report/Menu, and
-live Visual Studio evidence remains the closed #4621 baseline because the final
-changes were catalog/managed/test-only. After an immutable RC artifact passes,
-the long-lived v1 development branch may begin at that exact tag while RC
-stabilization remains isolated. Neither lane may reinterpret this parallel work
-as closure of #4403 or #4409 or as authority for an official 1.0 release.
+official release. Failed immutable `v0.1.0-rc.1` remains preserved; no secret
+or final artifact escaped its fail-closed assembly. Corrected protected tag
+`v0.1.0-rc.2` peels to exact reviewed commit `fd6bd94f8`. All exact-main native,
+package, IDE, UI, path, ABI, security, and permissive primary-hazard safety
+lanes passed there, followed by exact-tag run `31244558839` passing 12/12 jobs.
+The downloaded 19-file artifact `9018695984` has GitHub digest
+`sha256:501ba26642af4fb58c69e3c69ca0f29b7eb5e242a4980ea31770e83bd84605df`;
+checksums, all 17 manifest records, installers, VSIX, SBOM, license materials,
+and 1,404 exact Corresponding Source blobs passed independent inspection. No
+GitHub Release was created.
+
+Protected `v1-development` begins exactly at the peeled RC2 commit under
+no-bypass ruleset `20582609`, while immutable RC stabilization remains separate.
+Human RC2 evaluation is pending. The complete official-release evidence gate
+remains open until #4403 receives genuine arm's-length safety sign-off, closes,
+and passes strict validation, and until #4409 receives the approved protected
+launcher-trust signer/registry secrets and passes enforced Windows validation.
+The hosted Deep runner also lacked VFP9; accepted installed-VFP9,
+mounted-sample, RuntimePackage/xAsset/Report/Menu, and live Visual Studio
+evidence remains the closed #4621 baseline because the final changes were
+release infrastructure and documentation only. Neither lane may reinterpret
+this parallel work as closure of #4403 or #4409 or as authority for an official
+1.0 release.
 
 The #4873 Studio-host JSON-control-escape child is closed at exact product/test
 head `4a75d3273`. Focused shared-platform JSON and real Studio-host diagnostic


### PR DESCRIPTION
## What changed

- record the protected RC2 tag, exact validated baseline, hosted run evidence, and safety artifact
- record the exact-tag 12/12 assembly run and deeply inspected evaluation-bundle identity
- record the protected `v1-development` baseline and the remaining human/signing/release limitations

## Why

The durable handoff, roadmap, and changelog still described RC2 assembly and the v1 branch as pending after those acceptance criteria completed. This synchronizes repository documentation without modifying the immutable RC2 tag or v1 baseline.

## Validation

- `git diff --check`
- RC candidate workflow contract
- release licensing/source/attribution contract
- GPL/product licensing policy contract
- safety traceability workflow contract
- exact values cross-checked against GitHub tag, workflow, artifact, ruleset, and downloaded bundle evidence

No runtime, VFP9, localization catalog, package/debug schema, xAsset, report/label, IDE, stack, installer, or platform product behavior changed.
