### PR TITLE
feat(platform): add bounded artifact process execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@
   removes descendants after every terminal path. Windows uses a suspended root
   assigned to a kill-on-close Job Object before execution; POSIX uses a new
   process group plus a close-on-exec launch-status pipe and `execve`. Focused
-  GCC, Clang, native-isolation, and ASan/UBSan tests pass locally. This is an
-  execution primitive only: artifact authorization/hash trust, envelope
+  GCC, Clang, native-isolation, and ASan/UBSan tests pass locally. Exact head
+  `36f25b1e5` also passes Linux Native `324/324` (`31284210937`), macOS Native
+  `324/324` plus the existing four-locale matrix (`31284210940`), and Windows
+  Native `323/323` (`31284210974`), with the bounded-process regression
+  executed on every platform. This is an execution primitive only: artifact
+  authorization/hash trust, envelope
   validation, output capture, retry/fallback, telemetry, adapter wiring, and
-  PRG runtime routing remain unimplemented, and hosted Windows/macOS evidence
-  is still required.
+  PRG runtime routing remain unimplemented.
 
 - 2026-08-08: Completed the #4898 launcher-key-generation safety record. The
   durable report maps both declared DQ requirements to all three DV evidence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+- 2026-08-08: Added the v1 bounded-process prerequisite for the artifact-first
+  polyglot bridge. The portable API launches an executable directly without a
+  shell, supplies a complete explicit child environment that is empty by
+  default, applies finite timeout and fail-closed cancellation semantics, and
+  removes descendants after every terminal path. Windows uses a suspended root
+  assigned to a kill-on-close Job Object before execution; POSIX uses a new
+  process group plus a close-on-exec launch-status pipe and `execve`. Focused
+  GCC, Clang, native-isolation, and ASan/UBSan tests pass locally. This is an
+  execution primitive only: artifact authorization/hash trust, envelope
+  validation, output capture, retry/fallback, telemetry, adapter wiring, and
+  PRG runtime routing remain unimplemented, and hosted Windows/macOS evidence
+  is still required.
+
 - 2026-08-08: Completed the #4898 launcher-key-generation safety record. The
   durable report maps both declared DQ requirements to all three DV evidence
   classes and the two registered hazards, records the owner-run signer ID,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 - 2026-08-08: Added the v1 bounded-process prerequisite for the artifact-first
