### PR TITLE
Serialize PRG task completion publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,11 @@
   retained result/output plus unchanged final `AWAIT` consumption. The focused
   GCC control-flow test passes in 6.94 seconds, and the full target passes under
   Clang 21 ThreadSanitizer in 382.70 seconds with no race or deadlock finding.
+  Exact candidate `e93686326` passes Linux Native `31329773481` and macOS
+  Native `31329773480` at `331/331`, the macOS four-locale matrix at `8/8`,
+  and Windows Native `31329773507` at `330/330`; the control-flow target passes
+  everywhere. Candidate protected checks conclude seven successes plus the
+  non-failing neutral Socket project report.
 
 - 2026-08-09: Added the #279 durable .NET policy-audit boundary. Audited policy
   allows now expose `pending_audit`, not an executable route, until

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@
   `8/8`, and Windows Native `31307387195` at `325/325`; the control-flow target
   passes everywhere and all eight protected checks are green.
 
+- 2026-08-09: Serialized one-time task-completion publication for concurrent
+  PRG supervisors. Each task now owns a narrow completion mutex, so sibling
+  `CFTASK*()` callers polling the same handle cannot race while copying the
+  completed `RuntimePauseState`; unrelated tasks remain independent. An
+  end-to-end regression uses two spawned watchers on one target and verifies
+  retained result/output plus unchanged final `AWAIT` consumption. The focused
+  GCC control-flow test passes in 6.94 seconds, and the full target passes under
+  Clang 21 ThreadSanitizer in 382.70 seconds with no race or deadlock finding.
+
 - 2026-08-09: Added the #279 durable .NET policy-audit boundary. Audited policy
   allows now expose `pending_audit`, not an executable route, until
   `evaluate_and_commit_dotnet_interop_call` receives a successful non-empty

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -146,8 +146,12 @@ handle-lifetime, or `AWAIT` contracts. A new real-PRG regression drives two
 spawned watchers against one handle, retains the completed result and output,
 and then consumes the task through `AWAIT`. The GCC control-flow target passes
 in 6.94 seconds; the same full target passes under Clang 21 ThreadSanitizer in
-382.70 seconds with no race or deadlock finding. Hosted evidence remains to be
-recorded on the corrective PR head.
+382.70 seconds with no race or deadlock finding. At exact candidate head
+`e93686326`, Linux Native `31329773481` and macOS Native `31329773480` pass
+`331/331`, macOS also passes the four-locale matrix at `8/8`, and Windows
+Native `31329773507` passes `330/330`. The control-flow target passes on every
+platform. Candidate protected checks conclude seven successes plus the
+non-failing neutral Socket project report.
 
 ## V1 .NET interop durable-audit boundary candidate
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -137,6 +137,18 @@ plus the four-locale SET POINT matrix at `8/8`, and Windows Native
 `31307387195` passes `325/325`. The control-flow target passes on every
 platform and all eight protected PR checks are green.
 
+A follow-up concurrency audit found that two sibling supervisors could reach
+the same ready future and copy its completion record concurrently. The
+corrective implementation gives each task a dedicated mutex around the
+zero-duration readiness check and one-time result publication. It does not
+serialize unrelated tasks or change status, cancellation, result/output,
+handle-lifetime, or `AWAIT` contracts. A new real-PRG regression drives two
+spawned watchers against one handle, retains the completed result and output,
+and then consumes the task through `AWAIT`. The GCC control-flow target passes
+in 6.94 seconds; the same full target passes under Clang 21 ThreadSanitizer in
+382.70 seconds with no race or deadlock finding. Hosted evidence remains to be
+recorded on the corrective PR head.
+
 ## V1 .NET interop durable-audit boundary candidate
 
 Trusted #279 now has a follow-on candidate that removes the last executable

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -398,7 +398,10 @@ Concurrent same-handle polling now uses a per-task synchronization boundary
 for the one-time immutable completion publication. A two-sibling watcher
 regression passes under GCC and the complete control-flow target passes under
 Clang 21 ThreadSanitizer with no race or deadlock finding. This correction does
-not serialize unrelated tasks or broaden the interop execution surface.
+not serialize unrelated tasks or broaden the interop execution surface. Exact
+candidate `e93686326` passes Linux Native `31329773481` and macOS Native
+`31329773480` at `331/331`, macOS locales at `8/8`, and Windows Native
+`31329773507` at `330/330`; the control-flow target passes everywhere.
 
 The task-supervision implementation is directly validated at candidate head
 `09c1b1046`: Linux Native `31307387144` passes `326/326`, macOS Native

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -394,6 +394,12 @@ task, and monotonic non-reused handles prevent stale-task aliasing. No external
 artifact is connected yet, and foreign runtime threads do not directly enter
 mutable runtime state.
 
