### PR TITLE
Require durable audit before .NET interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+- 2026-08-09: Added the #279 durable .NET policy-audit boundary. Audited policy
+  allows now expose `pending_audit`, not an executable route, until
+  `evaluate_and_commit_dotnet_interop_call` receives a successful non-empty
+  receipt from its non-owning function-pointer sink callback. Missing, failed, empty-receipt,
+  and throwing sinks fail closed with the stable
+  `dotnet.interop.audit_commit_failed` diagnostic; denials and native fallbacks
+  use the same commit path. The focused adapter regression writes through the
+  contained, locked, hash-chained native audit stream and verifies the receipt,
+  chain, and durable actor/capability/decision/outcome fields. Managed execution
+  and runtime-host/PRG wiring remain unimplemented.
+
 - 2026-08-09: Added the #279 .NET interop threat model and fail-closed policy
   context gates. Candidate calls now require a trusted host to bind actor,
   verified policy context, audit readiness, and exact capability scope;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@
   use the same commit path. The focused adapter regression writes through the
   contained, locked, hash-chained native audit stream and verifies the receipt,
   chain, and durable actor/capability/decision/outcome fields. Managed execution
-  and runtime-host/PRG wiring remain unimplemented.
+  and runtime-host/PRG wiring remain unimplemented. At exact implementation
+  head `af99a3af5`, Linux Native run `31301544541` and macOS Native run
+  `31301544576` pass `326/326`, macOS also passes the four-locale SET POINT
+  matrix at `8/8`, and Windows Native run `31302777143` passes `325/325`;
+  `test_platform_models` and `test_dotnet_interop_audit` pass everywhere, as do
+  all eight protected checks.
 
 - 2026-08-09: Added the #279 .NET interop threat model and fail-closed policy
   context gates. Candidate calls now require a trusted host to bind actor,

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -14,8 +14,14 @@ The focused adapter regression binds the callback to the existing physically
 contained, locked, hash-chained audit stream and verifies its returned SHA-256
 receipt and chain. Actor, capability, decision, and outcome survive in the
 durable record. This does not execute managed code or wire the runtime host or
-PRG job facade. Focused and hosted evidence remains to be recorded before
-merge; no stub or no-op is introduced.
+PRG job facade. At exact implementation head `af99a3af5`, Linux Native run
+`31301544541` and macOS Native run `31301544576` pass `326/326`, with macOS also
+passing the four-locale SET POINT matrix at `8/8`; exact-SHA Windows Native run
+`31302777143` passes `325/325`. Both `test_platform_models` and
+`test_dotnet_interop_audit` pass on every platform, and all eight protected
+checks pass. The original Windows branch-ref dispatch `31301545011` never
+acquired a runner and was cancelled after the exact-SHA replacement started;
+it is not product evidence. No stub or no-op is introduced.
 
 ## V1 .NET interop security-gate candidate
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,22 @@
 # Agent Handoff
 
+## V1 .NET interop durable-audit boundary candidate
+
+Trusted #279 now has a follow-on candidate that removes the last executable
+interpretation from an uncommitted policy allow. Raw policy evaluation returns
+`pending_audit`; `evaluate_and_commit_dotnet_interop_call` promotes it to
+`dotnet` only after a non-owning function-pointer sink callback reports success with a
+non-empty receipt. Missing, failed, empty-receipt, and throwing sinks return a
+localized `dotnet.interop.audit_commit_failed` rejection. Rejections and native
+fallbacks use the same commit boundary when auditing is required.
+
+The focused adapter regression binds the callback to the existing physically
+contained, locked, hash-chained audit stream and verifies its returned SHA-256
+receipt and chain. Actor, capability, decision, and outcome survive in the
+durable record. This does not execute managed code or wire the runtime host or
+PRG job facade. Focused and hosted evidence remains to be recorded before
+merge; no stub or no-op is introduced.
+
 ## V1 .NET interop security-gate candidate
 
 Trusted #279 now has a fail-closed policy-gateway candidate. A .NET route can

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -46,7 +46,10 @@ an audited policy allow remains `pending_audit` until a trusted, non-owning func
 sink callback commits the structured event and returns a non-empty receipt.
 Absent, failing, empty-receipt, and throwing sinks fail closed. A focused
 adapter regression uses the contained hash-chained audit stream; managed
