### PR TITLE
feat(platform): validate polyglot response envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@
   capability/correlation/protocol identity. It applies 1 MiB/32-level defaults
   plus non-disableable 16 MiB/64-level ceilings and preserves an admitted
   success payload as exact validated JSON bytes. GCC, Clang, and Clang
-  ASan/UBSan focused tests pass. Request serialization, process-output capture,
-  artifact authorization/hashing, message rendering, runtime-host/PRG wiring,
-  fallback, and route execution remain unimplemented.
+  ASan/UBSan focused tests pass. Hosted Linux Native run `31287594685` and
+  macOS Native run `31287594735` passed `325/325` at implementation head
+  `171a1652b`. Windows run `31287594747` then exposed only an LF-hard-coded
+  fixture expectation while the parser correctly preserved checked-out CRLF
+  bytes. Test-only final head `09284457e` accepts either fixture convention,
+  independently proves exact LF and CRLF payload preservation under fresh
+  local GCC and Clang builds, and passes hosted Windows Native `324/324` in
+  run `31289912992`, including `test_polyglot_interop_envelope`. All eight
+  protected checks pass at the final head. Request serialization,
+  process-output capture, artifact authorization/hashing, message rendering,
+  runtime-host/PRG wiring, fallback, and route execution remain unimplemented.
 
 - 2026-08-08: Added the v1 bounded-process prerequisite for the artifact-first
   polyglot bridge. The portable API launches an absolute executable directly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+- 2026-08-08: Added a bounded polyglot response-envelope admission seam under
