### PR TITLE
docs(safety): trace launcher key generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+- 2026-08-08: Completed the #4898 launcher-key-generation safety record. The
+  durable report maps both declared DQ requirements to all three DV evidence
+  classes and the two registered hazards, records the owner-run signer ID,
+  public DER fingerprint, and mode check without private material, and records
+  the independent cryptographic/negative-case review. The focused package-
+  signer contract now fails if this evidence disappears. This documentation
+  closure does not create the GitHub `release` environment, provision secrets,
+  dispatch protected Windows validation, or close #4409.
+
 - 2026-08-08: Recovered the VFP9 `SET POINT` display contract under #4913
   from the mounted shipped `dv_foxhelp.chm` topic
   `html/ab6ea03e-d7f8-4ddb-b2e2-56755efd8857.htm`, then corrected the

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -199,8 +199,10 @@ two exact protected `release` environment secrets, and the key ID maps to the
 manual workflow input. No Windows generator or second identity is needed; the
 existing PowerShell signer consumes the same secret. This does not sign
 macOS/Linux artifacts or complete external #4409 environment provisioning,
-approval, or protected execution. Focused validation and independent review
-remain required before #4898 closure.
+approval, or protected execution. The owner ceremony, focused validation,
+independent review, and complete DQ/DV/HZ mapping are archived in
+`docs/safety/traceability-report-2026-08-08-launcher-keygen.md`; #4898 can close
+without weakening the still-open #4409 protected-execution gate.
 
 Requirements recovery has begun in
 `docs/32-recovered-requirements-traceability.md`. Closed child #4896 establishes

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -406,6 +406,13 @@ requires the externally approved registry/key pair and does not weaken #4409;
 the accepted #4621 hosted baseline remains separate from an exact-head live
 Visual Studio UI rerun.
 
+The #4898 Linux launcher-key generator has completed its bounded tool,
+walkthrough, independent-review, and DQ/DV/HZ evidence. The non-secret record
+is archived in
+`docs/safety/traceability-report-2026-08-08-launcher-keygen.md`. GitHub still
+has no `release` environment, so this child does not satisfy #4409 or authorize
+a protected Windows launcher-trust claim.
+
 The implementation-side #4894 matrix is current at exact head `f0c9e06e2`:
 Windows native `30559930672` passes `315/315` after building the new fixture
 with MSVC, Linux `30559930560` and macOS `30559930719` pass `316/316`, and the

--- a/docs/29-package-trust-contract.md
+++ b/docs/29-package-trust-contract.md
@@ -73,6 +73,11 @@ and must be backed up in a protected external store. One Linux generation
 ceremony supplies the existing Windows PowerShell workflow; creating a second
 Windows identity is neither required nor desired.
 
+The non-secret DQ/DV/HZ mapping, owner ceremony fingerprint, contract evidence,
+and independent review boundary are archived in
+`docs/safety/traceability-report-2026-08-08-launcher-keygen.md`. That report
+does not provision GitHub secrets or claim completion of protected gate #4409.
+
 ## Verification API And Failure States
 
 The native verifier is `copperfin::package_trust`, not `copperfin::licensing`. It may reuse the verify-only Ed25519 primitive, but it owns its envelope parser, canonicalization, launcher trust-key registry, and result statuses. It must not call license parsing or make license-state decisions.

--- a/docs/safety/traceability-report-2026-08-08-launcher-keygen.md
+++ b/docs/safety/traceability-report-2026-08-08-launcher-keygen.md
@@ -1,0 +1,61 @@
+# Launcher Key Generation Safety Traceability Report
+
+## Scope
+
+- Repository: `rhamenator/Project-Copperfin`
+- Issue: `#4898` under protected launcher-trust gate `#4409`
+- Product/tool implementation: `tools/package-signer/generate-launcher-signing-key.sh`
+- Safety boundary: dedicated Ed25519 launcher identity generation and handling
+- Non-claim: this report does not complete #4409, create a GitHub `release`
+  environment, provision its secrets, or execute the protected Windows guard.
+
+## DQ/DV/HZ Mapping
+
+| Documentation requirement | Verification evidence | Controlled hazards |
+| --- | --- | --- |
+| `DQ-MVP-launcher-keygen-dedicated-identity` | `DV-MVP-launcher-keygen-contract`; `DV-MVP-launcher-keygen-walkthrough`; `DV-MVP-launcher-keygen-independent-review` | `HZ-system-failure-01`; `HZ-doc-command-01` |
+| `DQ-MVP-launcher-keygen-secret-boundary` | `DV-MVP-launcher-keygen-contract`; `DV-MVP-launcher-keygen-walkthrough`; `DV-MVP-launcher-keygen-independent-review` | `HZ-system-failure-01`; `HZ-doc-command-01` |
+
+## Verification Evidence
+
+### DV-MVP-launcher-keygen-contract
+
+`test_package_signer_contract` generates a fresh identity outside the checkout,
+derives and compares its public key, compiles the generated registry, signs and
+verifies a canonical launcher inventory, checks mode `0600`, performs Windows
+provisioning preflight when PowerShell is present, and rejects overwrite,
+invalid identifiers, unsafe directory permissions, and checkout-contained
+output. The launcher-trust provisioning and native test-isolation contracts
+provide adjacent coverage. No generated private material is retained.
+
+### DV-MVP-launcher-keygen-walkthrough
+
+The repository owner ran the documented Linux ceremony on 2026-08-08 with
+signer ID `copperfin-launcher-2026-01`. The private PEM reported mode `0600`.
+The non-secret metadata identified Ed25519 and public-key DER SHA-256
+`de4e9c062bbad4f591031da08b4b76ebac6fb1319f6f82eea521737b6c72241a`.
+The generated private key, registry contents, backup location, and any future
+secret values are intentionally absent from this report.
+
+### DV-MVP-launcher-keygen-independent-review
+
+The read-only review recorded at coordination sequence 1423 generated an
+independent temporary identity, recomputed the DER fingerprint and raw public
+key with OpenSSL, compared them with the metadata and registry, ran the real
+contract, and exercised overwrite, unsafe identifier, traversal, symlink,
+checkout, and permission-negative cases. It found no tool defect and identified
+the missing durable DQ/DV/HZ record corrected by this report.
+
+## Hazard Controls And Residual Gate
+
+The dedicated-identity requirement prevents accidental reuse of the archived
+product-licensing key. The secret-boundary requirement keeps private material
+outside Git, packages, logs, and generated evidence while retaining a public
+fingerprint for identity checks. Fail-closed identifier, path, permission,
+algorithm, public/private-match, and overwrite checks control
+`HZ-system-failure-01` and `HZ-doc-command-01`.
+
+The `release` GitHub environment and its two protected secrets remain external
+operator prerequisites. Only a successful protected Windows Launcher Trust
+Validation run with the approved signer ID can satisfy #4409.
+