-execution and runtime-host/PRG wiring remain separate.
+execution and runtime-host/PRG wiring remain separate. Exact implementation
+head `af99a3af5` passes Linux and macOS at `326/326`, Windows at `325/325`, the
+macOS four-locale SET POINT matrix at `8/8`, and all eight protected checks;
+both focused policy/audit targets pass on every native platform.
 
 Current standalone Open evidence includes #4890 at product/test head
 `9e4b5a286`: localized File > Open exposes Ctrl+O through the existing picker

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -41,6 +41,13 @@ implementation head `5c6ccfa79` passes Linux and macOS at `325/325`, Windows at
 matrix at `8/8`, and all eight protected checks. Managed parity-call execution
 and the PRG job facade remain separate.
 
+The next .NET security criterion now has a candidate durable-audit boundary:
+an audited policy allow remains `pending_audit` until a trusted, non-owning function-pointer
+sink callback commits the structured event and returns a non-empty receipt.
+Absent, failing, empty-receipt, and throwing sinks fail closed. A focused
+adapter regression uses the contained hash-chained audit stream; managed
+execution and runtime-host/PRG wiring remain separate.
+
 Current standalone Open evidence includes #4890 at product/test head
 `9e4b5a286`: localized File > Open exposes Ctrl+O through the existing picker
 without changing filters, path admission, tab identity, or Close Ctrl+F4. The

--- a/docs/11-engineering-spec-dotnet.md
+++ b/docs/11-engineering-spec-dotnet.md
@@ -207,6 +207,8 @@ Current gate checks:
 - allowlist/denylist capability matching
 - host-verified actor and exact granted-capability scoping
 - required audit-sink availability with a structured actor/capability/decision/outcome event
+- non-executable `pending_audit` policy allows promoted to `dotnet` only after a
+  successful sink commit returns a non-empty receipt
 - reflection, assembly-loading, external-I/O, and secret-access capability scopes that default closed
 - latency-budget eligibility for in-process managed path
 - reflection restrictions for untrusted or security-sensitive inputs

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -318,7 +318,10 @@ value kinds, a policy-driven call gateway with three outcomes
 
 The portable profile now enforces verified actor, exact capability scope,
 required audit readiness, and separate reflection/assembly/I/O/secret scopes;
-it emits stable diagnostics and a structured audit record. The threat model in
+it emits stable diagnostics and a structured audit record. An audited allow is
+non-executable until a trusted sink commits the event and returns a non-empty
+receipt; the focused adapter exercises the contained hash-chained audit stream.
+The threat model in
 `docs/37-dotnet-interop-threat-model.md` also fixes the future PRG-supervised
 job and foreign-thread boundary.
 

--- a/docs/37-dotnet-interop-threat-model.md
+++ b/docs/37-dotnet-interop-threat-model.md
@@ -56,9 +56,15 @@ is initially scoped only to `safe-http-helpers`. A request is rejected before a
 
 Stable machine diagnostics use the `dotnet.interop.*` namespace. Human-facing
 reason text remains localizable and must not be parsed as a machine contract.
-An allow decision with `audit_commit_required=true` is conditional: the caller
-must durably append the returned event before invoking managed code. Rejection
-and native-fallback events must also be recorded when auditing is required.
+An allow decision with `audit_commit_required=true` is conditional and carries
+the non-executable `pending_audit` path. The caller must use
+`evaluate_and_commit_dotnet_interop_call` with a trusted audit sink before an
+executable `dotnet` path can be returned. The sink contract is a function
+pointer plus opaque context, avoiding an owning callback wrapper. Missing,
+failed, empty-receipt, or throwing sinks return
+`dotnet.interop.audit_commit_failed` and `reject`; no managed route is exposed.
+Rejection and native-fallback events are committed through the same boundary
+when auditing is required.
 
 `serialize_dotnet_interop_audit_event` emits one compact JSON object with fixed
 field order:
@@ -69,7 +75,15 @@ field order:
 
 The record always carries actor, capability, decision, outcome, and stable
 diagnostic code. The serializer escapes control characters and quotes so one
-untrusted value cannot forge an additional record.
+untrusted value cannot forge an additional record. It emits the audit stream's
+field delimiter as JSON `\\u007c`, preserving identity data instead of allowing
+the line format to rewrite it.
+
+The focused durable-adapter regression binds that sink to
+`append_immutable_audit_event_to_contained_file`. A successful receipt is the
+entry's SHA-256 chain hash after the audit implementation has flushed the
+replacement file and directory/write-through state. The gateway treats an
+empty receipt as failure even when a sink incorrectly reports success.
 
 ## Verification Evidence
 
@@ -85,8 +99,9 @@ matrix passes `8/8`, and all eight protected PR checks pass at that head.
 
 This slice does not load an assembly, launch a process, provide a PRG job
 facade, capture worker output, transport an invocation envelope, select or hash