+Concurrent same-handle polling now uses a per-task synchronization boundary
+for the one-time immutable completion publication. A two-sibling watcher
+regression passes under GCC and the complete control-flow target passes under
+Clang 21 ThreadSanitizer with no race or deadlock finding. This correction does
+not serialize unrelated tasks or broaden the interop execution surface.
+
 The task-supervision implementation is directly validated at candidate head
 `09c1b1046`: Linux Native `31307387144` passes `326/326`, macOS Native
 `31307387146` passes `326/326` plus the four-locale SET POINT matrix at `8/8`,

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -325,6 +325,9 @@ The threat model in `docs/37-dotnet-interop-threat-model.md` fixes the
 PRG-supervised job and foreign-thread boundary. The runtime now implements the
 nonblocking supervision half for existing `SPAWN` tasks, including status,
 cooperative cancellation, retained return values, and completed print output.
+Per-task completion publication is synchronized and directly exercised by two
+sibling supervisors polling the same handle under ThreadSanitizer; unrelated
+tasks remain independently scheduled.
 It also exposes bounded native JSON validation, type inspection, and JSON
 Pointer selection so PRG can examine immutable structured completion payloads
 without embedding foreign source or losing exact number spelling.

--- a/docs/38-prg-task-supervision.md
+++ b/docs/38-prg-task-supervision.md
@@ -33,6 +33,11 @@ machine status values are invariant and are not localized.
   that handle therefore return the documented unknown values.
 - A child owns its runtime state. The parent observes only the immutable
   `RuntimePauseState` published through the future after the child returns.
+- Completion publication is serialized by a mutex owned by that task. Multiple
+  sibling supervisors may poll one handle concurrently, but exactly one copies
+  the ready future into the retained result; every successful observer crosses
+  the same synchronization boundary before reading that immutable record.
+  Unrelated tasks do not share this publication mutex.
 
 `runtime.task.cancel_requested` records an accepted cancellation request with
 the task handle. Existing `runtime.task.spawn`, `runtime.task.await`, and child
@@ -72,3 +77,12 @@ At exact implementation-and-local-evidence head `09c1b1046`, Linux Native run
 Native run `31307387195` passes `325/325`. Every platform executes
 `test_prg_engine_control_flow` successfully, and all eight protected PR checks
 pass at that head.
+
+A later concurrency audit reproduced an unsynchronized same-handle completion
+publication under ThreadSanitizer. The corrective regression spawns one target
+and two sibling watchers that simultaneously poll it, then proves retained
+result/output integrity and unchanged `AWAIT` consumption. The focused GCC
+control-flow target passes in 6.94 seconds. The complete target passes under
+Clang 21 ThreadSanitizer in 382.70 seconds with no race or deadlock finding.
+This correction changes synchronization only; all public task-supervision
+semantics above remain unchanged.

--- a/docs/38-prg-task-supervision.md
+++ b/docs/38-prg-task-supervision.md
@@ -86,3 +86,10 @@ control-flow target passes in 6.94 seconds. The complete target passes under
 Clang 21 ThreadSanitizer in 382.70 seconds with no race or deadlock finding.
 This correction changes synchronization only; all public task-supervision
 semantics above remain unchanged.
+
+At exact corrective candidate head `e93686326`, Linux Native run
+`31329773481` and macOS Native run `31329773480` pass `331/331`, macOS also
+passes both SET POINT targets under four locales (`8/8`), and Windows Native
+run `31329773507` passes `330/330`. Every platform executes
+`test_prg_engine_control_flow` successfully. Candidate protected checks
+conclude seven successes plus the non-failing neutral Socket project report.

--- a/src/runtime/prg_engine.cpp
+++ b/src/runtime/prg_engine.cpp
@@ -836,6 +836,7 @@ namespace copperfin::runtime
             std::string source_path;
             std::shared_ptr<std::atomic<bool>> cancel_requested;
             std::shared_future<RuntimePauseState> future;
+            std::mutex completion_mutex;
             bool finished = false;
             RuntimePauseState result{};
         };

--- a/src/runtime/prg_engine_session_transaction_state.inl
+++ b/src/runtime/prg_engine_session_transaction_state.inl
@@ -513,6 +513,11 @@
             {
                 return false;
             }