-  polyglot bridge. The portable API launches an executable directly without a
-  shell, supplies a complete explicit child environment that is empty by
+  polyglot bridge. The portable API launches an absolute executable directly
+  without a shell, rejects relative paths and embedded-NUL inputs, and supplies
+  a complete explicit child environment that is empty by
   default, applies finite timeout and fail-closed cancellation semantics, and
   removes descendants after every terminal path. Windows uses a suspended root
   assigned to a kill-on-close Job Object before execution; POSIX uses a new

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,7 @@ endif()
 target_link_libraries(cf_package_trust PRIVATE cf_licensing)
 
 add_library(cf_platform_profile
+    src/platform/bounded_process.cpp
     src/platform/database_model.cpp
     src/platform/extensibility_model.cpp
     src/platform/federation_execution.cpp

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,28 @@
 # Agent Handoff
 
+## V1 bounded polyglot process prerequisite
+
+The trusted #4700 lane now has a rebased product/test candidate for the first
+external-artifact execution prerequisite. `run_bounded_process` invokes an
+absolute executable directly with an argument vector, explicit working
+directory, and complete explicit child environment; the default environment is
+empty so ambient build or agent secrets do not cross the boundary. Timeout and
+prompt cancellation are polled on both platforms, cancellation-callback
+exceptions fail closed, and descendants are removed even when the root exits
+normally. Windows assigns a suspended process to a kill-on-close Job Object
+before resuming it. POSIX creates a process group and uses a close-on-exec,
+nonblocking status pipe to keep pre-exec timeout/cancellation observable.
+
+Focused Linux evidence passes under GCC and Clang, the native test-isolation
+contract passes with `filesystem=process-owned`,
+`environment=scoped-process`, and `child-processes=bounded`, and a Clang
+ASan/UBSan build passes without findings. Focused analyzer checks produce no
+project diagnostics. Hosted Windows and macOS runs are still required. This
+candidate does not authorize or hash artifacts, parse envelopes, capture
+output, retry/fallback, emit migration telemetry, select routes, or connect an
+external language to PRG execution. It introduces no fallback/no-op runtime
+surface, so the runtime stub inventory is unchanged.
+
 ## V1 SET POINT Currency display and macOS evidence slice
 
 Trusted requirements-recovery issues #4897/#4913 and implementation child

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -4,9 +4,10 @@
 
 The trusted #4700 lane now has a rebased product/test candidate for the first
 external-artifact execution prerequisite. `run_bounded_process` invokes an
-absolute executable directly with an argument vector, explicit working
+absolute executable directly with an argument vector, absolute working
 directory, and complete explicit child environment; the default environment is
-empty so ambient build or agent secrets do not cross the boundary. Timeout and
+empty so ambient build or agent secrets do not cross the boundary. Relative
+paths and embedded-NUL inputs are rejected before launch. Timeout and
 prompt cancellation are polled on both platforms, cancellation-callback
 exceptions fail closed, and descendants are removed even when the root exits
 normally. Windows assigns a suspended process to a kill-on-close Job Object

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -14,12 +14,19 @@ normally. Windows assigns a suspended process to a kill-on-close Job Object
 before resuming it. POSIX creates a process group and uses a close-on-exec,
 nonblocking status pipe to keep pre-exec timeout/cancellation observable.
 
-Focused Linux evidence passes under GCC and Clang, the native test-isolation
-contract passes with `filesystem=process-owned`,
-`environment=scoped-process`, and `child-processes=bounded`, and a Clang
-ASan/UBSan build passes without findings. Focused analyzer checks produce no
-project diagnostics. Hosted Windows and macOS runs are still required. This
-candidate does not authorize or hash artifacts, parse envelopes, capture
+Exact implementation/test head `36f25b1e5` passes the focused GCC
+licensing/polyglot/isolation set `10/10`, Clang bounded-process coverage `1/1`,
+and Clang ASan/UBSan coverage `1/1` without findings; focused analyzer checks
+produce no project diagnostics. Hosted Linux Native run `31284210937` passes
+`324/324`, macOS Native run `31284210940` passes `324/324` plus the existing
+four-locale matrix, and Windows Native run `31284210974` passes `323/323`.
+Each full suite executes `test_bounded_process`. The immediately preceding
+macOS run `31283452931` failed only because the test compared equivalent
+`/var` and `/private/var` working-directory spellings textually; the corrected
+test compares filesystem identity while retaining exact argv, Unicode
+environment, and ambient-`PATH` isolation checks. Product code did not change
+for that correction. All eight protected PR checks also pass at `36f25b1e5`.
+This candidate does not authorize or hash artifacts, parse envelopes, capture
 output, retry/fallback, emit migration telemetry, select routes, or connect an
 external language to PRG execution. It introduces no fallback/no-op runtime
 surface, so the runtime stub inventory is unchanged.

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -327,9 +327,10 @@ found by this lane must be triaged separately according to demonstrated risk.
 
 The v1 polyglot lane now has a portable bounded-process prerequisite for its
 first artifact adapter. Direct argv invocation avoids a shell; the complete
-child environment is explicit and empty by default; timeouts, cancellation,
-callback failure, and normal root completion all close the owned descendant
-tree through Windows Job Objects or POSIX process groups. Focused GCC, Clang,
+child environment is explicit and empty by default; relative paths and
+embedded-NUL inputs are rejected. Timeout, cancellation, callback failure, and
+normal root completion all close the owned descendant tree through Windows Job
+Objects or POSIX process groups. Focused GCC, Clang,
 native-isolation, and ASan/UBSan evidence passes locally. Hosted Windows and
 macOS validation remains required before integration. This slice does not yet
 authorize/hash an artifact, validate envelopes, capture output, implement

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -325,6 +325,16 @@ It is enabled only by `COPPERFIN_BUILD_ROBUSTNESS_TESTS=ON`, changes no product
 behavior, and is neither an RC nor v1 completion gate. Any reproducible defect
 found by this lane must be triaged separately according to demonstrated risk.
 
+The v1 polyglot lane now has a portable bounded-process prerequisite for its
+first artifact adapter. Direct argv invocation avoids a shell; the complete
+child environment is explicit and empty by default; timeouts, cancellation,
+callback failure, and normal root completion all close the owned descendant
+tree through Windows Job Objects or POSIX process groups. Focused GCC, Clang,
+native-isolation, and ASan/UBSan evidence passes locally. Hosted Windows and
+macOS validation remains required before integration. This slice does not yet
+authorize/hash an artifact, validate envelopes, capture output, implement
+fallback/telemetry, select a route, or connect external code to PRG execution.
+
 Current v1 runtime-parity work under trusted #4913/#4914 recovers the shipped
 VFP9 `SET POINT` display contract and corrects the demonstrated Currency path.
 Display-only formatting now applies current data-session `POINT` and
@@ -546,7 +556,7 @@ standalone Studio shell, and FoxPro language-service layer."
 | E | `#111` (`E1`/`#22`, `E2`/`#23`, `E3`/`#24`) | Shared design model and designer fidelity (`E3` = report/label parity, the single largest lane in the repo) | Closed 2026-07-24 | Phase C |
 | F | `#112` (`F1`/`#25`, `F2`/`#26`) | VS extension parity + utility panes; standalone Studio as a full IDE | MVP implementation complete for standalone shell; hosted UI evidence remains under the RC gate | Phase C |
 | G | `#112` (`G1`/`#27`, `G2`/`#28`, `G3`/`#29`) | FoxPro language service: semantic resolution, navigation/refactoring, IntelliSense metadata | Recorded G1/G2/G3 slices closed; broader MVP scope remains under the live tree | Phase C |
-| H | `#113` (`H1`/`#30`, `H2`/`#31`, `H3`/`#32`) | Relational backend translators, document/vector + AI planning, .NET/MCP/polyglot outputs | Seeded (see gap analysis) | v1 item 3 |
+| H | `#113` (`H1`/`#30`, `H2`/`#31`, `H3`/`#32`) | Relational backend translators, document/vector + AI planning, .NET/MCP/polyglot outputs | Contract/model foundation and bounded process prerequisite implemented; real adapter/runtime dispatch remains | v1 item 3 |
 | I | `#113` (`I1`/`#33`, `I2`/`#34`) | Runtime/project security depth, extension/host/AI-MCP security boundary | Seeded (see gap analysis) | v1 item 4 |
 | J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | Open, no shipped evidence | v1 item 5 |
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -330,9 +330,12 @@ first artifact adapter. Direct argv invocation avoids a shell; the complete
 child environment is explicit and empty by default; relative paths and
 embedded-NUL inputs are rejected. Timeout, cancellation, callback failure, and
 normal root completion all close the owned descendant tree through Windows Job
-Objects or POSIX process groups. Focused GCC, Clang,
-native-isolation, and ASan/UBSan evidence passes locally. Hosted Windows and
-macOS validation remains required before integration. This slice does not yet
+Objects or POSIX process groups. Focused GCC, Clang, native-isolation, and
+ASan/UBSan evidence passes locally. At exact implementation/test head
+`36f25b1e5`, Linux Native run `31284210937` passes `324/324`, macOS Native run
+`31284210940` passes `324/324` plus the existing four-locale matrix, and
+Windows Native run `31284210974` passes `323/323`; all three execute the
+bounded-process regression. This slice does not yet
 authorize/hash an artifact, validate envelopes, capture output, implement
 fallback/telemetry, select a route, or connect external code to PRG execution.
 

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -110,8 +110,13 @@ Focused synthetic tests cover exact exit status, shell-metacharacter arguments, 
 Unicode working path and environment value, absence of ambient `PATH`, live and
 throwing cancellation, timeout cleanup, cleanup after normal root exit, missing
 executables, invalid budgets, and duplicate environment names. Local GCC, Clang, and
-ASan/UBSan executions pass, together with the native test-isolation contract. Hosted
-Windows and macOS evidence remains required before this prerequisite is integrated.
+ASan/UBSan executions pass, together with the native test-isolation contract. Exact
+implementation/test head `36f25b1e5` passes Linux Native `324/324`
+(`31284210937`), macOS Native `324/324` plus its existing four-locale matrix
+(`31284210940`), and Windows Native `323/323` (`31284210974`); each full suite
+executes this regression. The earlier macOS textual-path assertion was corrected to
+compare filesystem identity for equivalent `/var` and `/private/var` spellings without
+weakening exact argv, Unicode environment, or ambient-`PATH` isolation coverage.
 
 This primitive does **not** authorize or hash an artifact, validate migration
 contracts or typed envelopes, capture standard output/error, implement retries or

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -93,10 +93,11 @@ outside the policy model.
 
 `run_bounded_process` is the first execution prerequisite for an artifact-invoked
 bridge. It starts an absolute executable directly with an argument vector and explicit
-working directory; it never invokes a shell. The request supplies the complete child
-environment, and an empty environment is the secure default so build-host or agent
-secrets are not inherited implicitly. Environment names are validated and duplicates
-are rejected using platform semantics.
+absolute working directory; it never invokes a shell. Embedded NUL bytes in paths,
+arguments, or environment values are rejected before launch. The request supplies the
+complete child environment, and an empty environment is the secure default so
+build-host or agent secrets are not inherited implicitly. Environment names are
+validated and duplicates are rejected using platform semantics.
 
 The call owns one process tree. Windows starts the root suspended, assigns it to a
 kill-on-close Job Object, and only then resumes it. POSIX creates a new process group

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -20,6 +20,10 @@ Everything else must integrate through explicit, auditable boundaries.
 Current maturity:
 
 - .NET integration currently exists as an early generated-launcher path: the native runtime pipeline can spawn a generated C# stub as a child process, but generated C# transpilation output is not executed by the runtime host.
+- A portable bounded-process primitive now provides direct executable/argument
+  invocation, an explicit child environment, timeout and cancellation handling,
+  and descendant cleanup. It is infrastructure for a future artifact adapter,
+  not a runtime route or language integration by itself.
 - Python and broader polyglot support are planning/scaffolding surfaces only; there is no Python runtime hook today.
 - .NET, Python, R, and other polyglot features should require a user-selected modernization target before they are exposed as product capabilities.
 
@@ -79,10 +83,39 @@ The decision order is cancellation, timeout, latency-budget exhaustion, and the
 reported candidate failure class. `propagate` cancellation returns a cancelled result
 without fallback; `ignore` treats cancellation as a failure and applies the configured
 fallback. Other failures map to stable machine error codes and then either fail fast,
-select native, or select the fallback artifact. The implementation records the policy's
-attempt limit but does not claim that a process was started or retried; process
-execution, cancellation tokens, and adapter-specific retry mechanics remain outside
-this contract slice.
+select native, or select the fallback artifact. The policy model records the attempt
+limit but does not itself start or retry a process. The separate bounded-process
+primitive described below supplies a low-level execution boundary; adapter-specific
+retry and the connection from policy decisions to an authorized artifact remain
+outside the policy model.
+
+## Bounded Artifact Process Primitive
+
+`run_bounded_process` is the first execution prerequisite for an artifact-invoked
+bridge. It starts an absolute executable directly with an argument vector and explicit
+working directory; it never invokes a shell. The request supplies the complete child
+environment, and an empty environment is the secure default so build-host or agent
+secrets are not inherited implicitly. Environment names are validated and duplicates
+are rejected using platform semantics.
+
+The call owns one process tree. Windows starts the root suspended, assigns it to a
+kill-on-close Job Object, and only then resumes it. POSIX creates a new process group
+and uses a close-on-exec status pipe to distinguish successful `execve` from pre-exec
+failure. Both paths poll a finite timeout and a prompt cancellation callback, fail
+closed if that callback throws, return invariant status/error identifiers, and remove
+descendants after timeout, cancellation, launch failure, or normal root exit.
+
+Focused synthetic tests cover exact exit status, shell-metacharacter arguments, a
+Unicode working path and environment value, absence of ambient `PATH`, live and
+throwing cancellation, timeout cleanup, cleanup after normal root exit, missing
+executables, invalid budgets, and duplicate environment names. Local GCC, Clang, and
+ASan/UBSan executions pass, together with the native test-isolation contract. Hosted
+Windows and macOS evidence remains required before this prerequisite is integrated.
+
+This primitive does **not** authorize or hash an artifact, validate migration
+contracts or typed envelopes, capture standard output/error, implement retries or
+fallback, choose a route, emit migration telemetry, or connect any external language
+to the PRG runtime. Those remain separately reviewable adapter and dispatch work.
 
 ## Shadow Parity v1
 

--- a/include/copperfin/platform/bounded_process.h
+++ b/include/copperfin/platform/bounded_process.h
@@ -51,9 +51,10 @@ struct BoundedProcessResult {
     }
 };
 