-an artifact, or persist an audit event. The existing bounded-process and
-polyglot envelope primitives remain separate prerequisites. A later adapter
-must derive the verified context from trusted host state, commit required audit
-events, enforce artifact identity at execution time, and expose supervision to
-PRG without allowing foreign-thread runtime re-entry.
+an artifact, or wire a runtime-host/PRG call. The policy API can now require and
+prove an audit commit, and its regression uses the existing contained durable
+audit stream; a later runtime adapter must derive the verified context from
+trusted host state, bind that sink, enforce artifact identity at execution
+time, and expose supervision to PRG without allowing foreign-thread runtime
+re-entry.

--- a/docs/37-dotnet-interop-threat-model.md
+++ b/docs/37-dotnet-interop-threat-model.md
@@ -95,6 +95,16 @@ Linux Native run `31297811840` and macOS Native run `31297811846` pass
 `test_platform_models` passes in every matrix, the macOS four-locale SET POINT
 matrix passes `8/8`, and all eight protected PR checks pass at that head.
 
+At exact durable-audit implementation head `af99a3af5`, Linux Native run
+`31301544541` and macOS Native run `31301544576` pass `326/326`, and Windows
+Native run `31302777143` passes `325/325`. `test_platform_models` and
+`test_dotnet_interop_audit` pass on all three platforms; macOS also passes both
+SET POINT targets under `C`, `en_US.UTF-8`, `pt_BR.UTF-8`, and `de_DE.UTF-8`
+(`8/8`). All eight protected checks pass at that implementation head. Local
+GCC selected contracts pass `5/5`, focused post-delimiter-hardening contracts
+pass `2/2`, Clang 21 ASan/UBSan passes `2/2`, and focused static analysis reports
+no finding.
+
 ## Nonclaims And Later Work
 
 This slice does not load an assembly, launch a process, provide a PRG job