+  #91/#4700. The portable parser validates the versioned success/error JSON
+  shapes, UTF-8 and escape correctness, unique object keys, exact required
+  fields, success/error exclusivity, invariant error codes, and exact
+  capability/correlation/protocol identity. It applies 1 MiB/32-level defaults
+  plus non-disableable 16 MiB/64-level ceilings and preserves an admitted
+  success payload as exact validated JSON bytes. GCC, Clang, and Clang
+  ASan/UBSan focused tests pass. Request serialization, process-output capture,
+  artifact authorization/hashing, message rendering, runtime-host/PRG wiring,
+  fallback, and route execution remain unimplemented.
+
 - 2026-08-08: Added the v1 bounded-process prerequisite for the artifact-first
   polyglot bridge. The portable API launches an absolute executable directly
   without a shell, rejects relative paths and embedded-NUL inputs, and supplies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ add_library(cf_platform_profile
     src/platform/federation_execution.cpp
     src/platform/localized_text.cpp
     src/platform/polyglot_bridge_invocation.cpp
+    src/platform/polyglot_interop_envelope.cpp
     src/platform/polyglot_migration_telemetry.cpp
     src/platform/polyglot_parity_comparator.cpp
     src/platform/polyglot_route_registry.cpp

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -25,6 +25,19 @@ requests, capture process output, authorize/hash an artifact, render candidate
 messages, connect to the runtime host or PRG dispatch, or close #91/#4700.
 Those remain separate slices; the runtime stub inventory is unchanged.
 
+Hosted Linux Native run `31287594685` and macOS Native run `31287594735`
+passed `325/325` at implementation head `171a1652b`, including the envelope
+test. Windows Native run `31287594747` completed `323/324` and failed only
+because the fixture assertion hard-coded LF while the binary reader and parser
+correctly preserved the checkout's CRLF payload bytes. Owner-approved
+test-only final head `09284457e` makes the fixture expectation follow its
+actual LF/CRLF convention and separately requires exact preservation for
+synthetic LF and CRLF payloads. Fresh local GCC and Clang focused builds pass
+`1/1` without project warnings. Exact-final-head Windows Native run
+`31289912992` passes `324/324`, including
+`test_polyglot_interop_envelope`, and all eight protected checks pass. Product
+source did not change for the line-ending correction.
+
 ## V1 bounded polyglot process prerequisite
 
 The trusted #4700 lane now has a rebased product/test candidate for the first

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,30 @@
 # Agent Handoff
 
+## V1 polyglot response-envelope admission candidate
+
+Trusted #91 now has a portable first response-admission seam for the #4700
+artifact bridge. `parse_polyglot_interop_envelope` accepts only the versioned
+success/error shapes already defined in `docs/contracts`, validates JSON and
+UTF-8, rejects duplicate keys at every object depth, rejects unknown
+top-level/error fields, and enforces success-payload versus structured-error
+exclusivity. Capability id, correlation id, and protocol version must exactly
+match caller-supplied expectations before a result is admitted. Default limits
+are 1 MiB and 32 container levels, with non-disableable hard ceilings of 16 MiB
+and 64 levels. A validated success payload remains exact JSON bytes; candidate
+error code/message/retryability remain separate structured fields.
+
+Focused GCC and Clang tests pass, including the checked-in success/error
+examples, reordered fields, nested values, 4,096 unique payload fields,
+duplicate and unknown fields, malformed numbers/trailing bytes, invalid UTF-8
+and surrogate pairs, identity/version mismatch, wrong response shape, and
+byte/depth ceilings. Clang ASan/UBSan also passes without findings, focused
+analyzer checks produce no project diagnostics, and the isolation audit marks
+the test portable, parallel-safe, and free of filesystem, environment, child-
+process, sample, resource, and network use. This candidate does not serialize
+requests, capture process output, authorize/hash an artifact, render candidate
+messages, connect to the runtime host or PRG dispatch, or close #91/#4700.
+Those remain separate slices; the runtime stub inventory is unchanged.
+
 ## V1 bounded polyglot process prerequisite
 
 The trusted #4700 lane now has a rebased product/test candidate for the first

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -345,6 +345,13 @@ exclusive; all JSON objects have unique keys; unknown top-level/error fields,
 malformed UTF-8/escapes/numbers, trailing bytes, and excessive byte/depth use
 fail closed. Capability, correlation, and protocol identities must exactly
 match caller expectations. Focused GCC, Clang, and Clang ASan/UBSan tests pass.
+Hosted Linux Native `31287594685` and macOS Native `31287594735` pass
+`325/325` at implementation head `171a1652b`. A Windows-only LF fixture
+expectation exposed by run `31287594747` was corrected without changing the
+parser: final head `09284457e` follows the fixture's LF/CRLF convention and
+directly tests exact preservation of both forms. Fresh local GCC/Clang focused
+tests pass, exact-final-head Windows Native `31289912992` passes `324/324`, and
+all eight final-head protected checks pass.
 This is admission of already-captured bytes only: request serialization,
 process-output capture, artifact authorization/hash verification, runtime-host
 or PRG dispatch, and actual fallback/route execution remain open.

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -339,6 +339,16 @@ bounded-process regression. This slice does not yet
 authorize/hash an artifact, validate envelopes, capture output, implement
 fallback/telemetry, select a route, or connect external code to PRG execution.
 
+The next #91/#4700 bridge prerequisite now validates versioned candidate
+response envelopes before downstream use. Success and error shapes are
+exclusive; all JSON objects have unique keys; unknown top-level/error fields,
+malformed UTF-8/escapes/numbers, trailing bytes, and excessive byte/depth use
+fail closed. Capability, correlation, and protocol identities must exactly
+match caller expectations. Focused GCC, Clang, and Clang ASan/UBSan tests pass.
+This is admission of already-captured bytes only: request serialization,
+process-output capture, artifact authorization/hash verification, runtime-host
+or PRG dispatch, and actual fallback/route execution remain open.
+
 Current v1 runtime-parity work under trusted #4913/#4914 recovers the shipped
 VFP9 `SET POINT` display contract and corrects the demonstrated Currency path.
 Display-only formatting now applies current data-session `POINT` and
@@ -560,7 +570,7 @@ standalone Studio shell, and FoxPro language-service layer."
 | E | `#111` (`E1`/`#22`, `E2`/`#23`, `E3`/`#24`) | Shared design model and designer fidelity (`E3` = report/label parity, the single largest lane in the repo) | Closed 2026-07-24 | Phase C |
 | F | `#112` (`F1`/`#25`, `F2`/`#26`) | VS extension parity + utility panes; standalone Studio as a full IDE | MVP implementation complete for standalone shell; hosted UI evidence remains under the RC gate | Phase C |
 | G | `#112` (`G1`/`#27`, `G2`/`#28`, `G3`/`#29`) | FoxPro language service: semantic resolution, navigation/refactoring, IntelliSense metadata | Recorded G1/G2/G3 slices closed; broader MVP scope remains under the live tree | Phase C |
-| H | `#113` (`H1`/`#30`, `H2`/`#31`, `H3`/`#32`) | Relational backend translators, document/vector + AI planning, .NET/MCP/polyglot outputs | Contract/model foundation and bounded process prerequisite implemented; real adapter/runtime dispatch remains | v1 item 3 |
+| H | `#113` (`H1`/`#30`, `H2`/`#31`, `H3`/`#32`) | Relational backend translators, document/vector + AI planning, .NET/MCP/polyglot outputs | Contract/model foundation, bounded process, and response-envelope admission prerequisites implemented; real adapter/runtime dispatch remains | v1 item 3 |
 | I | `#113` (`I1`/`#33`, `I2`/`#34`) | Runtime/project security depth, extension/host/AI-MCP security boundary | Seeded (see gap analysis) | v1 item 4 |
 | J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | Open, no shipped evidence | v1 item 5 |
 

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -143,9 +143,14 @@ this layer. Stable `polyglot.envelope.*` machine codes classify admission failur
 
 Focused coverage consumes the checked-in success/error examples and rejects malformed,
 ambiguous, oversized, over-nested, identity-mismatched, and wrong-shape responses under
-GCC, Clang, and Clang ASan/UBSan. This seam does not serialize invocation requests,
-capture process output, authorize/hash artifacts, connect to the runtime host or PRG
-dispatch, apply fallback, or execute a route. Those remain separately reviewable work.
+GCC, Clang, and Clang ASan/UBSan. Hosted Linux/macOS runs `31287594685` and
+`31287594735` pass `325/325` at implementation head `171a1652b`. Test-only final
+head `09284457e` preserves either LF or CRLF fixture bytes, explicitly covers both
+forms under fresh local GCC/Clang builds, and passes hosted Windows Native
+`31289912992` at `324/324`, including this regression; all eight final-head
+protected checks pass. This seam does not serialize invocation requests, capture
+process output, authorize/hash artifacts, connect to the runtime host or PRG dispatch,
+apply fallback, or execute a route. Those remain separately reviewable work.
 
 ## Shadow Parity v1
 

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -123,6 +123,30 @@ contracts or typed envelopes, capture standard output/error, implement retries o
 fallback, choose a route, emit migration telemetry, or connect any external language
 to the PRG runtime. Those remain separately reviewable adapter and dispatch work.
 
+## Response Envelope Admission v1
+
+`parse_polyglot_interop_envelope` is the next host-safe seam for #91/#4700. It
+accepts already-captured response bytes and admits only the success/error shapes
+defined by the checked-in v1 examples. The parser validates JSON grammar, raw and
+escaped UTF-8, unique keys at every object depth, exact top-level and structured-error
+fields, success-payload versus error exclusivity, machine error-code syntax, and the
+`1.0` envelope version. Capability id, correlation id, and semantic protocol version
+must exactly match the invocation expectations, preventing cross-capability,
+cross-request, and cross-protocol response confusion.
+
+The default admission budget is 1 MiB and 32 container levels. Callers can select a
+smaller budget, but cannot exceed the hard 16 MiB and 64-level ceilings. A successful
+payload must be an object and remains exact validated JSON bytes so this seam does not
+invent type coercion or localization. Candidate error code, message, and retryability
+are returned separately; the message is untrusted display data and is not rendered by
+this layer. Stable `polyglot.envelope.*` machine codes classify admission failures.
+
+Focused coverage consumes the checked-in success/error examples and rejects malformed,
+ambiguous, oversized, over-nested, identity-mismatched, and wrong-shape responses under
+GCC, Clang, and Clang ASan/UBSan. This seam does not serialize invocation requests,
+capture process output, authorize/hash artifacts, connect to the runtime host or PRG
+dispatch, apply fallback, or execute a route. Those remain separately reviewable work.
+
 ## Shadow Parity v1
 
 Shadow comparison is caller-neutral: the comparison result always preserves the native

--- a/include/copperfin/platform/polyglot_interop_envelope.h
+++ b/include/copperfin/platform/polyglot_interop_envelope.h
@@ -1,0 +1,72 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace copperfin::platform {
+
+enum class PolyglotInteropEnvelopeKind : std::uint8_t {
+    success,
+    error
+};
+
+enum class PolyglotInteropEnvelopeError : std::uint8_t {
+    none,
+    document_required,
+    document_too_large,
+    invalid_limits,
+    invalid_json,
+    invalid_document,
+    invalid_envelope_version,
+    invalid_kind,
+    invalid_capability_id,
+    capability_id_mismatch,
+    correlation_id_required,
+    correlation_id_mismatch,
+    invalid_protocol_version,
+    protocol_version_mismatch,
+    payload_required,
+    error_required,
+    invalid_error_code
+};
+
+struct PolyglotInteropEnvelopeExpectation {
+    std::string capability_id;
+    std::string correlation_id;
+    std::string protocol_version;
+    std::size_t max_document_bytes = std::size_t{1024U} * 1024U;
+    std::uint32_t max_nesting_depth = 32U;
+};
+
+struct PolyglotInteropEnvelope {
+    PolyglotInteropEnvelopeKind kind = PolyglotInteropEnvelopeKind::error;
+    std::string capability_id;
+    std::string correlation_id;
+    std::string protocol_version;
+    std::string payload_json;
+    std::string candidate_error_code;
+    std::string candidate_error_message;
+    bool candidate_error_retryable = false;
+};
+
+struct PolyglotInteropEnvelopeResult {
+    PolyglotInteropEnvelope envelope;
+    PolyglotInteropEnvelopeError error = PolyglotInteropEnvelopeError::none;
+    std::string error_code;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return error == PolyglotInteropEnvelopeError::none;
+    }
+};
+
+[[nodiscard]] PolyglotInteropEnvelopeResult parse_polyglot_interop_envelope(
+    std::string_view document,
+    const PolyglotInteropEnvelopeExpectation& expectation);
+
+}  // namespace copperfin::platform