-// Starts an executable directly without a shell, polls cancellation while it
-// runs, and owns one process group/job. Closing the invocation always removes
-// descendants so an artifact cannot leave helpers behind after returning.
+// Starts an absolute executable directly without a shell, polls cancellation
+// while it runs, and owns one process group/job. Paths and arguments containing
+// NUL are rejected. Closing the invocation always removes descendants so an
+// artifact cannot leave helpers behind after returning.
 [[nodiscard]] BoundedProcessResult run_bounded_process(
     const BoundedProcessRequest& request);
 

--- a/include/copperfin/platform/bounded_process.h
+++ b/include/copperfin/platform/bounded_process.h
@@ -1,0 +1,63 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace copperfin::platform {
+
+enum class BoundedProcessStatus {
+    exited,
+    cancelled,
+    timed_out,
+    invalid_request,
+    launch_failed
+};
+
+struct BoundedProcessEnvironmentVariable {
+    std::string name;
+    std::string value;
+};
+
+struct BoundedProcessRequest {
+    std::string executable_path;
+    std::vector<std::string> arguments;
+    std::string working_directory;
+    // Complete child environment. The default is intentionally empty; ambient
+    // agent/build secrets are never inherited implicitly.
+    std::vector<BoundedProcessEnvironmentVariable> environment;
+    std::uint32_t timeout_ms = 5000U;
+    std::uint32_t poll_interval_ms = 10U;
+    // Must return promptly. true, or an exception, fails closed as cancellation.
+    std::function<bool()> cancellation_requested;
+};
+
+struct BoundedProcessResult {
+    BoundedProcessStatus status = BoundedProcessStatus::invalid_request;
+    bool started = false;
+    bool process_tree_closed = false;
+    int exit_code = -1;
+    int native_error = 0;
+    std::uint64_t elapsed_ms = 0U;
+    std::string error_code = "polyglot.process.invalid_request";
+
+    [[nodiscard]] bool completed() const noexcept {
+        return status == BoundedProcessStatus::exited;
+    }
+};
+
+// Starts an executable directly without a shell, polls cancellation while it
+// runs, and owns one process group/job. Closing the invocation always removes
+// descendants so an artifact cannot leave helpers behind after returning.
+[[nodiscard]] BoundedProcessResult run_bounded_process(
+    const BoundedProcessRequest& request);
+
+[[nodiscard]] const char* bounded_process_status_name(
+    BoundedProcessStatus status) noexcept;
+
+}  // namespace copperfin::platform