--- a/tests/run_package_signer_contract_check.cmake
+++ b/tests/run_package_signer_contract_check.cmake
@@ -10,9 +10,34 @@ set(SIGNER "${SOURCE_DIR}/tools/package-signer/sign-launcher-inventory.sh")
 set(WINDOWS_SIGNER "${SOURCE_DIR}/tools/package-signer/sign-launcher-inventory.ps1")
 set(KEY_GENERATOR
     "${SOURCE_DIR}/tools/package-signer/generate-launcher-signing-key.sh")
+set(KEY_GENERATOR_SAFETY_REPORT
+    "${SOURCE_DIR}/docs/safety/traceability-report-2026-08-08-launcher-keygen.md")
 foreach(REQUIRED_SIGNER IN ITEMS "${SIGNER}" "${WINDOWS_SIGNER}" "${KEY_GENERATOR}")
     if(NOT EXISTS "${REQUIRED_SIGNER}")
         message(FATAL_ERROR "package signer is missing: ${REQUIRED_SIGNER}")
+    endif()
+endforeach()
+
+if(NOT EXISTS "${KEY_GENERATOR_SAFETY_REPORT}")
+    message(FATAL_ERROR
+        "launcher key generator safety report is missing: ${KEY_GENERATOR_SAFETY_REPORT}")
+endif()
+file(READ "${KEY_GENERATOR_SAFETY_REPORT}" KEY_GENERATOR_SAFETY_CONTENT)
+foreach(REQUIRED_TEXT IN ITEMS
+    "DQ-MVP-launcher-keygen-dedicated-identity"
+    "DQ-MVP-launcher-keygen-secret-boundary"
+    "DV-MVP-launcher-keygen-contract"
+    "DV-MVP-launcher-keygen-walkthrough"
+    "DV-MVP-launcher-keygen-independent-review"
+    "HZ-system-failure-01"
+    "HZ-doc-command-01"
+    "copperfin-launcher-2026-01"
+    "de4e9c062bbad4f591031da08b4b76ebac6fb1319f6f82eea521737b6c72241a"
+    "does not complete #4409")
+    string(FIND "${KEY_GENERATOR_SAFETY_CONTENT}" "${REQUIRED_TEXT}" POSITION)
+    if(POSITION EQUAL -1)
+        message(FATAL_ERROR
+            "launcher key generator safety report is missing required evidence: ${REQUIRED_TEXT}")
     endif()
 endforeach()
 


### PR DESCRIPTION
## What changed

- archives the complete #4898 DQ/DV/HZ mapping in a dedicated safety report
- records the owner-run signer ID, public DER fingerprint, and mode result without private material
- records the independent cryptographic and negative-case review boundary
- makes the package-signer contract fail if the durable evidence disappears
- keeps #4409 explicitly open for the absent GitHub `release` environment, protected secrets, and Windows execution

## Why

The launcher key generator and its focused checks were complete, but the identifiers declared by #4898 were absent from `docs/safety/`. This closes that auditability gap without changing product behavior or provisioning any secret.

## Validation

- red contract: missing report failed `run_package_signer_contract_check.cmake`
- direct package-signer contract: pass
- focused CTest: package signer, launcher provisioning, native isolation, and safety workflow contracts pass 4/4
- `git diff --check`: pass

Closes #4898. Does not close #4409.