--- a/include/copperfin/platform/extensibility_model.h
+++ b/include/copperfin/platform/extensibility_model.h
@@ -76,6 +76,22 @@ struct DotNetInteropCallDecision {
     std::string diagnostic_code;
     DotNetInteropAuditEvent audit_event{};
     bool audit_commit_required = false;
+    bool audit_committed = false;
+    std::string audit_receipt;
+};
+
+struct DotNetInteropAuditCommitResult {
+    bool ok = false;
+    std::string receipt;
+};
+
+using DotNetInteropAuditCommitFunction = DotNetInteropAuditCommitResult (*)(
+    const DotNetInteropAuditEvent& event,
+    void* context);
+
+struct DotNetInteropAuditSink {
+    DotNetInteropAuditCommitFunction commit = nullptr;
+    void* context = nullptr;
 };
 
 struct LanguageIntegration {
@@ -122,6 +138,15 @@ struct ExtensibilityProfile {
 [[nodiscard]] DotNetInteropCallDecision evaluate_dotnet_interop_call(
     const ExtensibilityProfile& profile,
     const DotNetInteropCallRequest& request,
+    const localization::LocalizedCatalog& catalog);
+[[nodiscard]] DotNetInteropCallDecision evaluate_and_commit_dotnet_interop_call(
+    const ExtensibilityProfile& profile,
+    const DotNetInteropCallRequest& request,
+    const DotNetInteropAuditSink& sink);
+[[nodiscard]] DotNetInteropCallDecision evaluate_and_commit_dotnet_interop_call(
+    const ExtensibilityProfile& profile,
+    const DotNetInteropCallRequest& request,
+    const DotNetInteropAuditSink& sink,
     const localization::LocalizedCatalog& catalog);
 [[nodiscard]] std::string serialize_dotnet_interop_audit_event(
     const DotNetInteropAuditEvent& event);

--- a/resources/locales/en-US/strings.json
+++ b/resources/locales/en-US/strings.json
@@ -788,6 +788,7 @@
   "Platform.Extensibility.DotNetInteropDecision.CapabilityAllowedWithAuditRequired": "allowed by policy with audit-required path",
   "Platform.Extensibility.DotNetInteropDecision.ActorIdRequired": "verified actor id is required",
   "Platform.Extensibility.DotNetInteropDecision.AssemblyLoadingDenied": "assembly loading is not authorized for this capability",
+  "Platform.Extensibility.DotNetInteropDecision.AuditCommitFailed": "required policy audit event could not be committed",
   "Platform.Extensibility.DotNetInteropDecision.AuditSinkUnavailable": "required policy audit sink is unavailable",
   "Platform.Extensibility.DotNetInteropDecision.CapabilityDeniedByPolicy": "capability denied by policy allowlist/denylist",
   "Platform.Extensibility.DotNetInteropDecision.CapabilityIdRequired": "capability id is required",

--- a/resources/locales/es-419/strings.json
+++ b/resources/locales/es-419/strings.json
@@ -284,6 +284,7 @@
   "Platform.Extensibility.DotNetInteropDecision.CapabilityAllowedWithAuditRequired": "permitida por politica con ruta que requiere auditoria",
   "Platform.Extensibility.DotNetInteropDecision.ActorIdRequired": "se requiere un id de actor verificado",
   "Platform.Extensibility.DotNetInteropDecision.AssemblyLoadingDenied": "la carga de ensamblados no esta autorizada para esta capacidad",
+  "Platform.Extensibility.DotNetInteropDecision.AuditCommitFailed": "no se pudo confirmar el evento de auditoria de politica requerido",
   "Platform.Extensibility.DotNetInteropDecision.AuditSinkUnavailable": "el destino de auditoria de politica requerido no esta disponible",
   "Platform.Extensibility.DotNetInteropDecision.CapabilityDeniedByPolicy": "capacidad denegada por la politica de allowlist/denylist",
   "Platform.Extensibility.DotNetInteropDecision.CapabilityIdRequired": "se requiere un id de capacidad",

--- a/resources/locales/pt-BR/strings.json
+++ b/resources/locales/pt-BR/strings.json
@@ -284,6 +284,7 @@
   "Platform.Extensibility.DotNetInteropDecision.CapabilityAllowedWithAuditRequired": "permitida por politica com caminho que exige auditoria",
   "Platform.Extensibility.DotNetInteropDecision.ActorIdRequired": "e obrigatorio um id de ator verificado",
   "Platform.Extensibility.DotNetInteropDecision.AssemblyLoadingDenied": "o carregamento de assemblies nao esta autorizado para esta capacidade",
+  "Platform.Extensibility.DotNetInteropDecision.AuditCommitFailed": "nao foi possivel confirmar o evento de auditoria de politica obrigatorio",
   "Platform.Extensibility.DotNetInteropDecision.AuditSinkUnavailable": "o destino de auditoria de politica obrigatorio nao esta disponivel",
   "Platform.Extensibility.DotNetInteropDecision.CapabilityDeniedByPolicy": "capacidade negada pela politica de allowlist/denylist",
   "Platform.Extensibility.DotNetInteropDecision.CapabilityIdRequired": "o id da capacidade e obrigatorio",

--- a/resources/locales/qps-ploc/strings.json
+++ b/resources/locales/qps-ploc/strings.json
@@ -284,6 +284,7 @@
   "Platform.Extensibility.DotNetInteropDecision.CapabilityAllowedWithAuditRequired": "allowed by policy with audit-required path",
   "Platform.Extensibility.DotNetInteropDecision.ActorIdRequired": "verified actor id is required",
   "Platform.Extensibility.DotNetInteropDecision.AssemblyLoadingDenied": "assembly loading is not authorized for this capability",
+  "Platform.Extensibility.DotNetInteropDecision.AuditCommitFailed": "required policy audit event could not be committed",
   "Platform.Extensibility.DotNetInteropDecision.AuditSinkUnavailable": "required policy audit sink is unavailable",
   "Platform.Extensibility.DotNetInteropDecision.CapabilityDeniedByPolicy": "capability denied by policy allowlist/denylist",
   "Platform.Extensibility.DotNetInteropDecision.CapabilityIdRequired": "capability id is required",

--- a/src/platform/extensibility_model.cpp
+++ b/src/platform/extensibility_model.cpp
@@ -32,6 +32,20 @@ std::string decision_name(DotNetInteropDecision decision) {
     return "reject";
 }
 
+std::string audit_json_escape(std::string_view value) {
+    const std::string escaped = json_escape_string(value);
+    std::string result;
+    result.reserve(escaped.size());
+    for (const char ch : escaped) {
+        if (ch == '|') {
+            result += "\\u007c";
+        } else {
+            result.push_back(ch);
+        }
+    }
+    return result;
+}
+
 DotNetInteropCallDecision make_decision(
     const DotNetInteropCallRequest& request,
     DotNetInteropDecision value,
@@ -272,20 +286,71 @@ DotNetInteropCallDecision evaluate_dotnet_interop_call(
             "dotnet.interop.latency_budget_exceeded", rules.require_policy_audit);
     }
 
-    return make_decision(request, DotNetInteropDecision::allow, "dotnet",
+    return make_decision(request, DotNetInteropDecision::allow,
+        rules.require_policy_audit ? "pending_audit" : "dotnet",
         rules.require_policy_audit
             ? extensibility_text(catalog, "Platform.Extensibility.DotNetInteropDecision.CapabilityAllowedWithAuditRequired")
             : extensibility_text(catalog, "Platform.Extensibility.DotNetInteropDecision.CapabilityAllowedByPolicy"),
         "dotnet.interop.allowed", rules.require_policy_audit);
 }
 
+DotNetInteropCallDecision evaluate_and_commit_dotnet_interop_call(
+    const ExtensibilityProfile& profile,
+    const DotNetInteropCallRequest& request,
+    const DotNetInteropAuditSink& sink) {
+    return evaluate_and_commit_dotnet_interop_call(
+        profile,
+        request,
+        sink,
+        extensibility_profile_catalog());
+}
+
+DotNetInteropCallDecision evaluate_and_commit_dotnet_interop_call(
+    const ExtensibilityProfile& profile,
+    const DotNetInteropCallRequest& request,
+    const DotNetInteropAuditSink& sink,
+    const localization::LocalizedCatalog& catalog) {
+    DotNetInteropCallDecision decision =
+        evaluate_dotnet_interop_call(profile, request, catalog);
+    if (!decision.audit_commit_required) {
+        return decision;
+    }
+
+    DotNetInteropAuditCommitResult commit_result;
+    if (sink.commit != nullptr) {
+        try {
+            commit_result = sink.commit(decision.audit_event, sink.context);
+        } catch (...) {
+            commit_result = {};
+        }
+    }
+    if (!commit_result.ok || commit_result.receipt.empty()) {
+        return make_decision(
+            request,
+            DotNetInteropDecision::reject,
+            "none",
+            extensibility_text(
+                catalog,
+                "Platform.Extensibility.DotNetInteropDecision.AuditCommitFailed"),
+            "dotnet.interop.audit_commit_failed",
+            true);
+    }
+
+    decision.audit_committed = true;
+    decision.audit_receipt = std::move(commit_result.receipt);
+    if (decision.decision == DotNetInteropDecision::allow) {
+        decision.execution_path = "dotnet";
+    }
+    return decision;
+}
+
 std::string serialize_dotnet_interop_audit_event(const DotNetInteropAuditEvent& event) {
     std::ostringstream stream;
-    stream << "{\"schema_version\":1,\"actor\":\"" << json_escape_string(event.actor_id)
-           << "\",\"capability\":\"" << json_escape_string(event.capability_id)
-           << "\",\"decision\":\"" << json_escape_string(decision_name(event.decision))
-           << "\",\"outcome\":\"" << json_escape_string(event.outcome)
-           << "\",\"diagnostic_code\":\"" << json_escape_string(event.diagnostic_code) << "\"}";
+    stream << "{\"schema_version\":1,\"actor\":\"" << audit_json_escape(event.actor_id)
+           << "\",\"capability\":\"" << audit_json_escape(event.capability_id)
+           << "\",\"decision\":\"" << audit_json_escape(decision_name(event.decision))
+           << "\",\"outcome\":\"" << audit_json_escape(event.outcome)
+           << "\",\"diagnostic_code\":\"" << audit_json_escape(event.diagnostic_code) << "\"}";
     return stream.str();
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4659,6 +4659,10 @@ copperfin_add_test(test_platform_models "cf_security;cf_platform_profile"
     test_platform_models.cpp
 )
 
+copperfin_add_test(test_dotnet_interop_audit "cf_security;cf_platform_profile"
+    test_dotnet_interop_audit.cpp
+)
+
 copperfin_add_test(test_polyglot_route_registry cf_platform_profile
     test_polyglot_route_registry.cpp
 )

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -191,6 +191,16 @@ function(copperfin_configure_native_test_isolation)
         )
     endforeach()
 
+    copperfin_set_test_isolation(test_dotnet_interop_audit
+        FILESYSTEM test-owned-unique
+        ENVIRONMENT scoped-process
+        CHILD_PROCESSES none
+        NETWORK none
+        SAMPLES none
+        PLATFORM portable
+        AUDIT complete
+    )
+
     foreach(test_name IN ITEMS
             test_query_translator
             test_federation_execution)

--- a/tests/test_dotnet_interop_audit.cpp
+++ b/tests/test_dotnet_interop_audit.cpp
@@ -1,0 +1,220 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/extensibility_model.h"
+#include "copperfin/security/audit_stream.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << "\n";
+        ++failures;
+    }
+}
+
+struct FileAuditContext {
+    std::string log_path;
+    std::string package_root;
+    std::size_t calls = 0U;
+};
+
+copperfin::platform::DotNetInteropAuditCommitResult commit_to_contained_audit(
+    const copperfin::platform::DotNetInteropAuditEvent& event,
+    void* opaque_context) {
+    auto* context = static_cast<FileAuditContext*>(opaque_context);
+    if (context == nullptr) {
+        return {};
+    }
+    ++context->calls;
+    const std::string event_name =
+        event.decision == copperfin::platform::DotNetInteropDecision::reject
+        ? "policy.denied"
+        : "interop.dotnet_invoked";
+    const auto append = copperfin::security::append_immutable_audit_event_to_contained_file(
+        context->log_path,
+        context->package_root,
+        event_name,
+        copperfin::platform::serialize_dotnet_interop_audit_event(event));
+    return {
+        .ok = append.ok,
+        .receipt = append.entry_hash};
+}
+
+copperfin::platform::DotNetInteropAuditCommitResult fail_commit(
+    const copperfin::platform::DotNetInteropAuditEvent&,
+    void*) {
+    return {};
+}
+
+copperfin::platform::DotNetInteropAuditCommitResult empty_receipt_commit(
+    const copperfin::platform::DotNetInteropAuditEvent&,
+    void*) {
+    return {.ok = true, .receipt = {}};
+}
+
+copperfin::platform::DotNetInteropAuditCommitResult throw_commit(
+    const copperfin::platform::DotNetInteropAuditEvent&,
+    void*) {
+    throw std::runtime_error("synthetic audit sink failure");
+}
+
+copperfin::platform::DotNetInteropCallRequest authorized_request(
+    std::string capability_id) {
+    copperfin::platform::DotNetInteropCallRequest request;
+    request.capability_id = std::move(capability_id);
+    request.actor_id = "prg:main";
+    request.granted_capabilities = {request.capability_id};
+    request.policy_context_verified = true;
+    request.audit_sink_available = true;
+    return request;
+}
+
+std::string read_text(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return std::string(
+        std::istreambuf_iterator<char>(input),
+        std::istreambuf_iterator<char>());
+}
+
+void test_dotnet_audit_commit_boundary() {
+    namespace fs = std::filesystem;
+    const fs::path root =
+        fs::temp_directory_path() / "copperfin_dotnet_interop_audit_contract";
+    std::error_code error;
+    fs::remove_all(root, error);
+    error.clear();
+    fs::create_directories(root, error);
+    expect(!error, "#279: audit test root should be created");
+    const fs::path log_path = root / "audit" / "interop.log";
+
+    const auto profile = copperfin::platform::default_extensibility_profile();
+    const auto request = authorized_request("task-primitives");
+    const auto policy_only =
+        copperfin::platform::evaluate_dotnet_interop_call(profile, request);
+    expect(policy_only.decision == copperfin::platform::DotNetInteropDecision::allow &&
+               policy_only.execution_path == "pending_audit" &&
+               policy_only.audit_commit_required &&
+               !policy_only.audit_committed,
+           "#279: policy evaluation must withhold the executable route until audit commit");
+
+    FileAuditContext context{
+        .log_path = log_path.string(),
+        .package_root = root.string()};
+    const copperfin::platform::DotNetInteropAuditSink file_sink{
+        .commit = commit_to_contained_audit,
+        .context = &context};
+    const auto committed = copperfin::platform::evaluate_and_commit_dotnet_interop_call(
+        profile,
+        request,
+        file_sink);
+    expect(committed.decision == copperfin::platform::DotNetInteropDecision::allow &&
+               committed.execution_path == "dotnet" &&
+               committed.audit_committed &&
+               committed.audit_receipt.size() == 64U &&
+               context.calls == 1U,
+           "#279: durable audit commit should promote an allowed call to the .NET route");
+    const auto first_chain = copperfin::security::verify_immutable_audit_chain(log_path.string());
+    expect(first_chain.ok && first_chain.entries == 1U,
+           "#279: committed .NET allow should create one valid hash-chained audit entry");
+    const std::string first_log = read_text(log_path);
+    expect(first_log.find("interop.dotnet_invoked") != std::string::npos &&
+               first_log.find("\"actor\":\"prg:main\"") != std::string::npos &&
+               first_log.find("\"capability\":\"task-primitives\"") != std::string::npos &&
+               first_log.find("\"decision\":\"allow\"") != std::string::npos &&
+               first_log.find("\"outcome\":\"allow\"") != std::string::npos,
+           "#279: durable audit detail should retain actor, capability, decision, and outcome");
+
+    auto delimited_actor_request = request;
+    delimited_actor_request.actor_id = "prg:main|batch";
+    const auto delimited_actor_commit =
+        copperfin::platform::evaluate_and_commit_dotnet_interop_call(
+            profile,
+            delimited_actor_request,
+            file_sink);
+    const std::string delimited_actor_log = read_text(log_path);
+    const auto delimited_actor_chain =
+        copperfin::security::verify_immutable_audit_chain(log_path.string());
+    expect(delimited_actor_commit.audit_committed &&
+               delimited_actor_chain.ok &&
+               delimited_actor_chain.entries == 2U &&
+               delimited_actor_log.find("\"actor\":\"prg:main\\u007cbatch\"") !=
+                   std::string::npos,
+           "#279: a field delimiter in an actor ID must remain lossless JSON in the durable stream");
+
+    for (const auto& sink : {
+             copperfin::platform::DotNetInteropAuditSink{},
+             copperfin::platform::DotNetInteropAuditSink{.commit = fail_commit},
+             copperfin::platform::DotNetInteropAuditSink{.commit = empty_receipt_commit},
+             copperfin::platform::DotNetInteropAuditSink{.commit = throw_commit}}) {
+        const auto rejected = copperfin::platform::evaluate_and_commit_dotnet_interop_call(
+            profile,
+            request,
+            sink);
+        expect(rejected.decision == copperfin::platform::DotNetInteropDecision::reject &&
+                   rejected.execution_path == "none" &&
+                   rejected.diagnostic_code == "dotnet.interop.audit_commit_failed" &&
+                   rejected.reason == "required policy audit event could not be committed" &&
+                   !rejected.audit_committed &&
+                   rejected.audit_receipt.empty(),
+               "#279: absent, failed, empty-receipt, and throwing sinks must fail closed");
+    }
+
+    auto denied_request = authorized_request("unsafe-reflection-load");
+    denied_request.requires_reflection = true;
+    denied_request.untrusted_input = true;
+    denied_request.security_sensitive = true;
+    const auto committed_denial =
+        copperfin::platform::evaluate_and_commit_dotnet_interop_call(
+            profile,
+            denied_request,
+            file_sink);
+    expect(committed_denial.decision == copperfin::platform::DotNetInteropDecision::reject &&
+               committed_denial.execution_path == "none" &&
+               committed_denial.audit_committed &&
+               committed_denial.audit_receipt.size() == 64U &&
+               context.calls == 3U,
+           "#279: policy denials should be durably audited without becoming executable");
+    const auto second_chain = copperfin::security::verify_immutable_audit_chain(log_path.string());
+    expect(second_chain.ok && second_chain.entries == 3U,
+           "#279: allowed and denied decisions should share one valid audit chain");
+    expect(read_text(log_path).find("policy.denied") != std::string::npos,
+           "#279: denied decisions should use the policy denial event class");
+
+    auto unaudited_profile = profile;
+    unaudited_profile.dotnet_output.policy.require_policy_audit = false;
+    const auto unaudited = copperfin::platform::evaluate_and_commit_dotnet_interop_call(
+        unaudited_profile,
+        request,
+        {});
+    expect(unaudited.decision == copperfin::platform::DotNetInteropDecision::allow &&
+               unaudited.execution_path == "dotnet" &&
+               !unaudited.audit_commit_required &&
+               !unaudited.audit_committed &&
+               context.calls == 3U,
+           "#279: explicitly unaudited policy should not invoke a sink or require a receipt");
+
+    fs::remove_all(root, error);
+}
+
+}  // namespace
+
+int main() {
+    test_dotnet_audit_commit_boundary();
+    if (failures != 0) {
+        std::cerr << failures << " test(s) failed.\n";
+        return EXIT_FAILURE;
+    }
+    std::cout << "All tests passed.\n";
+    return EXIT_SUCCESS;
+}