--- a/src/platform/bounded_process.cpp
+++ b/src/platform/bounded_process.cpp
@@ -1,0 +1,695 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/bounded_process.h"
+
+#include "copperfin/platform/path.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cerrno>
+#include <cstdint>
+#include <cwctype>
+#include <filesystem>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#if defined(_WIN32)
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <csignal>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace copperfin::platform {
+namespace {
+
+#if defined(_WIN32)
+constexpr DWORD kTerminationWaitMilliseconds = 5000U;
+#endif
+
+using Clock = std::chrono::steady_clock;
+
+std::uint64_t elapsed_milliseconds(const Clock::time_point started) {
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        Clock::now() - started).count();
+    return elapsed <= 0 ? 0U : static_cast<std::uint64_t>(elapsed);
+}
+
+BoundedProcessResult invalid_request() {
+    return {};
+}
+
+bool cancellation_requested(const BoundedProcessRequest& request) noexcept {
+    if (!request.cancellation_requested) {
+        return false;
+    }
+    try {
+        return request.cancellation_requested();
+    } catch (...) {
+        // A callback failure must never unwind past an owned live process.
+        return true;
+    }
+}
+
+bool is_environment_name_character(const char character, const bool first) noexcept {
+    return (character >= 'A' && character <= 'Z') ||
+        (character >= 'a' && character <= 'z') || character == '_' ||
+        (!first && character >= '0' && character <= '9');
+}
+
+bool valid_environment_variable(
+    const BoundedProcessEnvironmentVariable& variable) noexcept {
+    if (variable.name.empty() ||
+        !is_environment_name_character(variable.name.front(), true) ||
+        variable.value.find('\0') != std::string::npos) {
+        return false;
+    }
+    for (std::size_t index = 1U; index < variable.name.size(); ++index) {
+        if (!is_environment_name_character(variable.name[index], false)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+#if defined(_WIN32)
+char ascii_lower(const char character) noexcept {
+    return character >= 'A' && character <= 'Z'
+        ? static_cast<char>(character - 'A' + 'a')
+        : character;
+}
+#endif
+
+bool environment_names_equal(
+    const std::string_view left,
+    const std::string_view right) noexcept {
+    if (left.size() != right.size()) {
+        return false;
+    }
+#if defined(_WIN32)
+    for (std::size_t index = 0U; index < left.size(); ++index) {
+        if (ascii_lower(left[index]) != ascii_lower(right[index])) {
+            return false;
+        }
+    }
+    return true;
+#else
+    return left == right;
+#endif
+}
+
+bool valid_environment(
+    const std::vector<BoundedProcessEnvironmentVariable>& environment) noexcept {
+    for (std::size_t index = 0U; index < environment.size(); ++index) {
+        if (!valid_environment_variable(environment[index])) {
+            return false;
+        }
+        for (std::size_t previous = 0U; previous < index; ++previous) {
+            if (environment_names_equal(
+                    environment[index].name, environment[previous].name)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+#if defined(_WIN32)
+
+std::wstring utf8_to_wide(const std::string& value, int& native_error) {
+    native_error = 0;
+    if (value.empty()) {
+        return {};
+    }
+    if (value.size() > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+        native_error = ERROR_INVALID_PARAMETER;
+        return {};
+    }
+    const int required = ::MultiByteToWideChar(
+        CP_UTF8,
+        MB_ERR_INVALID_CHARS,
+        value.data(),
+        static_cast<int>(value.size()),
+        nullptr,
+        0);
+    if (required <= 0) {
+        native_error = static_cast<int>(::GetLastError());
+        return {};
+    }
+    std::wstring result(static_cast<std::size_t>(required), L'\0');
+    if (::MultiByteToWideChar(
+            CP_UTF8,
+            MB_ERR_INVALID_CHARS,
+            value.data(),
+            static_cast<int>(value.size()),
+            result.data(),
+            required) != required) {
+        native_error = static_cast<int>(::GetLastError());
+        return {};
+    }
+    return result;
+}
+
+std::wstring quote_argument(const std::wstring& value) {
+    std::wstring result(1U, L'"');
+    std::size_t backslashes = 0U;
+    for (const wchar_t character : value) {
+        if (character == L'\\') {
+            ++backslashes;
+            continue;
+        }
+        if (character == L'"') {
+            result.append(backslashes * 2U + 1U, L'\\');
+            result.push_back(L'"');
+            backslashes = 0U;
+            continue;
+        }
+        result.append(backslashes, L'\\');
+        backslashes = 0U;
+        result.push_back(character);
+    }
+    result.append(backslashes * 2U, L'\\');
+    result.push_back(L'"');
+    return result;
+}
+
+bool wait_for_terminated_process(
+    const HANDLE process,
+    BoundedProcessResult& result) {
+    const DWORD wait_result =
+        ::WaitForSingleObject(process, kTerminationWaitMilliseconds);
+    if (wait_result == WAIT_OBJECT_0) {
+        return true;
+    }
+    result.status = BoundedProcessStatus::launch_failed;
+    result.error_code = "polyglot.process.tree_termination_failed";
+    result.native_error = wait_result == WAIT_FAILED
+        ? static_cast<int>(::GetLastError())
+        : static_cast<int>(WAIT_TIMEOUT);
+    return false;
+}
+
+BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
+    BoundedProcessResult result;
+    const auto started_at = Clock::now();
+    int conversion_error = 0;
+    const std::wstring executable = utf8_to_wide(request.executable_path, conversion_error);
+    const std::wstring working_directory =
+        utf8_to_wide(request.working_directory, conversion_error);
+    if (conversion_error != 0 || executable.empty() || working_directory.empty()) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.launch_failed";
+        result.native_error = conversion_error == 0 ? ERROR_INVALID_PARAMETER : conversion_error;
+        return result;
+    }
+
+    std::wstring command_line = quote_argument(executable);
+    for (const auto& argument : request.arguments) {
+        const std::wstring converted = utf8_to_wide(argument, conversion_error);
+        if (conversion_error != 0) {
+            result.status = BoundedProcessStatus::launch_failed;
+            result.error_code = "polyglot.process.launch_failed";
+            result.native_error = conversion_error;
+            return result;
+        }
+        command_line.push_back(L' ');
+        command_line += quote_argument(converted);
+    }
+
+    std::vector<std::pair<std::wstring, std::wstring>> environment_entries;
+    environment_entries.reserve(request.environment.size());
+    for (const auto& variable : request.environment) {
+        std::wstring name = utf8_to_wide(variable.name, conversion_error);
+        if (conversion_error != 0) {
+            result.status = BoundedProcessStatus::launch_failed;
+            result.error_code = "polyglot.process.environment_invalid";
+            result.native_error = conversion_error;
+            return result;
+        }
+        std::wstring value = utf8_to_wide(variable.value, conversion_error);
+        if (conversion_error != 0 && !variable.value.empty()) {
+            result.status = BoundedProcessStatus::launch_failed;
+            result.error_code = "polyglot.process.environment_invalid";
+            result.native_error = conversion_error;
+            return result;
+        }
+        environment_entries.emplace_back(std::move(name), std::move(value));
+    }
+    std::sort(
+        environment_entries.begin(),
+        environment_entries.end(),
+        [](const auto& left, const auto& right) {
+            return std::lexicographical_compare(
+                left.first.begin(), left.first.end(),
+                right.first.begin(), right.first.end(),
+                [](const wchar_t left_character, const wchar_t right_character) {
+                    return ::towlower(left_character) < ::towlower(right_character);
+                });
+        });
+    std::vector<wchar_t> environment_block;
+    for (const auto& [name, value] : environment_entries) {
+        environment_block.insert(environment_block.end(), name.begin(), name.end());
+        environment_block.push_back(L'=');
+        environment_block.insert(environment_block.end(), value.begin(), value.end());
+        environment_block.push_back(L'\0');
+    }
+    environment_block.push_back(L'\0');
+    if (environment_entries.empty()) {
+        environment_block.push_back(L'\0');
+    }
+
+    const HANDLE job = ::CreateJobObjectW(nullptr, nullptr);
+    if (job == nullptr) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.job_create_failed";
+        result.native_error = static_cast<int>(::GetLastError());
+        return result;
+    }
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits{};
+    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    if (::SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            &limits,
+            sizeof(limits)) == FALSE) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.job_configure_failed";
+        result.native_error = static_cast<int>(::GetLastError());
+        (void)::CloseHandle(job);
+        return result;
+    }
+
+    STARTUPINFOW startup_info{};
+    startup_info.cb = sizeof(startup_info);
+    PROCESS_INFORMATION process_info{};
+    const BOOL created = ::CreateProcessW(
+        executable.c_str(),
+        command_line.data(),
+        nullptr,
+        nullptr,
+        FALSE,
+        CREATE_NO_WINDOW | CREATE_SUSPENDED | CREATE_UNICODE_ENVIRONMENT,
+        environment_block.data(),
+        working_directory.c_str(),
+        &startup_info,
+        &process_info);
+    if (created == FALSE) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.launch_failed";
+        result.native_error = static_cast<int>(::GetLastError());
+        (void)::CloseHandle(job);
+        return result;
+    }
+    result.started = true;
+    if (::AssignProcessToJobObject(job, process_info.hProcess) == FALSE) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.job_assign_failed";
+        result.native_error = static_cast<int>(::GetLastError());
+        if (::TerminateProcess(process_info.hProcess, 1U) == FALSE) {
+            result.native_error = static_cast<int>(::GetLastError());
+            result.error_code = "polyglot.process.tree_termination_failed";
+        } else {
+            (void)wait_for_terminated_process(process_info.hProcess, result);
+        }
+        (void)::CloseHandle(process_info.hThread);
+        (void)::CloseHandle(process_info.hProcess);
+        (void)::CloseHandle(job);
+        result.process_tree_closed = true;
+        result.elapsed_ms = elapsed_milliseconds(started_at);
+        return result;
+    }
+    if (::ResumeThread(process_info.hThread) == static_cast<DWORD>(-1)) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.resume_failed";
+        result.native_error = static_cast<int>(::GetLastError());
+        if (::TerminateJobObject(job, 1U) == FALSE) {
+            result.native_error = static_cast<int>(::GetLastError());
+            result.error_code = "polyglot.process.tree_termination_failed";
+        } else {
+            (void)wait_for_terminated_process(process_info.hProcess, result);
+        }
+        (void)::CloseHandle(process_info.hThread);
+        (void)::CloseHandle(process_info.hProcess);
+        (void)::CloseHandle(job);
+        result.process_tree_closed = true;
+        result.elapsed_ms = elapsed_milliseconds(started_at);
+        return result;
+    }
+    (void)::CloseHandle(process_info.hThread);
+
+    const DWORD poll_ms = std::max<DWORD>(1U, request.poll_interval_ms);
+    for (;;) {
+        const DWORD wait_result = ::WaitForSingleObject(process_info.hProcess, poll_ms);
+        if (wait_result == WAIT_OBJECT_0) {
+            DWORD exit_code = 1U;
+            if (::GetExitCodeProcess(process_info.hProcess, &exit_code) == FALSE) {
+                result.status = BoundedProcessStatus::launch_failed;
+                result.error_code = "polyglot.process.exit_query_failed";
+                result.native_error = static_cast<int>(::GetLastError());
+            } else {
+                result.status = BoundedProcessStatus::exited;
+                result.error_code = "polyglot.process.exited";
+                result.exit_code = static_cast<int>(exit_code);
+            }
+            break;
+        }
+        if (wait_result == WAIT_FAILED) {
+            result.status = BoundedProcessStatus::launch_failed;
+            result.error_code = "polyglot.process.wait_failed";
+            result.native_error = static_cast<int>(::GetLastError());
+            (void)::TerminateJobObject(job, 1U);
+            result.process_tree_closed = true;
+            break;
+        }
+        if (cancellation_requested(request)) {
+            result.status = BoundedProcessStatus::cancelled;
+            result.error_code = "polyglot.process.cancelled";
+            if (::TerminateJobObject(job, 1U) == FALSE) {
+                result.status = BoundedProcessStatus::launch_failed;
+                result.error_code = "polyglot.process.tree_termination_failed";
+                result.native_error = static_cast<int>(::GetLastError());
+            } else {
+                (void)wait_for_terminated_process(process_info.hProcess, result);
+            }
+            result.process_tree_closed = true;
+            break;
+        }
+        if (elapsed_milliseconds(started_at) >= request.timeout_ms) {
+            result.status = BoundedProcessStatus::timed_out;
+            result.error_code = "polyglot.process.timeout";
+            if (::TerminateJobObject(job, 1U) == FALSE) {
+                result.status = BoundedProcessStatus::launch_failed;
+                result.error_code = "polyglot.process.tree_termination_failed";
+                result.native_error = static_cast<int>(::GetLastError());
+            } else {
+                (void)wait_for_terminated_process(process_info.hProcess, result);
+            }
+            result.process_tree_closed = true;
+            break;
+        }
+    }
+
+    // KILL_ON_JOB_CLOSE also removes descendants after an otherwise successful
+    // root exit; artifact invocations never authorize persistent child jobs.
+    (void)::CloseHandle(job);
+    result.process_tree_closed = true;
+    (void)::CloseHandle(process_info.hProcess);
+    result.elapsed_ms = elapsed_milliseconds(started_at);
+    return result;
+}
+
+#else
+
+bool write_child_error(const int descriptor, const int child_error) {
+    const auto* bytes = reinterpret_cast<const std::uint8_t*>(&child_error);
+    std::size_t written = 0U;
+    while (written < sizeof(child_error)) {
+        const ssize_t count =
+            ::write(descriptor, bytes + written, sizeof(child_error) - written);
+        if (count < 0 && errno == EINTR) {
+            continue;
+        }
+        if (count <= 0) {
+            return false;
+        }
+        written += static_cast<std::size_t>(count);
+    }
+    return true;
+}
+
+void terminate_process_group(const pid_t process_id) {
+    if (process_id <= 0) {
+        return;
+    }
+    (void)::kill(-process_id, SIGKILL);
+    (void)::kill(process_id, SIGKILL);
+}
+
+BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
+    BoundedProcessResult result;
+    const auto started_at = Clock::now();
+    int launch_pipe[2]{-1, -1};
+    if (::pipe(launch_pipe) != 0) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.launch_pipe_failed";
+        result.native_error = errno;
+        return result;
+    }
+    if (::fcntl(launch_pipe[1], F_SETFD, FD_CLOEXEC) == -1) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.launch_pipe_failed";
+        result.native_error = errno;
+        (void)::close(launch_pipe[0]);
+        (void)::close(launch_pipe[1]);
+        return result;
+    }
+    const int read_flags = ::fcntl(launch_pipe[0], F_GETFL, 0);
+    if (read_flags == -1 ||
+        ::fcntl(launch_pipe[0], F_SETFL, read_flags | O_NONBLOCK) == -1) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.launch_pipe_failed";
+        result.native_error = errno;
+        (void)::close(launch_pipe[0]);
+        (void)::close(launch_pipe[1]);
+        return result;
+    }
+
+    std::vector<std::string> argument_storage;
+    argument_storage.reserve(request.arguments.size() + 1U);
+    argument_storage.push_back(request.executable_path);
+    argument_storage.insert(
+        argument_storage.end(), request.arguments.begin(), request.arguments.end());
+    std::vector<char*> argv;
+    argv.reserve(argument_storage.size() + 1U);
+    for (auto& argument : argument_storage) {
+        argv.push_back(argument.data());
+    }
+    argv.push_back(nullptr);
+    std::vector<std::string> environment_storage;
+    environment_storage.reserve(request.environment.size());
+    for (const auto& variable : request.environment) {
+        environment_storage.push_back(variable.name + "=" + variable.value);
+    }
+    std::vector<char*> environment;
+    environment.reserve(environment_storage.size() + 1U);
+    for (auto& variable : environment_storage) {
+        environment.push_back(variable.data());
+    }
+    environment.push_back(nullptr);
+
+    const pid_t process_id = ::fork();
+    if (process_id == 0) {
+        (void)::close(launch_pipe[0]);
+        if (::setpgid(0, 0) != 0 ||
+            ::chdir(request.working_directory.c_str()) != 0) {
+            const int child_error = errno;
+            (void)write_child_error(launch_pipe[1], child_error);
+            _exit(127);
+        }
+        ::execve(request.executable_path.c_str(), argv.data(), environment.data());
+        const int child_error = errno;
+        (void)write_child_error(launch_pipe[1], child_error);
+        _exit(127);
+    }
+    (void)::close(launch_pipe[1]);
+    if (process_id < 0) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.launch_failed";
+        result.native_error = errno;
+        (void)::close(launch_pipe[0]);
+        return result;
+    }
+    if (::setpgid(process_id, process_id) != 0 && errno != EACCES && errno != ESRCH) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.group_create_failed";
+        result.native_error = errno;
+        terminate_process_group(process_id);
+        int ignored_status = 0;
+        (void)::waitpid(process_id, &ignored_status, 0);
+        (void)::close(launch_pipe[0]);
+        result.process_tree_closed = true;
+        result.elapsed_ms = elapsed_milliseconds(started_at);
+        return result;
+    }
+
+    int child_error = 0;
+    auto* error_bytes = reinterpret_cast<std::uint8_t*>(&child_error);
+    std::size_t error_count = 0U;
+    int launch_read_error = 0;
+    bool launch_complete = false;
+    while (error_count < sizeof(child_error)) {
+        const ssize_t count = ::read(
+            launch_pipe[0], error_bytes + error_count, sizeof(child_error) - error_count);
+        if (count < 0 && errno == EINTR) {
+            continue;
+        }
+        if (count < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+            launch_read_error = errno;
+            break;
+        }
+        if (count == 0) {
+            launch_complete = true;
+            break;
+        }
+        if (count > 0) {
+            error_count += static_cast<std::size_t>(count);
+            continue;
+        }
+        if (cancellation_requested(request)) {
+            result.status = BoundedProcessStatus::cancelled;
+            result.error_code = "polyglot.process.cancelled";
+            terminate_process_group(process_id);
+            int ignored_status = 0;
+            (void)::waitpid(process_id, &ignored_status, 0);
+            result.process_tree_closed = true;
+            result.elapsed_ms = elapsed_milliseconds(started_at);
+            (void)::close(launch_pipe[0]);
+            return result;
+        }
+        if (elapsed_milliseconds(started_at) >= request.timeout_ms) {
+            result.status = BoundedProcessStatus::timed_out;
+            result.error_code = "polyglot.process.timeout";
+            terminate_process_group(process_id);
+            int ignored_status = 0;
+            (void)::waitpid(process_id, &ignored_status, 0);
+            result.process_tree_closed = true;
+            result.elapsed_ms = elapsed_milliseconds(started_at);
+            (void)::close(launch_pipe[0]);
+            return result;
+        }
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(std::max<std::uint32_t>(1U, request.poll_interval_ms)));
+    }
+    (void)::close(launch_pipe[0]);
+    if (!launch_complete || error_count != 0U || launch_read_error != 0) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.launch_failed";
+        result.native_error = launch_read_error != 0
+            ? launch_read_error
+            : (error_count == sizeof(child_error) ? child_error : EIO);
+        int ignored_status = 0;
+        (void)::waitpid(process_id, &ignored_status, 0);
+        terminate_process_group(process_id);
+        result.process_tree_closed = true;
+        result.elapsed_ms = elapsed_milliseconds(started_at);
+        return result;
+    }
+    result.started = true;
+
+    int status = 0;
+    for (;;) {
+        const pid_t waited = ::waitpid(process_id, &status, WNOHANG);
+        if (waited == process_id) {
+            result.status = BoundedProcessStatus::exited;
+            result.error_code = "polyglot.process.exited";
+            if (WIFEXITED(status)) {
+                result.exit_code = WEXITSTATUS(status);
+            } else if (WIFSIGNALED(status)) {
+                result.exit_code = 128 + WTERMSIG(status);
+            }
+            break;
+        }
+        if (waited < 0 && errno != EINTR) {
+            result.status = BoundedProcessStatus::launch_failed;
+            result.error_code = "polyglot.process.wait_failed";
+            result.native_error = errno;
+            terminate_process_group(process_id);
+            (void)::waitpid(process_id, &status, 0);
+            break;
+        }
+        if (cancellation_requested(request)) {
+            result.status = BoundedProcessStatus::cancelled;
+            result.error_code = "polyglot.process.cancelled";
+            terminate_process_group(process_id);
+            (void)::waitpid(process_id, &status, 0);
+            break;
+        }
+        if (elapsed_milliseconds(started_at) >= request.timeout_ms) {
+            result.status = BoundedProcessStatus::timed_out;
+            result.error_code = "polyglot.process.timeout";
+            terminate_process_group(process_id);
+            (void)::waitpid(process_id, &status, 0);
+            break;
+        }
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(std::max<std::uint32_t>(1U, request.poll_interval_ms)));
+    }
+
+    // Remove helpers even when the root returned normally. A migration
+    // artifact is a bounded call, never a daemon-launch boundary.
+    terminate_process_group(process_id);
+    result.process_tree_closed = true;
+    result.elapsed_ms = elapsed_milliseconds(started_at);
+    return result;
+}
+
+#endif
+
+}  // namespace
+
+BoundedProcessResult run_bounded_process(const BoundedProcessRequest& request) {
+    if (request.executable_path.empty() || request.working_directory.empty() ||
+        request.timeout_ms == 0U || request.poll_interval_ms == 0U ||
+        request.poll_interval_ms > request.timeout_ms ||
+        !valid_environment(request.environment)) {
+        return invalid_request();
+    }
+    std::error_code error;
+    const std::filesystem::path executable =
+        copperfin::platform::path_from_utf8_string(request.executable_path);
+    const std::filesystem::path working_directory =
+        copperfin::platform::path_from_utf8_string(request.working_directory);
+    if (!std::filesystem::is_regular_file(executable, error) || error) {
+        BoundedProcessResult result;
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.executable_unavailable";
+        return result;
+    }
+    error.clear();
+    if (!std::filesystem::is_directory(working_directory, error) || error) {
+        return invalid_request();
+    }
+    if (cancellation_requested(request)) {
+        BoundedProcessResult result;
+        result.status = BoundedProcessStatus::cancelled;
+        result.error_code = "polyglot.process.cancelled";
+        return result;
+    }
+#if defined(_WIN32)
+    return run_windows(request);
+#else
+    return run_posix(request);
+#endif
+}
+
+const char* bounded_process_status_name(const BoundedProcessStatus status) noexcept {
+    switch (status) {
+    case BoundedProcessStatus::exited:
+        return "exited";
+    case BoundedProcessStatus::cancelled:
+        return "cancelled";
+    case BoundedProcessStatus::timed_out:
+        return "timed-out";
+    case BoundedProcessStatus::invalid_request:
+        return "invalid-request";
+    case BoundedProcessStatus::launch_failed:
+        return "launch-failed";
+    }
+    return "invalid-request";
+}
+
+}  // namespace copperfin::platform