--- a/src/platform/polyglot_interop_envelope.cpp
+++ b/src/platform/polyglot_interop_envelope.cpp
@@ -1,0 +1,719 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/polyglot_interop_envelope.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <set>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace copperfin::platform {
+
+namespace {
+
+constexpr std::size_t hard_max_document_bytes =
+    std::size_t{16U} * 1024U * 1024U;
+constexpr std::uint32_t hard_max_nesting_depth = 64U;
+
+bool is_lowercase_ascii_letter(const char value) noexcept {
+    return value >= 'a' && value <= 'z';
+}
+
+bool is_machine_identifier(const std::string_view value) noexcept {
+    if (value.empty() || !is_lowercase_ascii_letter(value.front())) {
+        return false;
+    }
+    return std::all_of(value.begin() + 1, value.end(), [](const char character) {
+        return is_lowercase_ascii_letter(character) ||
+            (character >= '0' && character <= '9') || character == '.' ||
+            character == '_' || character == '-';
+    });
+}
+
+bool is_semantic_version(const std::string_view value) noexcept {
+    unsigned int components = 0U;
+    bool digit_seen = false;
+    for (const char character : value) {
+        if (character >= '0' && character <= '9') {
+            digit_seen = true;
+            continue;
+        }
+        if (character != '.' || !digit_seen || components >= 2U) {
+            return false;
+        }
+        ++components;
+        digit_seen = false;
+    }
+    return components == 2U && digit_seen;
+}
+
+PolyglotInteropEnvelopeResult invalid_result(
+    const PolyglotInteropEnvelopeError error,
+    const char* error_code) {
+    PolyglotInteropEnvelopeResult result;
+    result.error = error;
+    result.error_code = error_code;
+    return result;
+}
+
+bool append_utf8(std::string& output, const std::uint32_t codepoint) {
+    if (codepoint <= 0x7FU) {
+        output.push_back(static_cast<char>(codepoint));
+        return true;
+    }
+    if (codepoint <= 0x7FFU) {
+        output.push_back(static_cast<char>(0xC0U | (codepoint >> 6U)));
+        output.push_back(static_cast<char>(0x80U | (codepoint & 0x3FU)));
+        return true;
+    }
+    if (codepoint >= 0xD800U && codepoint <= 0xDFFFU) {
+        return false;
+    }
+    if (codepoint <= 0xFFFFU) {
+        output.push_back(static_cast<char>(0xE0U | (codepoint >> 12U)));
+        output.push_back(static_cast<char>(0x80U | ((codepoint >> 6U) & 0x3FU)));
+        output.push_back(static_cast<char>(0x80U | (codepoint & 0x3FU)));
+        return true;
+    }
+    if (codepoint <= 0x10FFFFU) {
+        output.push_back(static_cast<char>(0xF0U | (codepoint >> 18U)));
+        output.push_back(static_cast<char>(0x80U | ((codepoint >> 12U) & 0x3FU)));
+        output.push_back(static_cast<char>(0x80U | ((codepoint >> 6U) & 0x3FU)));
+        output.push_back(static_cast<char>(0x80U | (codepoint & 0x3FU)));
+        return true;
+    }
+    return false;
+}
+
+class JsonCursor final {
+public:
+    JsonCursor(const std::string_view document, const std::uint32_t max_depth)
+        : document_(document), max_depth_(max_depth) {}
+
+    [[nodiscard]] bool consume(const char expected) noexcept {
+        skip_whitespace();
+        if (position_ >= document_.size() || document_[position_] != expected) {
+            return false;
+        }
+        ++position_;
+        return true;
+    }
+
+    [[nodiscard]] bool next_is(const char expected) const noexcept {
+        std::size_t position = position_;
+        skip_whitespace_at(position);
+        return position < document_.size() && document_[position] == expected;
+    }
+
+    [[nodiscard]] bool parse_string(std::string& value) {
+        skip_whitespace();
+        if (position_ >= document_.size() || document_[position_] != '"') {
+            return false;
+        }
+        ++position_;
+        value.clear();
+        while (position_ < document_.size()) {
+            const unsigned char character =
+                static_cast<unsigned char>(document_[position_++]);
+            if (character == static_cast<unsigned char>('"')) {
+                return true;
+            }
+            if (character < 0x20U) {
+                return false;
+            }
+            if (character == static_cast<unsigned char>('\\')) {
+                if (!parse_escape(value)) {
+                    return false;
+                }
+                continue;
+            }
+            if (character < 0x80U) {
+                value.push_back(static_cast<char>(character));
+                continue;
+            }
+            if (!append_raw_utf8(value, character)) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+    [[nodiscard]] bool parse_boolean(bool& value) noexcept {
+        skip_whitespace();
+        if (match_literal("true")) {
+            value = true;
+            return true;
+        }
+        if (match_literal("false")) {
+            value = false;
+            return true;
+        }
+        return false;
+    }
+
+    [[nodiscard]] bool capture_object(std::string& value) {
+        skip_whitespace();
+        if (position_ >= document_.size() || document_[position_] != '{') {
+            return false;
+        }
+        const std::size_t start = position_;
+        if (!skip_value(1U)) {
+            return false;
+        }
+        value.assign(document_.substr(start, position_ - start));
+        return true;
+    }
+
+    [[nodiscard]] bool at_end() const noexcept {
+        std::size_t position = position_;
+        skip_whitespace_at(position);
+        return position == document_.size();
+    }
+
+private:
+    static int hex_value(const char value) noexcept {
+        if (value >= '0' && value <= '9') {
+            return value - '0';
+        }
+        if (value >= 'a' && value <= 'f') {
+            return value - 'a' + 10;
+        }
+        if (value >= 'A' && value <= 'F') {
+            return value - 'A' + 10;
+        }
+        return -1;
+    }
+
+    [[nodiscard]] bool parse_hex_quad(std::uint32_t& value) noexcept {
+        if (document_.size() - position_ < 4U) {
+            return false;
+        }
+        value = 0U;
+        for (unsigned int index = 0U; index < 4U; ++index) {
+            const int digit = hex_value(document_[position_++]);
+            if (digit < 0) {
+                return false;
+            }
+            value = (value << 4U) | static_cast<std::uint32_t>(digit);
+        }
+        return true;
+    }
+
+    [[nodiscard]] bool parse_escape(std::string& value) {
+        if (position_ >= document_.size()) {
+            return false;
+        }
+        const char escaped = document_[position_++];
+        switch (escaped) {
+        case '"':
+        case '\\':
+        case '/':
+            value.push_back(escaped);
+            return true;
+        case 'b':
+            value.push_back('\b');
+            return true;
+        case 'f':
+            value.push_back('\f');
+            return true;
+        case 'n':
+            value.push_back('\n');
+            return true;
+        case 'r':
+            value.push_back('\r');
+            return true;
+        case 't':
+            value.push_back('\t');
+            return true;
+        case 'u':
+            break;
+        default:
+            return false;
+        }
+
+        std::uint32_t codepoint = 0U;
+        if (!parse_hex_quad(codepoint)) {
+            return false;
+        }
+        if (codepoint >= 0xD800U && codepoint <= 0xDBFFU) {
+            if (document_.size() - position_ < 6U ||
+                document_[position_] != '\\' || document_[position_ + 1U] != 'u') {
+                return false;
+            }
+            position_ += 2U;
+            std::uint32_t low_surrogate = 0U;
+            if (!parse_hex_quad(low_surrogate) ||
+                low_surrogate < 0xDC00U || low_surrogate > 0xDFFFU) {
+                return false;
+            }
+            codepoint = 0x10000U + ((codepoint - 0xD800U) << 10U) +
+                (low_surrogate - 0xDC00U);
+        } else if (codepoint >= 0xDC00U && codepoint <= 0xDFFFU) {
+            return false;
+        }
+        return append_utf8(value, codepoint);
+    }
+
+    [[nodiscard]] bool append_raw_utf8(
+        std::string& value,
+        const unsigned char first) {
+        std::size_t continuation_count = 0U;
+        std::uint32_t codepoint = 0U;
+        std::uint32_t minimum = 0U;
+        if (first >= 0xC2U && first <= 0xDFU) {
+            continuation_count = 1U;
+            codepoint = first & 0x1FU;
+            minimum = 0x80U;
+        } else if (first >= 0xE0U && first <= 0xEFU) {
+            continuation_count = 2U;
+            codepoint = first & 0x0FU;
+            minimum = 0x800U;
+        } else if (first >= 0xF0U && first <= 0xF4U) {
+            continuation_count = 3U;
+            codepoint = first & 0x07U;
+            minimum = 0x10000U;
+        } else {
+            return false;
+        }
+        if (document_.size() - position_ < continuation_count) {
+            return false;
+        }
+        const std::size_t sequence_start = position_ - 1U;
+        for (std::size_t index = 0U; index < continuation_count; ++index) {
+            const unsigned char continuation =
+                static_cast<unsigned char>(document_[position_++]);
+            if ((continuation & 0xC0U) != 0x80U) {
+                return false;
+            }
+            codepoint = (codepoint << 6U) | (continuation & 0x3FU);
+        }
+        if (codepoint < minimum || codepoint > 0x10FFFFU ||
+            (codepoint >= 0xD800U && codepoint <= 0xDFFFU)) {
+            return false;
+        }
+        value.append(document_.substr(sequence_start, continuation_count + 1U));
+        return true;
+    }
+
+    [[nodiscard]] bool match_literal(const std::string_view literal) noexcept {
+        if (document_.substr(position_, literal.size()) != literal) {
+            return false;
+        }
+        position_ += literal.size();
+        return true;
+    }
+
+    [[nodiscard]] bool skip_value(const std::uint32_t depth) {
+        skip_whitespace();
+        if (position_ >= document_.size()) {
+            return false;
+        }
+        const char character = document_[position_];
+        if (character == '{') {
+            return skip_object(depth);
+        }
+        if (character == '[') {
+            return skip_array(depth);
+        }
+        if (character == '"') {
+            std::string ignored;
+            return parse_string(ignored);
+        }
+        if (character == 't') {
+            return match_literal("true");
+        }
+        if (character == 'f') {
+            return match_literal("false");
+        }
+        if (character == 'n') {
+            return match_literal("null");
+        }
+        return skip_number();
+    }
+
+    [[nodiscard]] bool skip_object(const std::uint32_t depth) {
+        if (depth > max_depth_ || !consume('{')) {
+            return false;
+        }
+        std::set<std::string> keys;
+        if (consume('}')) {
+            return true;
+        }
+        while (true) {
+            std::string key;
+            if (!parse_string(key) || keys.find(key) != keys.end() ||
+                !consume(':') || !skip_value(depth + 1U)) {
+                return false;
+            }
+            keys.insert(std::move(key));
+            if (consume('}')) {
+                return true;
+            }
+            if (!consume(',') || next_is('}')) {
+                return false;
+            }
+        }
+    }
+
+    [[nodiscard]] bool skip_array(const std::uint32_t depth) {
+        if (depth > max_depth_ || !consume('[')) {
+            return false;
+        }
+        if (consume(']')) {
+            return true;
+        }
+        while (true) {
+            if (!skip_value(depth + 1U)) {
+                return false;
+            }
+            if (consume(']')) {
+                return true;
+            }
+            if (!consume(',') || next_is(']')) {
+                return false;
+            }
+        }
+    }
+
+    [[nodiscard]] bool skip_number() noexcept {
+        if (position_ >= document_.size()) {
+            return false;
+        }
+        if (document_[position_] == '-') {
+            ++position_;
+        }
+        if (position_ >= document_.size()) {
+            return false;
+        }
+        if (document_[position_] == '0') {
+            ++position_;
+            if (position_ < document_.size() &&
+                document_[position_] >= '0' && document_[position_] <= '9') {
+                return false;
+            }
+        } else if (document_[position_] >= '1' && document_[position_] <= '9') {
+            while (position_ < document_.size() &&
+                   document_[position_] >= '0' && document_[position_] <= '9') {
+                ++position_;
+            }
+        } else {
+            return false;
+        }
+        if (position_ < document_.size() && document_[position_] == '.') {
+            ++position_;
+            const std::size_t fractional_start = position_;
+            while (position_ < document_.size() &&
+                   document_[position_] >= '0' && document_[position_] <= '9') {
+                ++position_;
+            }
+            if (position_ == fractional_start) {
+                return false;
+            }
+        }
+        if (position_ < document_.size() &&
+            (document_[position_] == 'e' || document_[position_] == 'E')) {
+            ++position_;
+            if (position_ < document_.size() &&
+                (document_[position_] == '+' || document_[position_] == '-')) {
+                ++position_;
+            }
+            const std::size_t exponent_start = position_;
+            while (position_ < document_.size() &&
+                   document_[position_] >= '0' && document_[position_] <= '9') {
+                ++position_;
+            }
+            if (position_ == exponent_start) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    void skip_whitespace() noexcept {
+        skip_whitespace_at(position_);
+    }
+
+    void skip_whitespace_at(std::size_t& position) const noexcept {
+        while (position < document_.size()) {
+            const char character = document_[position];
+            if (character != ' ' && character != '\t' &&
+                character != '\r' && character != '\n') {
+                break;
+            }
+            ++position;
+        }
+    }
+
+    std::string_view document_;
+    std::size_t position_ = 0U;
+    std::uint32_t max_depth_ = 0U;
+};
+
+struct ParsedError final {
+    std::string code;
+    std::string message;
+    bool retryable = false;
+    bool has_code = false;
+    bool has_message = false;
+    bool has_retryable = false;
+};
+
+bool parse_error_object(JsonCursor& cursor, ParsedError& error) {
+    if (!cursor.consume('{')) {
+        return false;
+    }
+    std::set<std::string> keys;
+    if (cursor.consume('}')) {
+        return true;
+    }
+    while (true) {
+        std::string key;
+        if (!cursor.parse_string(key) || keys.find(key) != keys.end() ||
+            !cursor.consume(':')) {
+            return false;
+        }
+        keys.insert(key);
+        if (key == "code") {
+            if (!cursor.parse_string(error.code)) {
+                return false;
+            }
+            error.has_code = true;
+        } else if (key == "message") {
+            if (!cursor.parse_string(error.message)) {
+                return false;
+            }
+            error.has_message = true;
+        } else if (key == "retryable") {
+            if (!cursor.parse_boolean(error.retryable)) {
+                return false;
+            }
+            error.has_retryable = true;
+        } else {
+            return false;
+        }
+        if (cursor.consume('}')) {
+            return true;
+        }
+        if (!cursor.consume(',') || cursor.next_is('}')) {
+            return false;
+        }
+    }
+}
+
+}  // namespace
+
+PolyglotInteropEnvelopeResult parse_polyglot_interop_envelope(
+    const std::string_view document,
+    const PolyglotInteropEnvelopeExpectation& expectation) {
+    if (document.empty()) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::document_required,
+            "polyglot.envelope.document_required");
+    }
+    if (expectation.max_document_bytes == 0U ||
+        expectation.max_document_bytes > hard_max_document_bytes ||
+        expectation.max_nesting_depth == 0U ||
+        expectation.max_nesting_depth > hard_max_nesting_depth) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::invalid_limits,
+            "polyglot.envelope.invalid_limits");
+    }
+    if (document.size() > expectation.max_document_bytes) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::document_too_large,
+            "polyglot.envelope.document_too_large");
+    }
+    if (!is_machine_identifier(expectation.capability_id)) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::invalid_capability_id,
+            "polyglot.envelope.invalid_capability_id");
+    }
+    if (expectation.correlation_id.empty()) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::correlation_id_required,
+            "polyglot.envelope.correlation_id_required");
+    }
+    if (!is_semantic_version(expectation.protocol_version)) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::invalid_protocol_version,
+            "polyglot.envelope.invalid_protocol_version");
+    }
+
+    JsonCursor cursor(document, expectation.max_nesting_depth);
+    if (!cursor.consume('{')) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::invalid_json,
+            "polyglot.envelope.invalid_json");
+    }
+
+    std::set<std::string> keys;
+    std::string envelope_version;
+    std::string kind;
+    ParsedError candidate_error;
+    PolyglotInteropEnvelopeResult result;
+    bool has_envelope_version = false;
+    bool has_kind = false;
+    bool has_capability_id = false;
+    bool has_correlation_id = false;
+    bool has_protocol_version = false;
+    bool has_payload = false;
+    bool has_error = false;
+
+    if (!cursor.consume('}')) {
+        while (true) {
+            std::string key;
+            if (!cursor.parse_string(key) || keys.find(key) != keys.end() ||
+                !cursor.consume(':')) {
+                return invalid_result(
+                    PolyglotInteropEnvelopeError::invalid_document,
+                    "polyglot.envelope.invalid_document");
+            }
+            keys.insert(key);
+            if (key == "envelope_version") {
+                has_envelope_version = cursor.parse_string(envelope_version);
+                if (!has_envelope_version) {
+                    return invalid_result(
+                        PolyglotInteropEnvelopeError::invalid_json,
+                        "polyglot.envelope.invalid_json");
+                }
+            } else if (key == "kind") {
+                has_kind = cursor.parse_string(kind);
+                if (!has_kind) {
+                    return invalid_result(
+                        PolyglotInteropEnvelopeError::invalid_json,
+                        "polyglot.envelope.invalid_json");
+                }
+            } else if (key == "capability_id") {
+                has_capability_id = cursor.parse_string(result.envelope.capability_id);
+                if (!has_capability_id) {
+                    return invalid_result(
+                        PolyglotInteropEnvelopeError::invalid_json,
+                        "polyglot.envelope.invalid_json");
+                }
+            } else if (key == "correlation_id") {
+                has_correlation_id = cursor.parse_string(result.envelope.correlation_id);
+                if (!has_correlation_id) {
+                    return invalid_result(
+                        PolyglotInteropEnvelopeError::invalid_json,
+                        "polyglot.envelope.invalid_json");
+                }
+            } else if (key == "protocol_version") {
+                has_protocol_version = cursor.parse_string(result.envelope.protocol_version);
+                if (!has_protocol_version) {
+                    return invalid_result(
+                        PolyglotInteropEnvelopeError::invalid_json,
+                        "polyglot.envelope.invalid_json");
+                }
+            } else if (key == "payload") {
+                has_payload = cursor.capture_object(result.envelope.payload_json);
+                if (!has_payload) {
+                    return invalid_result(
+                        PolyglotInteropEnvelopeError::invalid_json,
+                        "polyglot.envelope.invalid_json");
+                }
+            } else if (key == "error") {
+                has_error = parse_error_object(cursor, candidate_error);
+                if (!has_error) {
+                    return invalid_result(
+                        PolyglotInteropEnvelopeError::invalid_document,
+                        "polyglot.envelope.invalid_document");
+                }
+            } else {
+                return invalid_result(
+                    PolyglotInteropEnvelopeError::invalid_document,
+                    "polyglot.envelope.invalid_document");
+            }
+
+            if (cursor.consume('}')) {
+                break;
+            }
+            if (!cursor.consume(',') || cursor.next_is('}')) {
+                return invalid_result(
+                    PolyglotInteropEnvelopeError::invalid_json,
+                    "polyglot.envelope.invalid_json");
+            }
+        }
+    }
+    if (!cursor.at_end()) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::invalid_json,
+            "polyglot.envelope.invalid_json");
+    }
+    if (!has_envelope_version || !has_kind || !has_capability_id ||
+        !has_correlation_id || !has_protocol_version) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::invalid_document,
+            "polyglot.envelope.invalid_document");
+    }
+    if (envelope_version != "1.0") {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::invalid_envelope_version,
+            "polyglot.envelope.invalid_envelope_version");
+    }
+    if (kind == "success") {
+        result.envelope.kind = PolyglotInteropEnvelopeKind::success;
+        if (!has_payload || has_error) {
+            return invalid_result(
+                PolyglotInteropEnvelopeError::payload_required,
+                "polyglot.envelope.payload_required");
+        }
+    } else if (kind == "error") {
+        result.envelope.kind = PolyglotInteropEnvelopeKind::error;
+        if (!has_error || has_payload || !candidate_error.has_code ||
+            !candidate_error.has_message || !candidate_error.has_retryable) {
+            return invalid_result(
+                PolyglotInteropEnvelopeError::error_required,
+                "polyglot.envelope.error_required");
+        }
+        if (!is_machine_identifier(candidate_error.code)) {
+            return invalid_result(
+                PolyglotInteropEnvelopeError::invalid_error_code,
+                "polyglot.envelope.invalid_error_code");
+        }
+        result.envelope.candidate_error_code = std::move(candidate_error.code);
+        result.envelope.candidate_error_message = std::move(candidate_error.message);
+        result.envelope.candidate_error_retryable = candidate_error.retryable;
+    } else {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::invalid_kind,
+            "polyglot.envelope.invalid_kind");
+    }
+    if (!is_machine_identifier(result.envelope.capability_id)) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::invalid_capability_id,
+            "polyglot.envelope.invalid_capability_id");
+    }
+    if (result.envelope.capability_id != expectation.capability_id) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::capability_id_mismatch,
+            "polyglot.envelope.capability_id_mismatch");
+    }
+    if (result.envelope.correlation_id.empty()) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::correlation_id_required,
+            "polyglot.envelope.correlation_id_required");
+    }
+    if (result.envelope.correlation_id != expectation.correlation_id) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::correlation_id_mismatch,
+            "polyglot.envelope.correlation_id_mismatch");
+    }
+    if (!is_semantic_version(result.envelope.protocol_version)) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::invalid_protocol_version,
+            "polyglot.envelope.invalid_protocol_version");
+    }
+    if (result.envelope.protocol_version != expectation.protocol_version) {
+        return invalid_result(
+            PolyglotInteropEnvelopeError::protocol_version_mismatch,
+            "polyglot.envelope.protocol_version_mismatch");
+    }
+    return result;
+}
+
+}  // namespace copperfin::platform

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4672,6 +4672,16 @@ copperfin_add_test(test_polyglot_bridge_invocation cf_platform_profile
     test_polyglot_bridge_invocation.cpp
 )
 