--- a/tests/test_platform_models.cpp
+++ b/tests/test_platform_models.cpp
@@ -412,8 +412,8 @@ void test_dotnet_interop_policy_gateway() {
         allowed.decision == copperfin::platform::DotNetInteropDecision::allow,
         "policy gateway should allow listed .NET parity capabilities within budget");
     expect(
-        allowed.execution_path == "dotnet",
-        "#2493: allowed .NET interop execution path should remain invariant");
+        allowed.execution_path == "pending_audit",
+        "#279: audited .NET interop should not expose an executable path before commit");
     expect(
         allowed.reason == "allowed by policy with audit-required path",
         "#2493: allowed .NET interop reason should preserve default en-US prose");
@@ -421,19 +421,21 @@ void test_dotnet_interop_policy_gateway() {
            "#279: allowed interop should expose a stable diagnostic code");
     expect(allowed.audit_commit_required,
            "#279: an allowed audited call must require durable audit commit before execution");
+    expect(!allowed.audit_committed && allowed.audit_receipt.empty(),
+           "#279: policy evaluation alone must not claim audit persistence");
     expect(allowed.audit_event.actor_id == "prg:main" &&
                allowed.audit_event.capability_id == "task-primitives" &&
                allowed.audit_event.decision == copperfin::platform::DotNetInteropDecision::allow &&
                allowed.audit_event.outcome == "allow",
            "#279: audit event should bind actor, capability, decision, and outcome");
     auto escaped_event = allowed.audit_event;