--- a/src/platform/bounded_process.cpp
+++ b/src/platform/bounded_process.cpp
@@ -65,6 +65,16 @@ bool cancellation_requested(const BoundedProcessRequest& request) noexcept {
     }
 }
 
+bool contains_nul(const std::string_view value) noexcept {
+    return value.find('\0') != std::string_view::npos;
+}
+
+bool valid_arguments(const std::vector<std::string>& arguments) noexcept {
+    return std::none_of(
+        arguments.begin(), arguments.end(),
+        [](const std::string& argument) { return contains_nul(argument); });
+}
+
 bool is_environment_name_character(const char character, const bool first) noexcept {
     return (character >= 'A' && character <= 'Z') ||
         (character >= 'a' && character <= 'z') || character == '_' ||
@@ -75,7 +85,7 @@ bool valid_environment_variable(
     const BoundedProcessEnvironmentVariable& variable) noexcept {
     if (variable.name.empty() ||
         !is_environment_name_character(variable.name.front(), true) ||
-        variable.value.find('\0') != std::string::npos) {
+        contains_nul(variable.value)) {
         return false;
     }
     for (std::size_t index = 1U; index < variable.name.size(); ++index) {
@@ -643,6 +653,9 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
 
 BoundedProcessResult run_bounded_process(const BoundedProcessRequest& request) {
     if (request.executable_path.empty() || request.working_directory.empty() ||
+        contains_nul(request.executable_path) ||
+        contains_nul(request.working_directory) ||
+        !valid_arguments(request.arguments) ||
         request.timeout_ms == 0U || request.poll_interval_ms == 0U ||
         request.poll_interval_ms > request.timeout_ms ||
         !valid_environment(request.environment)) {
@@ -653,6 +666,9 @@ BoundedProcessResult run_bounded_process(const BoundedProcessRequest& request) {
         copperfin::platform::path_from_utf8_string(request.executable_path);
     const std::filesystem::path working_directory =
         copperfin::platform::path_from_utf8_string(request.working_directory);
+    if (!executable.is_absolute() || !working_directory.is_absolute()) {
+        return invalid_request();
+    }
     if (!std::filesystem::is_regular_file(executable, error) || error) {
         BoundedProcessResult result;
         result.status = BoundedProcessStatus::launch_failed;

--- a/src/platform/bounded_process.cpp
+++ b/src/platform/bounded_process.cpp
@@ -581,9 +581,9 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
         result.native_error = launch_read_error != 0
             ? launch_read_error
             : (error_count == sizeof(child_error) ? child_error : EIO);
+        terminate_process_group(process_id);
         int ignored_status = 0;
         (void)::waitpid(process_id, &ignored_status, 0);
-        terminate_process_group(process_id);
         result.process_tree_closed = true;
         result.elapsed_ms = elapsed_milliseconds(started_at);
         return result;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4672,6 +4672,10 @@ copperfin_add_test(test_polyglot_bridge_invocation cf_platform_profile
     test_polyglot_bridge_invocation.cpp
 )
 
+copperfin_add_test(test_bounded_process cf_platform_profile
+    test_bounded_process.cpp
+)
+
 copperfin_add_test(test_polyglot_parity_comparator cf_platform_profile
     test_polyglot_parity_comparator.cpp
 )

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -127,6 +127,16 @@ function(copperfin_configure_native_test_isolation)
             AUDIT complete
         )
     endforeach()
+    copperfin_set_test_isolation(test_bounded_process
+        PARALLEL_SAFE
+        FILESYSTEM process-owned
+        ENVIRONMENT scoped-process
+        CHILD_PROCESSES bounded
+        NETWORK none
+        SAMPLES none
+        PLATFORM portable
+        AUDIT complete
+    )
     copperfin_set_test_isolation(test_polyglot_contract
         PARALLEL_SAFE
         FILESYSTEM read-only

--- a/tests/test_bounded_process.cpp
+++ b/tests/test_bounded_process.cpp
@@ -339,6 +339,49 @@ int run_tests(const std::filesystem::path& executable) {
             !invalid_environment.started,
         "#4700: duplicate explicit environment names should be rejected");
 
+    const auto relative_executable = copperfin::platform::run_bounded_process({
+        .executable_path = executable.filename().string(),
+        .arguments = {},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 100U,
+        .poll_interval_ms = 1U,
+        .cancellation_requested = {}});
+    expect(
+        relative_executable.status ==
+                copperfin::platform::BoundedProcessStatus::invalid_request &&
+            !relative_executable.started,
+        "#4700: relative executable paths should be rejected before launch");
+
+    const auto relative_working_directory =
+        copperfin::platform::run_bounded_process({
+            .executable_path = executable_path,
+            .arguments = {},
+            .working_directory = ".",
+            .environment = {},
+            .timeout_ms = 100U,
+            .poll_interval_ms = 1U,
+            .cancellation_requested = {}});
+    expect(
+        relative_working_directory.status ==
+                copperfin::platform::BoundedProcessStatus::invalid_request &&
+            !relative_working_directory.started,
+        "#4700: relative working directories should be rejected before launch");
+
+    const auto nul_argument = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {std::string{"truncated\0suffix", 16U}},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 100U,
+        .poll_interval_ms = 1U,
+        .cancellation_requested = {}});
+    expect(
+        nul_argument.status ==
+                copperfin::platform::BoundedProcessStatus::invalid_request &&
+            !nul_argument.started,
+        "#4700: arguments containing NUL should be rejected before launch");
+
     fs::remove_all(root, error);
     return failures == 0 ? 0 : 1;
 }

--- a/tests/test_bounded_process.cpp
+++ b/tests/test_bounded_process.cpp
@@ -1,0 +1,373 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/bounded_process.h"
+#include "copperfin/platform/environment.h"
+#include "copperfin/platform/path.h"
+
+#include <atomic>
+#include <chrono>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
+namespace {
+
+int failures = 0;
+
+unsigned long current_process_id() {
+#if defined(_WIN32)
+    return static_cast<unsigned long>(::GetCurrentProcessId());
+#else
+    return static_cast<unsigned long>(::getpid());
+#endif
+}
+
+void expect(const bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+void write_marker(const std::filesystem::path& path, const std::string& value) {
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    output << value;
+}
+
+#if defined(_WIN32)
+
+std::wstring quote_argument(const std::wstring& value) {
+    std::wstring result(1U, L'"');
+    std::size_t backslashes = 0U;
+    for (const wchar_t character : value) {
+        if (character == L'\\') {
+            ++backslashes;
+            continue;
+        }
+        if (character == L'"') {
+            result.append(backslashes * 2U + 1U, L'\\');
+            result.push_back(L'"');
+            backslashes = 0U;
+            continue;
+        }
+        result.append(backslashes, L'\\');
+        backslashes = 0U;
+        result.push_back(character);
+    }
+    result.append(backslashes * 2U, L'\\');
+    result.push_back(L'"');
+    return result;
+}
+
+bool spawn_grandchild(
+    const std::filesystem::path& executable,
+    const std::filesystem::path& marker) {
+    std::wstring command = quote_argument(executable.wstring()) + L" --grandchild " +
+        quote_argument(marker.wstring());
+    STARTUPINFOW startup{};
+    startup.cb = sizeof(startup);
+    PROCESS_INFORMATION process{};
+    const BOOL started = ::CreateProcessW(
+        executable.c_str(), command.data(), nullptr, nullptr, FALSE,
+        CREATE_NO_WINDOW, nullptr, nullptr, &startup, &process);
+    if (started == FALSE) {
+        return false;
+    }
+    (void)::CloseHandle(process.hThread);
+    (void)::CloseHandle(process.hProcess);
+    return true;
+}
+
+#else
+
+bool spawn_grandchild(
+    const std::filesystem::path& executable,
+    const std::filesystem::path& marker) {
+    const pid_t child = ::fork();
+    if (child == 0) {
+        const std::string executable_bytes = executable.string();
+        const std::string marker_bytes = marker.string();
+        const char* arguments[]{
+            executable_bytes.c_str(), "--grandchild", marker_bytes.c_str(), nullptr};
+        ::execv(executable_bytes.c_str(), const_cast<char* const*>(arguments));
+        _exit(127);
+    }
+    return child > 0;
+}
+
+#endif
+
+int run_helper(
+    const std::filesystem::path& executable,
+    const std::vector<std::string>& arguments) {
+    if (arguments.empty()) {
+        return 90;
+    }
+    if (arguments[0] == "--exit" && arguments.size() == 2U) {
+        return std::stoi(arguments[1]);
+    }
+    if (arguments[0] == "--record" && arguments.size() == 3U) {
+        const auto explicit_value =
+            copperfin::platform::read_environment_variable("COPPERFIN_TEST_VALUE");
+        const auto ambient_path = copperfin::platform::read_environment_variable("PATH");
+        write_marker(
+            copperfin::platform::path_from_utf8_string(arguments[1]),
+            copperfin::platform::path_to_utf8_string(std::filesystem::current_path()) +
+                "|" + arguments[2] + "|" + explicit_value.value_or("missing") +
+                "|" + (ambient_path.has_value() ? "ambient" : "isolated"));
+        return 0;
+    }
+    if (arguments[0] == "--sleep" && arguments.size() == 2U) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(std::stoi(arguments[1])));
+        return 0;
+    }
+    if (arguments[0] == "--grandchild" && arguments.size() == 2U) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+        write_marker(copperfin::platform::path_from_utf8_string(arguments[1]), "orphaned");
+        return 0;
+    }
+    if (arguments[0] == "--tree" && arguments.size() == 2U) {
+        if (!spawn_grandchild(
+                executable,
+                copperfin::platform::path_from_utf8_string(arguments[1]))) {
+            return 91;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+        return 0;
+    }
+    if (arguments[0] == "--tree-exit" && arguments.size() == 2U) {
+        return spawn_grandchild(
+            executable,
+            copperfin::platform::path_from_utf8_string(arguments[1])) ? 0 : 91;
+    }
+    return 92;
+}
+
+int run_tests(const std::filesystem::path& executable) {
+    namespace fs = std::filesystem;
+    const fs::path root = fs::temp_directory_path() /
+        copperfin::platform::path_from_utf8_string(
+            std::string{"copperfin-bounded-process-"} + "\xC3\xA9" + "-" +
+                std::to_string(current_process_id()));
+    std::error_code error;
+    fs::remove_all(root, error);
+    error.clear();
+    fs::create_directories(root, error);
+    expect(!error, "#4700: bounded-process fixture root should be created");
+
+    const std::string executable_path =
+        copperfin::platform::path_to_utf8_string(fs::absolute(executable));
+    const std::string root_path = copperfin::platform::path_to_utf8_string(root);
+    const std::string explicit_environment_value =
+        std::string{"explic"} + "\xC3\xAD" + "t";
+
+    const auto exited = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {"--exit", "37"},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 2000U,
+        .poll_interval_ms = 5U,
+        .cancellation_requested = {}});
+    expect(exited.completed() && exited.started && exited.exit_code == 37,
+           "#4700: direct invocation should preserve the candidate exit code");
+    expect(exited.process_tree_closed && exited.error_code == "polyglot.process.exited",
+           "#4700: normal completion should close the owned process tree");
+
+    const fs::path record_path = root / "record.txt";
+    const auto recorded = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {
+            "--record", copperfin::platform::path_to_utf8_string(record_path),
+            "space value & no shell"},
+        .working_directory = root_path,
+        .environment = {{
+            .name = "COPPERFIN_TEST_VALUE",
+            .value = explicit_environment_value}},
+        .timeout_ms = 2000U,
+        .poll_interval_ms = 5U,
+        .cancellation_requested = {}});
+    std::ifstream record(record_path, std::ios::binary);
+    const std::string record_text{
+        std::istreambuf_iterator<char>(record), std::istreambuf_iterator<char>()};
+    expect(recorded.completed() && recorded.exit_code == 0,
+           "#4700: direct invocation should complete in the requested directory");
+    expect(
+        record_text == root_path + "|space value & no shell|" +
+            explicit_environment_value + "|isolated",
+        "#4700: argv, working directory, and explicit environment should survive without shell parsing or ambient PATH inheritance");
+
+    std::atomic_int cancellation_polls{0};
+    const auto cancelled = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {"--sleep", "2000"},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 3000U,
+        .poll_interval_ms = 10U,
+        .cancellation_requested = [&cancellation_polls]() {
+            return cancellation_polls.fetch_add(1) >= 3;
+        }});
+    expect(cancelled.status == copperfin::platform::BoundedProcessStatus::cancelled &&
+               cancelled.started && cancelled.process_tree_closed,
+           "#4700: live cancellation should stop the owned process tree");
+    expect(cancelled.elapsed_ms < 1000U,
+           "#4700: cancellation should not wait for the candidate sleep to finish");
+
+    std::atomic_int throwing_cancellation_polls{0};
+    const auto callback_failed = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {"--sleep", "2000"},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 3000U,
+        .poll_interval_ms = 10U,
+        .cancellation_requested = [&throwing_cancellation_polls]() {
+            if (throwing_cancellation_polls.fetch_add(1) >= 2) {
+                throw std::runtime_error("synthetic cancellation callback failure");
+            }
+            return false;
+        }});
+    expect(
+        callback_failed.status ==
+                copperfin::platform::BoundedProcessStatus::cancelled &&
+            callback_failed.started && callback_failed.process_tree_closed,
+        "#4700: a failing cancellation callback should fail closed and stop the owned process tree");
+
+    const fs::path orphan_marker = root / "orphan.txt";
+    const auto timed_out = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {"--tree", copperfin::platform::path_to_utf8_string(orphan_marker)},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 100U,
+        .poll_interval_ms = 5U,
+        .cancellation_requested = {}});
+    expect(timed_out.status == copperfin::platform::BoundedProcessStatus::timed_out &&
+               timed_out.started && timed_out.process_tree_closed,
+           "#4700: timeout should stop the candidate and its descendants");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1300));
+    expect(!fs::exists(orphan_marker),
+           "#4700: a timed-out descendant must not survive to write its marker");
+
+    const fs::path completed_orphan_marker = root / "completed-orphan.txt";
+    const auto tree_exited = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {
+            "--tree-exit",
+            copperfin::platform::path_to_utf8_string(completed_orphan_marker)},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 1000U,
+        .poll_interval_ms = 5U,
+        .cancellation_requested = {}});
+    expect(tree_exited.completed() && tree_exited.exit_code == 0 &&
+               tree_exited.process_tree_closed,
+           "#4700: normal root exit should close its remaining descendant tree");
+    std::this_thread::sleep_for(std::chrono::milliseconds(1300));
+    expect(!fs::exists(completed_orphan_marker),
+           "#4700: a descendant must not outlive a normally completed artifact call");
+
+    const auto pre_cancelled = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {"--sleep", "10"},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 100U,
+        .poll_interval_ms = 5U,
+        .cancellation_requested = []() { return true; }});
+    expect(pre_cancelled.status == copperfin::platform::BoundedProcessStatus::cancelled &&
+               !pre_cancelled.started,
+           "#4700: pre-launch cancellation should not start the candidate");
+
+    const auto missing = copperfin::platform::run_bounded_process({
+        .executable_path = root_path + "/missing-artifact",
+        .arguments = {},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 100U,
+        .poll_interval_ms = 5U,
+        .cancellation_requested = {}});
+    expect(missing.status == copperfin::platform::BoundedProcessStatus::launch_failed &&
+               !missing.started &&
+               missing.error_code == "polyglot.process.executable_unavailable",
+           "#4700: a missing artifact should fail before process creation");
+
+    const auto invalid = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 0U,
+        .poll_interval_ms = 1U,
+        .cancellation_requested = {}});
+    expect(invalid.status == copperfin::platform::BoundedProcessStatus::invalid_request &&
+               !invalid.started,
+           "#4700: a zero execution budget should be rejected");
+
+    const auto invalid_environment = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {},
+        .working_directory = root_path,
+        .environment = {
+            {.name = "DUPLICATE", .value = "one"},
+            {.name = "DUPLICATE", .value = "two"}},
+        .timeout_ms = 100U,
+        .poll_interval_ms = 1U,
+        .cancellation_requested = {}});
+    expect(
+        invalid_environment.status ==
+            copperfin::platform::BoundedProcessStatus::invalid_request &&
+            !invalid_environment.started,
+        "#4700: duplicate explicit environment names should be rejected");
+
+    fs::remove_all(root, error);
+    return failures == 0 ? 0 : 1;
+}
+
+}  // namespace
+
+#if defined(_WIN32)
+int wmain(int argc, wchar_t** argv) {
+    try {
+        const std::filesystem::path executable = std::filesystem::absolute(argv[0]);
+        std::vector<std::string> arguments;
+        for (int index = 1; index < argc; ++index) {
+            arguments.push_back(copperfin::platform::path_to_utf8_string(argv[index]));
+        }
+        return arguments.empty() ? run_tests(executable) : run_helper(executable, arguments);
+    } catch (const std::exception& error) {
+        std::cerr << "FAIL: bounded-process test exception: " << error.what() << '\n';
+        return 99;
+    }
+}
+#else
+int main(int argc, char** argv) {
+    try {
+        const std::filesystem::path executable = std::filesystem::absolute(argv[0]);
+        const std::vector<std::string> arguments(argv + 1, argv + argc);
+        return arguments.empty() ? run_tests(executable) : run_helper(executable, arguments);
+    } catch (const std::exception& error) {
+        std::cerr << "FAIL: bounded-process test exception: " << error.what() << '\n';
+        return 99;
+    }
+}
+#endif