+copperfin_add_test(test_polyglot_interop_envelope cf_platform_profile
+    test_polyglot_interop_envelope.cpp
+)
+target_compile_definitions(
+    test_polyglot_interop_envelope
+    PRIVATE
+        COPPERFIN_POLYGLOT_SUCCESS_ENVELOPE_PATH="${CMAKE_SOURCE_DIR}/docs/contracts/polyglot-success-envelope-v1.json"
+        COPPERFIN_POLYGLOT_ERROR_ENVELOPE_PATH="${CMAKE_SOURCE_DIR}/docs/contracts/polyglot-error-envelope-v1.json"
+)
+
 copperfin_add_test(test_bounded_process cf_platform_profile
     test_bounded_process.cpp
 )

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -113,6 +113,7 @@ function(copperfin_configure_native_test_isolation)
 
     foreach(test_name IN ITEMS
             test_polyglot_bridge_invocation
+            test_polyglot_interop_envelope
             test_polyglot_migration_telemetry
             test_polyglot_parity_comparator
             test_polyglot_route_registry)

--- a/tests/test_polyglot_interop_envelope.cpp
+++ b/tests/test_polyglot_interop_envelope.cpp
@@ -1,0 +1,277 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/polyglot_interop_envelope.h"
+
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void expect(const bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+std::string read_text(const std::string& path) {
+    std::ifstream input(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+copperfin::platform::PolyglotInteropEnvelopeExpectation expectation() {
+    return {
+        .capability_id = "reports.invoice.render",
+        .correlation_id = "example-correlation-001",
+        .protocol_version = "1.0.0"};
+}
+
+void expect_error(
+    const std::string& document,
+    const copperfin::platform::PolyglotInteropEnvelopeExpectation& expected,
+    const copperfin::platform::PolyglotInteropEnvelopeError error,
+    const std::string& error_code,
+    const std::string& message) {
+    const auto result =
+        copperfin::platform::parse_polyglot_interop_envelope(document, expected);
+    expect(!result.ok() && result.error == error && result.error_code == error_code, message);
+}
+
+void test_versioned_examples_and_field_order() {
+    using copperfin::platform::PolyglotInteropEnvelopeKind;
+    auto expected = expectation();
+    const auto success = copperfin::platform::parse_polyglot_interop_envelope(
+        read_text(COPPERFIN_POLYGLOT_SUCCESS_ENVELOPE_PATH), expected);
+    expect(success.ok() && success.envelope.kind == PolyglotInteropEnvelopeKind::success,
+           "#91: versioned success example should parse");
+    expect(success.envelope.payload_json ==
+               "{\n    \"artifact_id\": \"invoice-preview-001\",\n    \"content_type\": \"application/pdf\"\n  }",
+           "#91: success payload should remain exact validated JSON bytes");
+
+    expected.correlation_id = "example-correlation-002";
+    const auto error = copperfin::platform::parse_polyglot_interop_envelope(
+        read_text(COPPERFIN_POLYGLOT_ERROR_ENVELOPE_PATH), expected);
+    expect(error.ok() && error.envelope.kind == PolyglotInteropEnvelopeKind::error &&
+               error.envelope.candidate_error_code == "bridge.timeout" &&
+               error.envelope.candidate_error_retryable,
+           "#91: versioned error example should expose structured failure fields");
+
+    const auto reordered = copperfin::platform::parse_polyglot_interop_envelope(
+        R"json({"payload":{"nested":[true,null,-1.25e+3]},"protocol_version":"1.0.0","correlation_id":"example-correlation-001","capability_id":"reports.invoice.render","kind":"success","envelope_version":"1.0"})json",
+        expectation());
+    expect(reordered.ok() &&
+               reordered.envelope.payload_json == "{\"nested\":[true,null,-1.25e+3]}",
+           "#91: field order should not affect a valid exact response");
+}
+
+void test_identity_and_shape_fail_closed() {
+    using copperfin::platform::PolyglotInteropEnvelopeError;
+    const std::string success =
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{}})json";
+
+    auto expected = expectation();
+    expected.capability_id = "reports.other.render";
+    expect_error(success, expected, PolyglotInteropEnvelopeError::capability_id_mismatch,
+                 "polyglot.envelope.capability_id_mismatch",
+                 "#91: capability confusion should fail closed");
+    expected = expectation();
+    expected.correlation_id = "other-correlation";
+    expect_error(success, expected, PolyglotInteropEnvelopeError::correlation_id_mismatch,
+                 "polyglot.envelope.correlation_id_mismatch",
+                 "#91: replayed correlation identity should fail closed");
+    expected = expectation();
+    expected.protocol_version = "1.1.0";
+    expect_error(success, expected, PolyglotInteropEnvelopeError::protocol_version_mismatch,
+                 "polyglot.envelope.protocol_version_mismatch",
+                 "#91: protocol mismatch should fail closed");
+
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","error":{"code":"bridge.failed","message":"no","retryable":false}})json",
+        expectation(), PolyglotInteropEnvelopeError::payload_required,
+        "polyglot.envelope.payload_required",
+        "#91: success envelopes should require payload and reject error shape");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"error","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{}})json",
+        expectation(), PolyglotInteropEnvelopeError::error_required,
+        "polyglot.envelope.error_required",
+        "#91: error envelopes should require structured error and reject payload shape");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"error","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","error":{"code":"Bridge Failed","message":"no","retryable":false}})json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_error_code,
+        "polyglot.envelope.invalid_error_code",
+        "#91: candidate error code should remain a machine identifier");
+}
+
+void test_ambiguous_and_malformed_json_rejected() {
+    using copperfin::platform::PolyglotInteropEnvelopeError;
+    expect_error("", expectation(), PolyglotInteropEnvelopeError::document_required,
+                 "polyglot.envelope.document_required",
+                 "#91: empty responses should fail before parsing");
+    expect_error(
+        R"json({"envelope_version":"2.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{}})json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_envelope_version,
+        "polyglot.envelope.invalid_envelope_version",
+        "#91: incompatible envelope versions should be rejected");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"request","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{}})json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_kind,
+        "polyglot.envelope.invalid_kind",
+        "#91: response parser should reject request and unknown kinds");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","capability\u005fid":"reports.other.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{}})json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_document,
+        "polyglot.envelope.invalid_document",
+        "#91: escape-equivalent duplicate top-level keys should be rejected");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{"value":1,"value":2}})json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_json,
+        "polyglot.envelope.invalid_json",
+        "#91: duplicate keys inside opaque payloads should still be rejected");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{},"extra":false})json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_document,
+        "polyglot.envelope.invalid_document",
+        "#91: unknown top-level fields should be rejected");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"error","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","error":{"code":"bridge.failed","message":"no","retryable":false,"extra":false}})json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_document,
+        "polyglot.envelope.invalid_document",
+        "#91: unknown candidate-error fields should be rejected");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"error","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","error":{"code":"bridge.failed","message":"no","message":"again","retryable":false}})json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_document,
+        "polyglot.envelope.invalid_document",
+        "#91: duplicate candidate-error fields should be rejected");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":[]} )json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_json,
+        "polyglot.envelope.invalid_json",
+        "#91: success payload should be a typed JSON object");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{"value":01}})json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_json,
+        "polyglot.envelope.invalid_json",
+        "#91: non-JSON number grammar should be rejected");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{}} trailing)json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_json,
+        "polyglot.envelope.invalid_json",
+        "#91: trailing bytes should be rejected");
+}
+
+void test_unicode_and_resource_bounds() {
+    using copperfin::platform::PolyglotInteropEnvelopeError;
+    const auto escaped_unicode = copperfin::platform::parse_polyglot_interop_envelope(
+        R"json({"envelope_version":"1.0","kind":"error","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","error":{"code":"bridge.failed","message":"caf\u00e9 \ud83d\ude80","retryable":false}})json",
+        expectation());
+    expect(escaped_unicode.ok() &&
+               escaped_unicode.envelope.candidate_error_message ==
+                   std::string{"caf\xC3\xA9 \xF0\x9F\x9A\x80"},
+           "#91: valid BMP and surrogate-pair escapes should decode to UTF-8");
+
+    std::string invalid_utf8 =
+        R"json({"envelope_version":"1.0","kind":"error","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","error":{"code":"bridge.failed","message":")json";
+    invalid_utf8.push_back(static_cast<char>(0xC0));
+    invalid_utf8 += R"json(","retryable":false}})json";
+    expect_error(invalid_utf8, expectation(), PolyglotInteropEnvelopeError::invalid_document,
+                 "polyglot.envelope.invalid_document",
+                 "#91: invalid raw UTF-8 should be rejected");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"error","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","error":{"code":"bridge.failed","message":"\ud800","retryable":false}})json",
+        expectation(), PolyglotInteropEnvelopeError::invalid_document,
+        "polyglot.envelope.invalid_document",
+        "#91: unpaired surrogate escapes should be rejected");
+
+    auto expected = expectation();
+    expected.max_document_bytes = 10U;
+    expect_error("{\"value\":123}", expected, PolyglotInteropEnvelopeError::document_too_large,
+                 "polyglot.envelope.document_too_large",
+                 "#91: response byte budget should fail before parsing");
+    expected = expectation();
+    expected.max_nesting_depth = 2U;
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{"a":{"b":{"c":1}}}})json",
+        expected, PolyglotInteropEnvelopeError::invalid_json,
+        "polyglot.envelope.invalid_json",
+        "#91: response nesting budget should bound recursive parsing");
+    expected = expectation();
+    expected.max_nesting_depth = 65U;
+    expect_error("{}", expected, PolyglotInteropEnvelopeError::invalid_limits,
+                 "polyglot.envelope.invalid_limits",
+                 "#91: callers should not disable the hard nesting ceiling");
+    expected = expectation();
+    expected.max_document_bytes = std::size_t{17U} * 1024U * 1024U;
+    expect_error("{}", expected, PolyglotInteropEnvelopeError::invalid_limits,
+                 "polyglot.envelope.invalid_limits",
+                 "#91: callers should not disable the hard byte ceiling");
+}
+
+void test_large_bounded_payload() {
+    std::string document =
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{)json";
+    for (unsigned int index = 0U; index < 4096U; ++index) {
+        if (index != 0U) {
+            document.push_back(',');
+        }
+        document += "\"field" + std::to_string(index) + "\":" + std::to_string(index);
+    }
+    document += "}}";
+    const auto result =
+        copperfin::platform::parse_polyglot_interop_envelope(document, expectation());
+    expect(result.ok() && result.envelope.payload_json.size() > 60000U,
+           "#91: thousands of unique payload fields should remain bounded and valid");
+}
+
+void test_expectation_validation() {
+    using copperfin::platform::PolyglotInteropEnvelopeError;
+    auto expected = expectation();
+    expected.capability_id = "Invalid Capability";
+    expect_error("{}", expected, PolyglotInteropEnvelopeError::invalid_capability_id,
+                 "polyglot.envelope.invalid_capability_id",
+                 "#91: invalid expected capability should fail before response parsing");
+    expected = expectation();
+    expected.correlation_id.clear();
+    expect_error("{}", expected, PolyglotInteropEnvelopeError::correlation_id_required,
+                 "polyglot.envelope.correlation_id_required",
+                 "#91: correlation expectation should be mandatory");
+    expected = expectation();
+    expected.protocol_version = "1.0";
+    expect_error("{}", expected, PolyglotInteropEnvelopeError::invalid_protocol_version,
+                 "polyglot.envelope.invalid_protocol_version",
+                 "#91: expected protocol should use semantic version syntax");
+
+    expected = expectation();
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"Invalid Capability","correlation_id":"example-correlation-001","protocol_version":"1.0.0","payload":{}})json",
+        expected, PolyglotInteropEnvelopeError::invalid_capability_id,
+        "polyglot.envelope.invalid_capability_id",
+        "#91: response capability should use invariant identifier syntax");
+    expect_error(
+        R"json({"envelope_version":"1.0","kind":"success","capability_id":"reports.invoice.render","correlation_id":"example-correlation-001","protocol_version":"1.0","payload":{}})json",
+        expected, PolyglotInteropEnvelopeError::invalid_protocol_version,
+        "polyglot.envelope.invalid_protocol_version",
+        "#91: response protocol should use semantic version syntax");
+}
+
+}  // namespace
+
+int main() {
+    test_versioned_examples_and_field_order();
+    test_identity_and_shape_fail_closed();
+    test_ambiguous_and_malformed_json_rejected();
+    test_unicode_and_resource_bounds();
+    test_large_bounded_payload();
+    test_expectation_validation();
+    if (failures != 0) {
+        std::cerr << failures << " polyglot interop envelope test(s) failed\n";
+        return 1;
+    }
+    std::cout << "All polyglot interop envelope tests passed\n";
+    return 0;
+}