-    escaped_event.actor_id = "prg:\"main\"\nsecond-line";
+    escaped_event.actor_id = "prg:\"main\"|batch\nsecond-line";
     expect(
         copperfin::platform::serialize_dotnet_interop_audit_event(escaped_event) ==
-            "{\"schema_version\":1,\"actor\":\"prg:\\\"main\\\"\\nsecond-line\","
+            "{\"schema_version\":1,\"actor\":\"prg:\\\"main\\\"\\u007cbatch\\nsecond-line\","
             "\"capability\":\"task-primitives\",\"decision\":\"allow\","
             "\"outcome\":\"allow\",\"diagnostic_code\":\"dotnet.interop.allowed\"}",
-        "#279: audit serialization should be deterministic and prevent line/JSON injection");
+        "#279: audit serialization should be deterministic and preserve JSON through the delimited stream");
 
     const auto missing_actor = copperfin::platform::evaluate_dotnet_interop_call(
         profile,
@@ -600,8 +602,8 @@ void test_dotnet_interop_policy_gateway() {
         spanish_catalog);
     expect(spanish_allowed.reason == "permitida por politica con ruta que requiere auditoria",
            "#2599: es-419 allowed .NET interop reason should localize the prose");
-    expect(spanish_allowed.execution_path == "dotnet",
-           "#2599: es-419 allowed .NET interop should preserve execution-path values");
+    expect(spanish_allowed.execution_path == "pending_audit",
+           "#279: localized policy evaluation should preserve the pending-audit path");
 
     const auto portuguese_denied = copperfin::platform::evaluate_dotnet_interop_call(
         profile,
@@ -627,8 +629,8 @@ void test_dotnet_interop_policy_gateway() {
         pseudo_allowed.decision == copperfin::platform::DotNetInteropDecision::allow,
         "#2493: pseudo-localized allowed decision enum should remain invariant");
     expect(
-        pseudo_allowed.execution_path == "dotnet",
-        "#2493: pseudo-localized allowed execution path should remain invariant");
+        pseudo_allowed.execution_path == "pending_audit",
+        "#279: pseudo-localized policy evaluation should preserve the pending-audit path");
     expect(
         pseudo_allowed.reason.find("[!! ") != std::string::npos,
         "#2493: pseudo-localized allowed reason should route through the catalog");

--- a/tests/test_runtime_pipeline_startup_and_staging.cpp
+++ b/tests/test_runtime_pipeline_startup_and_staging.cpp
@@ -490,6 +490,10 @@ void test_materialize_runtime_package() {
                "debug manifest should preserve task-primitives parity matrix entries");
         expect(debug_manifest.find("dotnet_gateway_task_primitives=") != std::string::npos,
                "debug manifest should preserve .NET gateway allow decision diagnostics");
+        expect(
+            manifest_value_for_key(debug_manifest, "dotnet_gateway_task_primitives")
+                    .find("pending_audit:") != std::string::npos,
+            "#279: debug manifest must not present an uncommitted .NET allow as executable");
         expect(debug_manifest.find("dotnet_gateway_unsafe_reflection=") != std::string::npos,
                "debug manifest should preserve .NET gateway deny decision diagnostics");
         expect(debug_manifest.find("language_integration_count=") != std::string::npos,


### PR DESCRIPTION
Advances #279 without closing it.

This slice makes an audited policy allow non-executable (`pending_audit`) until a trusted non-owning function-pointer sink durably commits the structured event and returns a non-empty receipt. Missing, failed, empty-receipt, and throwing sinks fail closed. The focused adapter uses the existing contained, locked, hash-chained native audit stream and preserves delimiter-bearing identity data as valid JSON.

Managed execution, runtime-host binding, artifact admission, and the PRG supervision facade remain out of scope and unimplemented.

Implementation/test head: `af99a3af5`
Evidence-only final head: `a580c7559`

Validation:
- Linux Native `31301544541`: 326/326; both focused tests pass
- macOS Native `31301544576`: 326/326; both focused tests pass; four-locale SET POINT matrix 8/8
- Windows Native exact-SHA `31302777143`: 325/325; both focused tests pass
- GCC selected contracts: 5/5; post-delimiter hardening: 2/2
- Clang 21 ASan/UBSan: 2/2
- focused Clang static analysis: no findings
- all eight protected checks passed at the implementation head

The original Windows branch-ref dispatch `31301545011` never acquired a runner and was cancelled after the exact-SHA replacement started; it is not product evidence.

Signed-off-by: rhamenator <rhamenator@gmail.com>