+
+            // Multiple spawned supervisors can poll the same handle. Publish
+            // the future's result exactly once and establish a happens-before
+            // edge before any caller reads the immutable completion record.
+            std::lock_guard<std::mutex> completion_lock(task->completion_mutex);
             if (task->finished)
             {
                 return true;

--- a/tests/test_prg_engine_control_flow.cpp
+++ b/tests/test_prg_engine_control_flow.cpp
@@ -182,6 +182,7 @@ int main() {
     test_sleep_duration_uses_heap_backed_frame_continuations();
     test_spawn_and_await_command_runs_task_to_completion();
     test_spawn_task_supervision_observes_status_result_and_output_without_consuming_task();
+    test_spawn_task_supervision_serializes_same_handle_completion_publication();
     test_spawn_task_supervision_requests_cooperative_cancellation();
     test_spawn_arguments_use_heap_backed_frame_continuations();
     test_spawn_cancellation_propagates_to_sibling_tasks();

--- a/tests/test_prg_engine_control_flow_concurrency_and_critical_sections.cpp
+++ b/tests/test_prg_engine_control_flow_concurrency_and_critical_sections.cpp
@@ -324,6 +324,66 @@ void test_spawn_task_supervision_observes_status_result_and_output_without_consu
     fs::remove_all(temp_root, ignored);
 }
 
+void test_spawn_task_supervision_serializes_same_handle_completion_publication() {
+    namespace fs = std::filesystem;
+    const fs::path temp_root =
+        fs::temp_directory_path() / "copperfin_prg_task_supervision_same_handle";
+    std::error_code ignored;
+    fs::remove_all(temp_root, ignored);
+    fs::create_directories(temp_root);
+
+    const fs::path main_path = temp_root / "task_supervision_same_handle_test.prg";
+    write_text(
+        main_path,
+        "PROCEDURE worker\n"
+        "    SLEEP 25\n"
+        "    ? 'published once'\n"
+        "    RETURN 42\n"
+        "ENDPROC\n"
+        "PROCEDURE watcher\n"
+        "    DO WHILE CFTASKSTATUS(nTarget) == 'running'\n"
+        "        YIELD\n"
+        "    ENDDO\n"
+        "    RETURN CFTASKRESULT(nTarget)\n"
+        "ENDPROC\n"
+        "SPAWN worker TO nTarget\n"
+        "SPAWN watcher TO nWatcherOne\n"
+        "SPAWN watcher TO nWatcherTwo\n"
+        "AWAIT nWatcherOne TO lWatcherOneDone\n"
+        "AWAIT nWatcherTwo TO lWatcherTwoDone\n"
+        "nRetainedResult = CFTASKRESULT(nTarget)\n"
+        "cRetainedOutput = CFTASKOUTPUT(nTarget)\n"
+        "AWAIT nTarget TO lTargetDone\n"
+        "RETURN\n");
+
+    copperfin::runtime::PrgRuntimeSession session =
+        copperfin::runtime::PrgRuntimeSession::create(
+            make_runtime_session_options(main_path.string(), temp_root.string(), false));
+    const auto state = session.run(copperfin::runtime::DebugResumeAction::continue_run);
+    expect(state.completed,
+           "same-handle task-supervision script should complete: " + state.message);
+
+    const auto watcher_one_done = state.globals.find("lwatcheronedone");
+    const auto watcher_two_done = state.globals.find("lwatchertwodone");
+    const auto retained_result = state.globals.find("nretainedresult");
+    const auto retained_output = state.globals.find("cretainedoutput");
+    const auto target_done = state.globals.find("ltargetdone");
+    expect(watcher_one_done != state.globals.end() && watcher_one_done->second.boolean_value,
+           "the first sibling watcher should complete");
+    expect(watcher_two_done != state.globals.end() && watcher_two_done->second.boolean_value,
+           "the second sibling watcher should complete");
+    expect(retained_result != state.globals.end() &&
+               copperfin::runtime::format_value(retained_result->second) == "42",
+           "concurrent watchers should retain the target result without corruption");
+    expect(retained_output != state.globals.end() &&
+               retained_output->second.string_value == "published once",
+           "concurrent watchers should retain the target output without corruption");
+    expect(target_done != state.globals.end() && target_done->second.boolean_value,
+           "the target should remain awaitable after concurrent supervision");
+
+    fs::remove_all(temp_root, ignored);
+}
+
 void test_spawn_task_supervision_requests_cooperative_cancellation() {
     namespace fs = std::filesystem;
     const fs::path temp_root = fs::temp_directory_path() / "copperfin_prg_task_supervision_cancel";

--- a/tests/test_prg_engine_control_flow_support.h
+++ b/tests/test_prg_engine_control_flow_support.h
@@ -137,6 +137,7 @@ void test_sleep_command_emits_runtime_sleep_event();
 void test_sleep_duration_uses_heap_backed_frame_continuations();
 void test_spawn_and_await_command_runs_task_to_completion();
 void test_spawn_task_supervision_observes_status_result_and_output_without_consuming_task();
+void test_spawn_task_supervision_serializes_same_handle_completion_publication();
 void test_spawn_task_supervision_requests_cooperative_cancellation();
 void test_spawn_arguments_use_heap_backed_frame_continuations();
 void test_spawn_cancellation_propagates_to_sibling_tasks();


### PR DESCRIPTION
## Summary

- serialize one-time `RuntimePauseState` publication with a mutex owned by each asynchronous task
- preserve nonblocking `CFTASK*()` behavior and independent scheduling for unrelated tasks
- add an end-to-end PRG regression with two sibling watchers polling one target handle
- record the corrective concurrency and ThreadSanitizer evidence

## Validation

- GCC `test_prg_engine_control_flow`: pass
- GCC package-document install, native-isolation contract, and control-flow selection: 3/3 pass
- Clang 21 ThreadSanitizer full `test_prg_engine_control_flow`: pass in 382.70 seconds with no race or deadlock finding
- `git diff --check`: pass

## Scope

This is a synchronization-only correction prompted by an independently reproduced same-handle completion-publication race. It does not change task handles, status values, cooperative cancellation, retained result/output, `AWAIT` consumption, artifact admission, external execution, or interop scope.