--- a/tests/test_bounded_process.cpp
+++ b/tests/test_bounded_process.cpp
@@ -208,11 +208,27 @@ int run_tests(const std::filesystem::path& executable) {
     std::ifstream record(record_path, std::ios::binary);
     const std::string record_text{
         std::istreambuf_iterator<char>(record), std::istreambuf_iterator<char>()};
+    const std::string expected_record_suffix =
+        "|space value & no shell|" + explicit_environment_value + "|isolated";
+    const bool record_suffix_matches =
+        record_text.size() >= expected_record_suffix.size() &&
+        record_text.compare(
+            record_text.size() - expected_record_suffix.size(),
+            expected_record_suffix.size(), expected_record_suffix) == 0;
+    std::error_code equivalent_error;
+    bool working_directory_matches = false;
+    if (record_suffix_matches) {
+        const std::string recorded_working_directory = record_text.substr(
+            0, record_text.size() - expected_record_suffix.size());
+        working_directory_matches = fs::equivalent(
+            copperfin::platform::path_from_utf8_string(
+                recorded_working_directory),
+            root, equivalent_error);
+    }
     expect(recorded.completed() && recorded.exit_code == 0,
            "#4700: direct invocation should complete in the requested directory");
     expect(
-        record_text == root_path + "|space value & no shell|" +
-            explicit_environment_value + "|isolated",
+        record_suffix_matches && !equivalent_error && working_directory_matches,
         "#4700: argv, working directory, and explicit environment should survive without shell parsing or ambient PATH inheritance");
 
     std::atomic_int cancellation_polls{0};


### PR DESCRIPTION
## Summary

- add a portable direct-argv process primitive with explicit empty-by-default child environments
- own and close descendant trees across normal exit, cancellation, callback failure, timeout, and launch failure
- use suspended Job Object admission on Windows and process-group/exec-status-pipe handling on POSIX
- reject relative executable/working-directory paths and embedded-NUL inputs before OS APIs can reinterpret them
- add focused portable regression and isolation coverage
- document exact boundaries and remaining adapter work

Part of #4700; this prerequisite does not close the parent.

## Local evidence

- final documentation head focused GCC licensing/polyglot/isolation suite: 10/10 passed
- Clang bounded-process coverage: 1/1 passed
- Clang ASan/UBSan bounded-process coverage: 1/1 passed, no findings
- focused analyzer checks: no project diagnostics
- `git diff --check`: clean

## Exact implementation/test-head native evidence

- implementation/test head: `36f25b1e5`
- Linux Native `31284210937`: 324/324 passed
- macOS Native `31284210940`: 324/324 passed, plus the existing four-locale matrix
- Windows Native `31284210974`: 323/323 passed
- all three full suites executed `test_bounded_process`
- all eight protected PR checks passed at the implementation/test head

The preceding macOS run exposed a test-only `/var` versus `/private/var` path-alias assumption. The corrected test compares filesystem identity while retaining exact argv, Unicode environment, and ambient `PATH` isolation checks; product code was unchanged by that correction.

## Non-claims

No artifact authorization/hash validation, envelope parsing, output capture, retries/fallback, telemetry, route selection, language adapter, or PRG runtime dispatch is added.