--- a/tests/test_polyglot_interop_envelope.cpp
+++ b/tests/test_polyglot_interop_envelope.cpp
@@ -46,12 +46,18 @@ void expect_error(
 void test_versioned_examples_and_field_order() {
     using copperfin::platform::PolyglotInteropEnvelopeKind;
     auto expected = expectation();
+    const auto success_document = read_text(COPPERFIN_POLYGLOT_SUCCESS_ENVELOPE_PATH);
     const auto success = copperfin::platform::parse_polyglot_interop_envelope(
-        read_text(COPPERFIN_POLYGLOT_SUCCESS_ENVELOPE_PATH), expected);
+        success_document, expected);
     expect(success.ok() && success.envelope.kind == PolyglotInteropEnvelopeKind::success,
            "#91: versioned success example should parse");
-    expect(success.envelope.payload_json ==
-               "{\n    \"artifact_id\": \"invoice-preview-001\",\n    \"content_type\": \"application/pdf\"\n  }",
+    const std::string fixture_newline =
+        success_document.find("\r\n") == std::string::npos ? "\n" : "\r\n";
+    const std::string expected_fixture_payload =
+        "{" + fixture_newline +
+        "    \"artifact_id\": \"invoice-preview-001\"," + fixture_newline +
+        "    \"content_type\": \"application/pdf\"" + fixture_newline + "  }";
+    expect(success.envelope.payload_json == expected_fixture_payload,
            "#91: success payload should remain exact validated JSON bytes");
 
     expected.correlation_id = "example-correlation-002";
@@ -68,6 +74,22 @@ void test_versioned_examples_and_field_order() {
     expect(reordered.ok() &&
                reordered.envelope.payload_json == "{\"nested\":[true,null,-1.25e+3]}",
            "#91: field order should not affect a valid exact response");
+}
+
+void test_payload_line_endings_remain_exact() {
+    for (const std::string& newline : {std::string("\n"), std::string("\r\n")}) {
+        const std::string payload =
+            "{" + newline + "  \"value\": true" + newline + "}";
+        const std::string document =
+            "{\"envelope_version\":\"1.0\",\"kind\":\"success\","
+            "\"capability_id\":\"reports.invoice.render\","
+            "\"correlation_id\":\"example-correlation-001\","
+            "\"protocol_version\":\"1.0.0\",\"payload\":" + payload + "}";
+        const auto result = copperfin::platform::parse_polyglot_interop_envelope(
+            document, expectation());
+        expect(result.ok() && result.envelope.payload_json == payload,
+               "#91: LF and CRLF payload bytes should remain exact");
+    }
 }
 
 void test_identity_and_shape_fail_closed() {
@@ -263,6 +285,7 @@ void test_expectation_validation() {
 
 int main() {
     test_versioned_examples_and_field_order();
+    test_payload_line_endings_remain_exact();
     test_identity_and_shape_fail_closed();
     test_ambiguous_and_malformed_json_rejected();
     test_unicode_and_resource_bounds();


### PR DESCRIPTION
## Summary

- add a portable bounded parser for the versioned polyglot success/error response envelopes under #91/#4700
- reject malformed JSON/UTF-8, duplicate object keys, unknown top-level/error fields, wrong success/error shapes, and excessive byte/depth use
- require exact capability, correlation, and protocol identities before admitting a response
- preserve an admitted success payload as exact validated JSON bytes and expose structured candidate error fields
- cover checked-in contract examples and adversarial boundaries under a complete portable isolation classification
- preserve exact payload bytes under both LF and CRLF fixture conventions

This is response admission only and does not close #91 or #4700.

## Evidence

- GCC licensing/polyglot/isolation selected suite: 11/11 passed
- Clang polyglot suite: 6/6 passed
- Clang ASan/UBSan envelope test: 1/1 passed, no findings
- focused analyzer/bug-prone/CERT/performance checks: no project diagnostics
- implementation head `171a1652b`: Linux Native `31287594685` and macOS Native `31287594735` passed 325/325
- Windows run `31287594747`: 323/324, exposing only the rejected LF-hard-coded fixture assertion while the parser preserved CRLF correctly
- owner-approved test-only head `09284457e`: fresh local GCC/Clang focused builds passed 1/1; Windows Native `31289912992` passed 324/324 including `test_polyglot_interop_envelope`
- all eight protected checks passed at evidence-only final head `0c9b99718`
- `git diff --check`: clean

## Non-claims

No invocation-request serializer, process-output capture, artifact authorization/hash verification, candidate-message rendering, runtime-host or PRG dispatch, fallback application, or route execution is added.
