### PR TITLE
Capture bounded artifact process output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   the admitted prefix, returns invariant `output-limit-exceeded` status with a
   stream-specific machine error, and closes the entire owned process tree.
   Dedicated concurrent readers prevent either pipe from blocking the other.
+  POSIX readers use nonblocking drains plus an explicit shutdown signal, so a
+  retained writer cannot make capture wait indefinitely after tree shutdown.
   Timeout and cooperative cancellation retain bytes emitted before shutdown.
   Windows uses an explicit process handle list so enabling capture inherits
   only null stdin and the two pipe writers, not unrelated agent/host handles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
   checks are clean. This slice does not authorize or hash an artifact, write a
   request, validate the captured envelope, choose a route, apply fallback,
   expose PRG dispatch, or connect any external language runtime.
+  Exact candidate head `93350a1a6` passes Linux Native `31334334063` and macOS
+  Native `31334334101` at `331/331`, the macOS four-locale SET POINT matrix at
+  `8/8`, and Windows Native `31334334089` at `330/330`;
+  `test_bounded_process` passes on every platform. All eight candidate-head
+  protected checks pass.
 
 - 2026-08-09: Extended the bounded native PRG payload facade with
   `CFHMACSHA256()` and `CFHMACVERIFY()`. Exact binary key/data bytes produce

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+- 2026-08-09: Extended the #4700 bounded artifact-process prerequisite with
+  exact-byte stdout and stderr capture. Independent positive budgets default to
+  1 MiB and cannot exceed the fixed 16 MiB hard ceiling; overflow retains only
+  the admitted prefix, returns invariant `output-limit-exceeded` status with a
+  stream-specific machine error, and closes the entire owned process tree.
+  Dedicated concurrent readers prevent either pipe from blocking the other.
+  Timeout and cooperative cancellation retain bytes emitted before shutdown.
+  Windows uses an explicit process handle list so enabling capture inherits
+  only null stdin and the two pipe writers, not unrelated agent/host handles.
+  Focused GCC, Clang 21 ASan/UBSan, and Clang 21 ThreadSanitizer runs pass; the
+  GCC regression also passes 20 consecutive executions, and focused analyzer
+  checks are clean. This slice does not authorize or hash an artifact, write a
+  request, validate the captured envelope, choose a route, apply fallback,
+  expose PRG dispatch, or connect any external language runtime.
+
 - 2026-08-09: Extended the bounded native PRG payload facade with
   `CFHMACSHA256()` and `CFHMACVERIFY()`. Exact binary key/data bytes produce
   canonical lowercase HMAC-SHA256; verification admits only 64 lowercase hex

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,36 @@
 # Agent Handoff
 
+## V1 bounded artifact-process output-capture candidate
+
+The approved #4700 transport prerequisite now captures exact stdout and stderr
+bytes from the already-bounded child process. Each stream has an independent
+positive budget, defaults to 1 MiB, and is capped at a non-disableable 16 MiB.
+The result retains each admitted prefix separately. Crossing a limit returns
+invariant `output-limit-exceeded` plus
+`polyglot.process.stdout_limit_exceeded` or
+`polyglot.process.stderr_limit_exceeded`, terminates the owned job/process
+group, and preserves the existing descendant-cleanup guarantee. Timeout and
+cancellation retain bytes emitted before shutdown.
+
+The two streams are drained concurrently so a candidate cannot deadlock the
+parent by filling one pipe while the other is read. Windows creates the root
+suspended and uses `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`: the child receives
+only null stdin and the stdout/stderr pipe writers before job assignment and
+resume. It does not inherit other host or agent handles. POSIX duplicates only
+the two writers onto standard output/error and retains the close-on-exec launch
+status pipe. Capture-reader creation and read failures fail closed.
+
+Focused `test_bounded_process` passes under GCC and repeats successfully 20
+times. It separately proves embedded-NUL/high-byte/newline and CRLF capture,
+256 KiB simultaneous stream saturation, stdout and stderr overflow, retained
+pre-cancellation/pre-timeout output, and invalid-budget rejection while
+retaining the existing argv/environment/tree tests. Clang 21 ASan/UBSan and
+ThreadSanitizer runs pass without findings, and focused analyzer checks are
+clean. Hosted native evidence is still required. No artifact authorization,
+hashing, request transport, envelope admission, route selection, fallback,
+telemetry, PRG dispatch, or external-language adapter is added; the runtime
+stub inventory is unchanged.
+
 ## V1 PRG HMAC payload-authentication candidate
 
 The approved native parity pack now adds `CFHMACSHA256()` and

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -18,7 +18,9 @@ suspended and uses `PROC_THREAD_ATTRIBUTE_HANDLE_LIST`: the child receives
 only null stdin and the stdout/stderr pipe writers before job assignment and
 resume. It does not inherit other host or agent handles. POSIX duplicates only
 the two writers onto standard output/error and retains the close-on-exec launch
-status pipe. Capture-reader creation and read failures fail closed.
+status pipe. Its readers drain nonblocking and honor an explicit parent shutdown
+signal, preventing a retained pipe writer from making process cleanup wait
+indefinitely. Capture-reader creation and read failures fail closed.
 
 Focused `test_bounded_process` passes under GCC and repeats successfully 20
 times. It separately proves embedded-NUL/high-byte/newline and CRLF capture,

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -28,10 +28,13 @@ times. It separately proves embedded-NUL/high-byte/newline and CRLF capture,
 pre-cancellation/pre-timeout output, and invalid-budget rejection while
 retaining the existing argv/environment/tree tests. Clang 21 ASan/UBSan and
 ThreadSanitizer runs pass without findings, and focused analyzer checks are
-clean. Hosted native evidence is still required. No artifact authorization,
-hashing, request transport, envelope admission, route selection, fallback,
-telemetry, PRG dispatch, or external-language adapter is added; the runtime
-stub inventory is unchanged.
+clean. Exact candidate head `93350a1a6` passes Linux Native `31334334063` and
+macOS Native `31334334101` at `331/331`, the macOS four-locale SET POINT
+matrix at `8/8`, and Windows Native `31334334089` at `330/330`;
+`test_bounded_process` passes on every platform. All eight candidate-head
+protected checks pass. No artifact authorization, hashing, request transport,
+envelope admission, route selection, fallback, telemetry, PRG dispatch, or
+external-language adapter is added; the runtime stub inventory is unchanged.
 
 ## V1 PRG HMAC payload-authentication candidate
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -367,7 +367,11 @@ before shutdown. POSIX nonblocking drains honor an explicit shutdown signal so
 a retained writer cannot stall capture cleanup. Windows restricts inherited
 handles to null stdin and the two pipe writers. Focused GCC, Clang 21
 ASan/UBSan, ThreadSanitizer, 20-run stress,
-and analyzer evidence passes locally; hosted native evidence remains required.
+and analyzer evidence passes locally. At exact candidate head `93350a1a6`,
+Linux Native `31334334063` and macOS Native `31334334101` pass `331/331`,
+macOS also passes the four-locale SET POINT matrix at `8/8`, and Windows Native
+`31334334089` passes `330/330`; all three execute `test_bounded_process`
+successfully. All eight candidate-head protected checks pass.
 These slices still do not authorize/hash an artifact, write a request, validate
 captured envelopes, implement fallback/telemetry, select a route, or connect
 external code to PRG execution.

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -363,8 +363,10 @@ stdout and stderr bytes under independent 1 MiB defaults and fixed 16 MiB hard
 ceilings. Concurrent readers prevent cross-stream pipe deadlock; overflow
 retains the admitted prefix, returns a stream-specific invariant failure, and
 closes the owned descendant tree. Timeout and cancellation retain bytes emitted
-before shutdown. Windows restricts inherited handles to null stdin and the two
-pipe writers. Focused GCC, Clang 21 ASan/UBSan, ThreadSanitizer, 20-run stress,
+before shutdown. POSIX nonblocking drains honor an explicit shutdown signal so
+a retained writer cannot stall capture cleanup. Windows restricts inherited
+handles to null stdin and the two pipe writers. Focused GCC, Clang 21
+ASan/UBSan, ThreadSanitizer, 20-run stress,
 and analyzer evidence passes locally; hosted native evidence remains required.
 These slices still do not authorize/hash an artifact, write a request, validate
 captured envelopes, implement fallback/telemetry, select a route, or connect

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -358,9 +358,17 @@ ASan/UBSan evidence passes locally. At exact implementation/test head
 `36f25b1e5`, Linux Native run `31284210937` passes `324/324`, macOS Native run
 `31284210940` passes `324/324` plus the existing four-locale matrix, and
 Windows Native run `31284210974` passes `323/323`; all three execute the
-bounded-process regression. This slice does not yet
-authorize/hash an artifact, validate envelopes, capture output, implement
-fallback/telemetry, select a route, or connect external code to PRG execution.
+bounded-process regression. The adjacent v1 transport slice now captures exact
+stdout and stderr bytes under independent 1 MiB defaults and fixed 16 MiB hard
+ceilings. Concurrent readers prevent cross-stream pipe deadlock; overflow
+retains the admitted prefix, returns a stream-specific invariant failure, and
+closes the owned descendant tree. Timeout and cancellation retain bytes emitted
+before shutdown. Windows restricts inherited handles to null stdin and the two
+pipe writers. Focused GCC, Clang 21 ASan/UBSan, ThreadSanitizer, 20-run stress,
+and analyzer evidence passes locally; hosted native evidence remains required.
+These slices still do not authorize/hash an artifact, write a request, validate
+captured envelopes, implement fallback/telemetry, select a route, or connect
+external code to PRG execution.
 
 The next #91/#4700 bridge prerequisite now validates versioned candidate
 response envelopes before downstream use. Success and error shapes are

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -22,8 +22,9 @@ Current maturity:
 - .NET integration currently exists as an early generated-launcher path: the native runtime pipeline can spawn a generated C# stub as a child process, but generated C# transpilation output is not executed by the runtime host.
 - A portable bounded-process primitive now provides direct executable/argument
   invocation, an explicit child environment, timeout and cancellation handling,
-  and descendant cleanup. It is infrastructure for a future artifact adapter,
-  not a runtime route or language integration by itself.
+  descendant cleanup, and independently bounded exact-byte stdout/stderr
+  capture. It is infrastructure for a future artifact adapter, not a runtime
+  route or language integration by itself.
 - A portable serializer now emits the versioned invocation request in fixed,
   compact field order after strict identity and arguments-object admission; the
   matching response parser admits only the checked-in success/error shapes.
@@ -129,6 +130,16 @@ failure. Both paths poll a finite timeout and a prompt cancellation callback, fa
 closed if that callback throws, return invariant status/error identifiers, and remove
 descendants after timeout, cancellation, launch failure, or normal root exit.
 
+Standard output and error are captured independently as exact bytes. Each positive
+budget defaults to 1 MiB and cannot exceed the fixed 16 MiB hard ceiling. Dedicated
+readers drain both streams concurrently so filling one pipe cannot prevent the other
+from making progress. An overflow retains only that stream's admitted prefix, returns
+`output-limit-exceeded` with `polyglot.process.stdout_limit_exceeded` or
+`polyglot.process.stderr_limit_exceeded`, and closes the complete owned tree. Timeout
+and cancellation retain bytes captured before shutdown. Windows restricts inherited
+handles with `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` to null stdin and the two pipe writers;
+unrelated inheritable host/agent handles remain outside the child.
+
 Focused synthetic tests cover exact exit status, shell-metacharacter arguments, a
 Unicode working path and environment value, absence of ambient `PATH`, live and
 throwing cancellation, timeout cleanup, cleanup after normal root exit, missing
@@ -141,10 +152,17 @@ executes this regression. The earlier macOS textual-path assertion was corrected
 compare filesystem identity for equivalent `/var` and `/private/var` spellings without
 weakening exact argv, Unicode environment, or ambient-`PATH` isolation coverage.
 
+The capture extension adds exact binary/CRLF tests, 256 KiB simultaneous stream
+saturation, independent overflow, retained pre-timeout/pre-cancellation bytes, and
+invalid output budgets. Focused GCC passes and repeats 20 times; Clang 21 ASan/UBSan
+and ThreadSanitizer pass without findings, and focused analyzer checks are clean.
+Hosted Linux/macOS/Windows native evidence remains required for this extension.
+
 This primitive does **not** authorize or hash an artifact, validate migration
-contracts or typed envelopes, capture standard output/error, implement retries or
-fallback, choose a route, emit migration telemetry, or connect any external language
-to the PRG runtime. Those remain separately reviewable adapter and dispatch work.
+contracts or typed envelopes, write a request to the child, validate captured output,
+implement retries or fallback, choose a route, emit migration telemetry, or connect any
+external language to the PRG runtime. Those remain separately reviewable adapter and
+dispatch work.
 
 ## Invocation Request Serialization v1
 

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -138,7 +138,9 @@ from making progress. An overflow retains only that stream's admitted prefix, re
 `polyglot.process.stderr_limit_exceeded`, and closes the complete owned tree. Timeout
 and cancellation retain bytes captured before shutdown. Windows restricts inherited
 handles with `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` to null stdin and the two pipe writers;
-unrelated inheritable host/agent handles remain outside the child.
+unrelated inheritable host/agent handles remain outside the child. POSIX readers drain
+nonblocking and accept an explicit shutdown signal, so a retained writer cannot make
+capture cleanup wait indefinitely.
 
 Focused synthetic tests cover exact exit status, shell-metacharacter arguments, a
 Unicode working path and environment value, absence of ambient `PATH`, live and

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -158,7 +158,10 @@ The capture extension adds exact binary/CRLF tests, 256 KiB simultaneous stream
 saturation, independent overflow, retained pre-timeout/pre-cancellation bytes, and
 invalid output budgets. Focused GCC passes and repeats 20 times; Clang 21 ASan/UBSan
 and ThreadSanitizer pass without findings, and focused analyzer checks are clean.
-Hosted Linux/macOS/Windows native evidence remains required for this extension.
+Exact candidate head `93350a1a6` passes Linux Native `31334334063` and macOS
+Native `31334334101` at `331/331`, the macOS four-locale SET POINT matrix at
+`8/8`, and Windows Native `31334334089` at `330/330`; the bounded-process
+regression passes on every platform. All eight candidate-head protected checks pass.
 
 This primitive does **not** authorize or hash an artifact, validate migration
 contracts or typed envelopes, write a request to the child, validate captured output,

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -328,6 +328,12 @@ cooperative cancellation, retained return values, and completed print output.
 Per-task completion publication is synchronized and directly exercised by two
 sibling supervisors polling the same handle under ThreadSanitizer; unrelated
 tasks remain independently scheduled.
+The portable external-process prerequisite now captures exact stdout/stderr
+bytes under independent fixed ceilings while preserving timeout, cancellation,
+and complete descendant cleanup. Cross-stream drainers prevent pipe deadlock,
+and Windows restricts inherited handles to the three explicit standard handles.
+This is transport evidence only: captured bytes are not yet tied to an admitted
+artifact, request, route, or PRG dispatch.
 It also exposes bounded native JSON validation, type inspection, and JSON
 Pointer selection so PRG can examine immutable structured completion payloads
 without embedding foreign source or losing exact number spelling.

--- a/include/copperfin/platform/bounded_process.h
+++ b/include/copperfin/platform/bounded_process.h
@@ -15,6 +15,7 @@ enum class BoundedProcessStatus {
     exited,
     cancelled,
     timed_out,
+    output_limit_exceeded,
     invalid_request,
     launch_failed
 };
@@ -33,6 +34,10 @@ struct BoundedProcessRequest {
     std::vector<BoundedProcessEnvironmentVariable> environment;
     std::uint32_t timeout_ms = 5000U;
     std::uint32_t poll_interval_ms = 10U;
+    // Output is captured as exact bytes. Limits must be positive and cannot
+    // exceed the implementation hard ceiling.
+    std::uint32_t stdout_limit_bytes = 1024U * 1024U;
+    std::uint32_t stderr_limit_bytes = 1024U * 1024U;
     // Must return promptly. true, or an exception, fails closed as cancellation.
     std::function<bool()> cancellation_requested;
 };
@@ -45,6 +50,8 @@ struct BoundedProcessResult {
     int native_error = 0;
     std::uint64_t elapsed_ms = 0U;
     std::string error_code = "polyglot.process.invalid_request";
+    std::string standard_output;
+    std::string standard_error;
 
     [[nodiscard]] bool completed() const noexcept {
         return status == BoundedProcessStatus::exited;
@@ -52,9 +59,10 @@ struct BoundedProcessResult {
 };
 
 // Starts an absolute executable directly without a shell, polls cancellation
-// while it runs, and owns one process group/job. Paths and arguments containing
-// NUL are rejected. Closing the invocation always removes descendants so an
-// artifact cannot leave helpers behind after returning.
+// while it runs, captures stdout/stderr under fixed byte ceilings, and owns one
+// process group/job. Paths and arguments containing NUL are rejected. Closing
+// the invocation always removes descendants so an artifact cannot leave helpers
+// behind after returning.
 [[nodiscard]] BoundedProcessResult run_bounded_process(
     const BoundedProcessRequest& request);
 

--- a/src/platform/bounded_process.cpp
+++ b/src/platform/bounded_process.cpp
@@ -143,6 +143,7 @@ bool valid_environment(
 
 struct CapturedStreamState {
     std::atomic_bool limit_exceeded{false};
+    std::atomic_bool stop_requested{false};
     std::atomic_int native_error{0};
 };
 
@@ -712,9 +713,11 @@ bool create_posix_capture_pipe(int descriptors[2]) {
     if (::pipe(descriptors) != 0) {
         return false;
     }
-    const int flags = ::fcntl(descriptors[1], F_GETFD, 0);
-    if (flags == -1 ||
-        ::fcntl(descriptors[1], F_SETFD, flags | FD_CLOEXEC) == -1) {
+    const int read_flags = ::fcntl(descriptors[0], F_GETFL, 0);
+    const int write_flags = ::fcntl(descriptors[1], F_GETFD, 0);
+    if (read_flags == -1 || write_flags == -1 ||
+        ::fcntl(descriptors[0], F_SETFL, read_flags | O_NONBLOCK) == -1 ||
+        ::fcntl(descriptors[1], F_SETFD, write_flags | FD_CLOEXEC) == -1) {
         const int pipe_error = errno;
         (void)::close(descriptors[0]);
         (void)::close(descriptors[1]);
@@ -735,6 +738,13 @@ void read_posix_capture_pipe(
     for (;;) {
         const ssize_t count = ::read(descriptor, buffer, sizeof(buffer));
         if (count < 0 && errno == EINTR) {
+            continue;
+        }
+        if (count < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            if (state.stop_requested.load(std::memory_order_acquire)) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1U));
             continue;
         }
         if (count < 0) {
@@ -865,6 +875,8 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
     std::thread stdout_thread;
     std::thread stderr_thread;
     const auto finish_capture = [&]() {
+        stdout_state.stop_requested.store(true, std::memory_order_release);
+        stderr_state.stop_requested.store(true, std::memory_order_release);
         if (stdout_thread.joinable()) {
             stdout_thread.join();
         }

--- a/src/platform/bounded_process.cpp
+++ b/src/platform/bounded_process.cpp
@@ -7,6 +7,7 @@
 #include "copperfin/platform/path.h"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cerrno>
 #include <cstdint>
@@ -36,6 +37,8 @@
 
 namespace copperfin::platform {
 namespace {
+
+constexpr std::uint32_t kMaximumCapturedOutputBytes = 16U * 1024U * 1024U;
 
 #if defined(_WIN32)
 constexpr DWORD kTerminationWaitMilliseconds = 5000U;
@@ -138,6 +141,51 @@ bool valid_environment(
     return true;
 }
 
+struct CapturedStreamState {
+    std::atomic_bool limit_exceeded{false};
+    std::atomic_int native_error{0};
+};
+
+void append_captured_bytes(
+    std::string& output,
+    const char* bytes,
+    const std::size_t count,
+    const std::uint32_t limit,
+    CapturedStreamState& state) {
+    const std::size_t remaining =
+        static_cast<std::size_t>(limit) - output.size();
+    const std::size_t accepted = std::min(count, remaining);
+    output.append(bytes, accepted);
+    if (accepted != count) {
+        state.limit_exceeded.store(true, std::memory_order_release);
+    }
+}
+
+bool apply_capture_failure(
+    const CapturedStreamState& stdout_state,
+    const CapturedStreamState& stderr_state,
+    BoundedProcessResult& result) {
+    if (stdout_state.limit_exceeded.load(std::memory_order_acquire)) {
+        result.status = BoundedProcessStatus::output_limit_exceeded;
+        result.error_code = "polyglot.process.stdout_limit_exceeded";
+        return true;
+    }
+    if (stderr_state.limit_exceeded.load(std::memory_order_acquire)) {
+        result.status = BoundedProcessStatus::output_limit_exceeded;
+        result.error_code = "polyglot.process.stderr_limit_exceeded";
+        return true;
+    }
+    const int stdout_error = stdout_state.native_error.load(std::memory_order_acquire);
+    const int stderr_error = stderr_state.native_error.load(std::memory_order_acquire);
+    if (stdout_error != 0 || stderr_error != 0) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.output_read_failed";
+        result.native_error = stdout_error != 0 ? stdout_error : stderr_error;
+        return true;
+    }
+    return false;
+}
+
 #if defined(_WIN32)
 
 std::wstring utf8_to_wide(const std::string& value, int& native_error) {
@@ -213,6 +261,53 @@ bool wait_for_terminated_process(
     return false;
 }
 
+bool create_windows_capture_pipe(HANDLE& read_handle, HANDLE& write_handle) {
+    SECURITY_ATTRIBUTES attributes{};
+    attributes.nLength = sizeof(attributes);
+    attributes.bInheritHandle = TRUE;
+    if (::CreatePipe(&read_handle, &write_handle, &attributes, 0U) == FALSE) {
+        return false;
+    }
+    if (::SetHandleInformation(read_handle, HANDLE_FLAG_INHERIT, 0U) == FALSE) {
+        const DWORD error = ::GetLastError();
+        (void)::CloseHandle(read_handle);
+        (void)::CloseHandle(write_handle);
+        read_handle = nullptr;
+        write_handle = nullptr;
+        ::SetLastError(error);
+        return false;
+    }
+    return true;
+}
+
+void read_windows_capture_pipe(
+    const HANDLE read_handle,
+    std::string& output,
+    const std::uint32_t limit,
+    CapturedStreamState& state) {
+    char buffer[8192];
+    for (;;) {
+        DWORD read = 0U;
+        if (::ReadFile(
+                read_handle, buffer, static_cast<DWORD>(sizeof(buffer)),
+                &read, nullptr) == FALSE) {
+            const DWORD error = ::GetLastError();
+            if (error != ERROR_BROKEN_PIPE) {
+                state.native_error.store(static_cast<int>(error), std::memory_order_release);
+            }
+            break;
+        }
+        if (read == 0U) {
+            break;
+        }
+        append_captured_bytes(output, buffer, static_cast<std::size_t>(read), limit, state);
+        if (state.limit_exceeded.load(std::memory_order_acquire)) {
+            break;
+        }
+    }
+    (void)::CloseHandle(read_handle);
+}
+
 BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
     BoundedProcessResult result;
     const auto started_at = Clock::now();
@@ -282,11 +377,54 @@ BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
         environment_block.push_back(L'\0');
     }
 
+    HANDLE stdout_read = nullptr;
+    HANDLE stdout_write = nullptr;
+    HANDLE stderr_read = nullptr;
+    HANDLE stderr_write = nullptr;
+    if (!create_windows_capture_pipe(stdout_read, stdout_write) ||
+        !create_windows_capture_pipe(stderr_read, stderr_write)) {
+        const int pipe_error = static_cast<int>(::GetLastError());
+        if (stdout_read != nullptr) {
+            (void)::CloseHandle(stdout_read);
+            (void)::CloseHandle(stdout_write);
+        }
+        if (stderr_read != nullptr) {
+            (void)::CloseHandle(stderr_read);
+            (void)::CloseHandle(stderr_write);
+        }
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.output_pipe_failed";
+        result.native_error = pipe_error;
+        return result;
+    }
+
+    SECURITY_ATTRIBUTES input_attributes{};
+    input_attributes.nLength = sizeof(input_attributes);
+    input_attributes.bInheritHandle = TRUE;
+    const HANDLE null_input = ::CreateFileW(
+        L"NUL", GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
+        &input_attributes, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (null_input == INVALID_HANDLE_VALUE) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.output_pipe_failed";
+        result.native_error = static_cast<int>(::GetLastError());
+        (void)::CloseHandle(stdout_read);
+        (void)::CloseHandle(stdout_write);
+        (void)::CloseHandle(stderr_read);
+        (void)::CloseHandle(stderr_write);
+        return result;
+    }
+
     const HANDLE job = ::CreateJobObjectW(nullptr, nullptr);
     if (job == nullptr) {
         result.status = BoundedProcessStatus::launch_failed;
         result.error_code = "polyglot.process.job_create_failed";
         result.native_error = static_cast<int>(::GetLastError());
+        (void)::CloseHandle(null_input);
+        (void)::CloseHandle(stdout_read);
+        (void)::CloseHandle(stdout_write);
+        (void)::CloseHandle(stderr_read);
+        (void)::CloseHandle(stderr_write);
         return result;
     }
     JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits{};
@@ -300,31 +438,103 @@ BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
         result.error_code = "polyglot.process.job_configure_failed";
         result.native_error = static_cast<int>(::GetLastError());
         (void)::CloseHandle(job);
+        (void)::CloseHandle(null_input);
+        (void)::CloseHandle(stdout_read);
+        (void)::CloseHandle(stdout_write);
+        (void)::CloseHandle(stderr_read);
+        (void)::CloseHandle(stderr_write);
         return result;
     }
 
-    STARTUPINFOW startup_info{};
-    startup_info.cb = sizeof(startup_info);
+    STARTUPINFOEXW startup_info{};
+    startup_info.StartupInfo.cb = sizeof(startup_info);
+    startup_info.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    startup_info.StartupInfo.hStdInput = null_input;
+    startup_info.StartupInfo.hStdOutput = stdout_write;
+    startup_info.StartupInfo.hStdError = stderr_write;
+    SIZE_T attribute_bytes = 0U;
+    const BOOL attribute_sizing =
+        ::InitializeProcThreadAttributeList(nullptr, 1U, 0U, &attribute_bytes);
+    const DWORD attribute_sizing_error = ::GetLastError();
+    if (attribute_sizing != FALSE ||
+        attribute_sizing_error != ERROR_INSUFFICIENT_BUFFER || attribute_bytes == 0U) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.output_pipe_failed";
+        result.native_error = static_cast<int>(
+            attribute_sizing_error == ERROR_SUCCESS
+                ? ERROR_INVALID_PARAMETER
+                : attribute_sizing_error);
+        (void)::CloseHandle(job);
+        (void)::CloseHandle(null_input);
+        (void)::CloseHandle(stdout_read);
+        (void)::CloseHandle(stdout_write);
+        (void)::CloseHandle(stderr_read);
+        (void)::CloseHandle(stderr_write);
+        return result;
+    }
+    std::vector<std::uint8_t> attribute_storage(attribute_bytes);
+    startup_info.lpAttributeList = reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(
+        attribute_storage.data());
+    HANDLE inherited_handles[]{null_input, stdout_write, stderr_write};
+    if (::InitializeProcThreadAttributeList(
+            startup_info.lpAttributeList, 1U, 0U, &attribute_bytes) == FALSE ||
+        ::UpdateProcThreadAttribute(
+            startup_info.lpAttributeList, 0U, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+            inherited_handles, sizeof(inherited_handles), nullptr, nullptr) == FALSE) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.output_pipe_failed";
+        result.native_error = static_cast<int>(::GetLastError());
+        if (startup_info.lpAttributeList != nullptr) {
+            ::DeleteProcThreadAttributeList(startup_info.lpAttributeList);
+        }
+        (void)::CloseHandle(job);
+        (void)::CloseHandle(null_input);
+        (void)::CloseHandle(stdout_read);
+        (void)::CloseHandle(stdout_write);
+        (void)::CloseHandle(stderr_read);
+        (void)::CloseHandle(stderr_write);
+        return result;
+    }
     PROCESS_INFORMATION process_info{};
     const BOOL created = ::CreateProcessW(
         executable.c_str(),
         command_line.data(),
         nullptr,
         nullptr,
-        FALSE,
-        CREATE_NO_WINDOW | CREATE_SUSPENDED | CREATE_UNICODE_ENVIRONMENT,
+        TRUE,
+        CREATE_NO_WINDOW | CREATE_SUSPENDED | CREATE_UNICODE_ENVIRONMENT |
+            EXTENDED_STARTUPINFO_PRESENT,
         environment_block.data(),
         working_directory.c_str(),
-        &startup_info,
+        &startup_info.StartupInfo,
         &process_info);
+    const DWORD create_error = created == FALSE ? ::GetLastError() : ERROR_SUCCESS;
+    ::DeleteProcThreadAttributeList(startup_info.lpAttributeList);
+    (void)::CloseHandle(null_input);
+    (void)::CloseHandle(stdout_write);
+    (void)::CloseHandle(stderr_write);
     if (created == FALSE) {
         result.status = BoundedProcessStatus::launch_failed;
         result.error_code = "polyglot.process.launch_failed";
-        result.native_error = static_cast<int>(::GetLastError());
+        result.native_error = static_cast<int>(create_error);
         (void)::CloseHandle(job);
+        (void)::CloseHandle(stdout_read);
+        (void)::CloseHandle(stderr_read);
         return result;
     }
     result.started = true;
+    CapturedStreamState stdout_state;
+    CapturedStreamState stderr_state;
+    std::thread stdout_thread;
+    std::thread stderr_thread;
+    const auto finish_capture = [&]() {
+        if (stdout_thread.joinable()) {
+            stdout_thread.join();
+        }
+        if (stderr_thread.joinable()) {
+            stderr_thread.join();
+        }
+    };
     if (::AssignProcessToJobObject(job, process_info.hProcess) == FALSE) {
         result.status = BoundedProcessStatus::launch_failed;
         result.error_code = "polyglot.process.job_assign_failed";
@@ -338,6 +548,38 @@ BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
         (void)::CloseHandle(process_info.hThread);
         (void)::CloseHandle(process_info.hProcess);
         (void)::CloseHandle(job);
+        (void)::CloseHandle(stdout_read);
+        (void)::CloseHandle(stderr_read);
+        result.process_tree_closed = true;
+        result.elapsed_ms = elapsed_milliseconds(started_at);
+        return result;
+    }
+    try {
+        stdout_thread = std::thread(
+            read_windows_capture_pipe, stdout_read, std::ref(result.standard_output),
+            request.stdout_limit_bytes, std::ref(stdout_state));
+        stderr_thread = std::thread(
+            read_windows_capture_pipe, stderr_read, std::ref(result.standard_error),
+            request.stderr_limit_bytes, std::ref(stderr_state));
+    } catch (...) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.output_reader_create_failed";
+        if (::TerminateJobObject(job, 1U) == FALSE &&
+            ::TerminateProcess(process_info.hProcess, 1U) == FALSE) {
+            result.error_code = "polyglot.process.tree_termination_failed";
+            result.native_error = static_cast<int>(::GetLastError());
+        }
+        (void)::CloseHandle(job);
+        (void)wait_for_terminated_process(process_info.hProcess, result);
+        if (!stdout_thread.joinable()) {
+            (void)::CloseHandle(stdout_read);
+        }
+        if (!stderr_thread.joinable()) {
+            (void)::CloseHandle(stderr_read);
+        }
+        finish_capture();
+        (void)::CloseHandle(process_info.hThread);
+        (void)::CloseHandle(process_info.hProcess);
         result.process_tree_closed = true;
         result.elapsed_ms = elapsed_milliseconds(started_at);
         return result;
@@ -355,6 +597,8 @@ BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
         (void)::CloseHandle(process_info.hThread);
         (void)::CloseHandle(process_info.hProcess);
         (void)::CloseHandle(job);
+        finish_capture();
+        (void)apply_capture_failure(stdout_state, stderr_state, result);
         result.process_tree_closed = true;
         result.elapsed_ms = elapsed_milliseconds(started_at);
         return result;
@@ -398,6 +642,17 @@ BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
             result.process_tree_closed = true;
             break;
         }
+        if (apply_capture_failure(stdout_state, stderr_state, result)) {
+            if (::TerminateJobObject(job, 1U) == FALSE) {
+                result.status = BoundedProcessStatus::launch_failed;
+                result.error_code = "polyglot.process.tree_termination_failed";
+                result.native_error = static_cast<int>(::GetLastError());
+            } else {
+                (void)wait_for_terminated_process(process_info.hProcess, result);
+            }
+            result.process_tree_closed = true;
+            break;
+        }
         if (elapsed_milliseconds(started_at) >= request.timeout_ms) {
             result.status = BoundedProcessStatus::timed_out;
             result.error_code = "polyglot.process.timeout";
@@ -418,6 +673,10 @@ BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
     (void)::CloseHandle(job);
     result.process_tree_closed = true;
     (void)::CloseHandle(process_info.hProcess);
+    finish_capture();
+    if (result.status == BoundedProcessStatus::exited) {
+        (void)apply_capture_failure(stdout_state, stderr_state, result);
+    }
     result.elapsed_ms = elapsed_milliseconds(started_at);
     return result;
 }
@@ -449,6 +708,51 @@ void terminate_process_group(const pid_t process_id) {
     (void)::kill(process_id, SIGKILL);
 }
 
+bool create_posix_capture_pipe(int descriptors[2]) {
+    if (::pipe(descriptors) != 0) {
+        return false;
+    }
+    const int flags = ::fcntl(descriptors[1], F_GETFD, 0);
+    if (flags == -1 ||
+        ::fcntl(descriptors[1], F_SETFD, flags | FD_CLOEXEC) == -1) {
+        const int pipe_error = errno;
+        (void)::close(descriptors[0]);
+        (void)::close(descriptors[1]);
+        descriptors[0] = -1;
+        descriptors[1] = -1;
+        errno = pipe_error;
+        return false;
+    }
+    return true;
+}
+
+void read_posix_capture_pipe(
+    const int descriptor,
+    std::string& output,
+    const std::uint32_t limit,
+    CapturedStreamState& state) {
+    char buffer[8192];
+    for (;;) {
+        const ssize_t count = ::read(descriptor, buffer, sizeof(buffer));
+        if (count < 0 && errno == EINTR) {
+            continue;
+        }
+        if (count < 0) {
+            state.native_error.store(errno, std::memory_order_release);
+            break;
+        }
+        if (count == 0) {
+            break;
+        }
+        append_captured_bytes(
+            output, buffer, static_cast<std::size_t>(count), limit, state);
+        if (state.limit_exceeded.load(std::memory_order_acquire)) {
+            break;
+        }
+    }
+    (void)::close(descriptor);
+}
+
 BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
     BoundedProcessResult result;
     const auto started_at = Clock::now();
@@ -467,6 +771,25 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
         (void)::close(launch_pipe[1]);
         return result;
     }
+    int stdout_pipe[2]{-1, -1};
+    int stderr_pipe[2]{-1, -1};
+    if (!create_posix_capture_pipe(stdout_pipe) ||
+        !create_posix_capture_pipe(stderr_pipe)) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.output_pipe_failed";
+        result.native_error = errno;
+        (void)::close(launch_pipe[0]);
+        (void)::close(launch_pipe[1]);
+        if (stdout_pipe[0] != -1) {
+            (void)::close(stdout_pipe[0]);
+            (void)::close(stdout_pipe[1]);
+        }
+        if (stderr_pipe[0] != -1) {
+            (void)::close(stderr_pipe[0]);
+            (void)::close(stderr_pipe[1]);
+        }
+        return result;
+    }
     const int read_flags = ::fcntl(launch_pipe[0], F_GETFL, 0);
     if (read_flags == -1 ||
         ::fcntl(launch_pipe[0], F_SETFL, read_flags | O_NONBLOCK) == -1) {
@@ -475,6 +798,10 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
         result.native_error = errno;
         (void)::close(launch_pipe[0]);
         (void)::close(launch_pipe[1]);
+        (void)::close(stdout_pipe[0]);
+        (void)::close(stdout_pipe[1]);
+        (void)::close(stderr_pipe[0]);
+        (void)::close(stderr_pipe[1]);
         return result;
     }
 
@@ -504,25 +831,47 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
     const pid_t process_id = ::fork();
     if (process_id == 0) {
         (void)::close(launch_pipe[0]);
-        if (::setpgid(0, 0) != 0 ||
+        (void)::close(stdout_pipe[0]);
+        (void)::close(stderr_pipe[0]);
+        if (::dup2(stdout_pipe[1], STDOUT_FILENO) == -1 ||
+            ::dup2(stderr_pipe[1], STDERR_FILENO) == -1 ||
+            ::setpgid(0, 0) != 0 ||
             ::chdir(request.working_directory.c_str()) != 0) {
             const int child_error = errno;
             (void)write_child_error(launch_pipe[1], child_error);
             _exit(127);
         }
+        (void)::close(stdout_pipe[1]);
+        (void)::close(stderr_pipe[1]);
         ::execve(request.executable_path.c_str(), argv.data(), environment.data());
         const int child_error = errno;
         (void)write_child_error(launch_pipe[1], child_error);
         _exit(127);
     }
     (void)::close(launch_pipe[1]);
+    (void)::close(stdout_pipe[1]);
+    (void)::close(stderr_pipe[1]);
     if (process_id < 0) {
         result.status = BoundedProcessStatus::launch_failed;
         result.error_code = "polyglot.process.launch_failed";
         result.native_error = errno;
         (void)::close(launch_pipe[0]);
+        (void)::close(stdout_pipe[0]);
+        (void)::close(stderr_pipe[0]);
         return result;
     }
+    CapturedStreamState stdout_state;
+    CapturedStreamState stderr_state;
+    std::thread stdout_thread;
+    std::thread stderr_thread;
+    const auto finish_capture = [&]() {
+        if (stdout_thread.joinable()) {
+            stdout_thread.join();
+        }
+        if (stderr_thread.joinable()) {
+            stderr_thread.join();
+        }
+    };
     if (::setpgid(process_id, process_id) != 0 && errno != EACCES && errno != ESRCH) {
         result.status = BoundedProcessStatus::launch_failed;
         result.error_code = "polyglot.process.group_create_failed";
@@ -531,6 +880,33 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
         int ignored_status = 0;
         (void)::waitpid(process_id, &ignored_status, 0);
         (void)::close(launch_pipe[0]);
+        (void)::close(stdout_pipe[0]);
+        (void)::close(stderr_pipe[0]);
+        result.process_tree_closed = true;
+        result.elapsed_ms = elapsed_milliseconds(started_at);
+        return result;
+    }
+    try {
+        stdout_thread = std::thread(
+            read_posix_capture_pipe, stdout_pipe[0], std::ref(result.standard_output),
+            request.stdout_limit_bytes, std::ref(stdout_state));
+        stderr_thread = std::thread(
+            read_posix_capture_pipe, stderr_pipe[0], std::ref(result.standard_error),
+            request.stderr_limit_bytes, std::ref(stderr_state));
+    } catch (...) {
+        result.status = BoundedProcessStatus::launch_failed;
+        result.error_code = "polyglot.process.output_reader_create_failed";
+        terminate_process_group(process_id);
+        int ignored_status = 0;
+        (void)::waitpid(process_id, &ignored_status, 0);
+        (void)::close(launch_pipe[0]);
+        if (!stdout_thread.joinable()) {
+            (void)::close(stdout_pipe[0]);
+        }
+        if (!stderr_thread.joinable()) {
+            (void)::close(stderr_pipe[0]);
+        }
+        finish_capture();
         result.process_tree_closed = true;
         result.elapsed_ms = elapsed_milliseconds(started_at);
         return result;
@@ -568,6 +944,17 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
             result.process_tree_closed = true;
             result.elapsed_ms = elapsed_milliseconds(started_at);
             (void)::close(launch_pipe[0]);
+            finish_capture();
+            return result;
+        }
+        if (apply_capture_failure(stdout_state, stderr_state, result)) {
+            terminate_process_group(process_id);
+            int ignored_status = 0;
+            (void)::waitpid(process_id, &ignored_status, 0);
+            result.process_tree_closed = true;
+            result.elapsed_ms = elapsed_milliseconds(started_at);
+            (void)::close(launch_pipe[0]);
+            finish_capture();
             return result;
         }
         if (elapsed_milliseconds(started_at) >= request.timeout_ms) {
@@ -579,6 +966,7 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
             result.process_tree_closed = true;
             result.elapsed_ms = elapsed_milliseconds(started_at);
             (void)::close(launch_pipe[0]);
+            finish_capture();
             return result;
         }
         std::this_thread::sleep_for(
@@ -596,6 +984,7 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
         (void)::waitpid(process_id, &ignored_status, 0);
         result.process_tree_closed = true;
         result.elapsed_ms = elapsed_milliseconds(started_at);
+        finish_capture();
         return result;
     }
     result.started = true;
@@ -628,6 +1017,11 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
             (void)::waitpid(process_id, &status, 0);
             break;
         }
+        if (apply_capture_failure(stdout_state, stderr_state, result)) {
+            terminate_process_group(process_id);
+            (void)::waitpid(process_id, &status, 0);
+            break;
+        }
         if (elapsed_milliseconds(started_at) >= request.timeout_ms) {
             result.status = BoundedProcessStatus::timed_out;
             result.error_code = "polyglot.process.timeout";
@@ -643,6 +1037,10 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
     // artifact is a bounded call, never a daemon-launch boundary.
     terminate_process_group(process_id);
     result.process_tree_closed = true;
+    finish_capture();
+    if (result.status == BoundedProcessStatus::exited) {
+        (void)apply_capture_failure(stdout_state, stderr_state, result);
+    }
     result.elapsed_ms = elapsed_milliseconds(started_at);
     return result;
 }
@@ -658,6 +1056,9 @@ BoundedProcessResult run_bounded_process(const BoundedProcessRequest& request) {
         !valid_arguments(request.arguments) ||
         request.timeout_ms == 0U || request.poll_interval_ms == 0U ||
         request.poll_interval_ms > request.timeout_ms ||
+        request.stdout_limit_bytes == 0U || request.stderr_limit_bytes == 0U ||
+        request.stdout_limit_bytes > kMaximumCapturedOutputBytes ||
+        request.stderr_limit_bytes > kMaximumCapturedOutputBytes ||
         !valid_environment(request.environment)) {
         return invalid_request();
     }
@@ -700,6 +1101,8 @@ const char* bounded_process_status_name(const BoundedProcessStatus status) noexc
         return "cancelled";
     case BoundedProcessStatus::timed_out:
         return "timed-out";
+    case BoundedProcessStatus::output_limit_exceeded:
+        return "output-limit-exceeded";
     case BoundedProcessStatus::invalid_request:
         return "invalid-request";
     case BoundedProcessStatus::launch_failed:

--- a/src/platform/bounded_process.cpp
+++ b/src/platform/bounded_process.cpp
@@ -287,24 +287,31 @@ void read_windows_capture_pipe(
     const std::uint32_t limit,
     CapturedStreamState& state) {
     char buffer[8192];
-    for (;;) {
-        DWORD read = 0U;
-        if (::ReadFile(
-                read_handle, buffer, static_cast<DWORD>(sizeof(buffer)),
-                &read, nullptr) == FALSE) {
-            const DWORD error = ::GetLastError();
-            if (error != ERROR_BROKEN_PIPE) {
-                state.native_error.store(static_cast<int>(error), std::memory_order_release);
+    try {
+        for (;;) {
+            DWORD read = 0U;
+            if (::ReadFile(
+                    read_handle, buffer, static_cast<DWORD>(sizeof(buffer)),
+                    &read, nullptr) == FALSE) {
+                const DWORD error = ::GetLastError();
+                if (error != ERROR_BROKEN_PIPE) {
+                    state.native_error.store(
+                        static_cast<int>(error), std::memory_order_release);
+                }
+                break;
             }
-            break;
+            if (read == 0U) {
+                break;
+            }
+            append_captured_bytes(
+                output, buffer, static_cast<std::size_t>(read), limit, state);
+            if (state.limit_exceeded.load(std::memory_order_acquire)) {
+                break;
+            }
         }
-        if (read == 0U) {
-            break;
-        }
-        append_captured_bytes(output, buffer, static_cast<std::size_t>(read), limit, state);
-        if (state.limit_exceeded.load(std::memory_order_acquire)) {
-            break;
-        }
+    } catch (...) {
+        state.native_error.store(
+            static_cast<int>(ERROR_NOT_ENOUGH_MEMORY), std::memory_order_release);
     }
     (void)::CloseHandle(read_handle);
 }
@@ -735,30 +742,34 @@ void read_posix_capture_pipe(
     const std::uint32_t limit,
     CapturedStreamState& state) {
     char buffer[8192];
-    for (;;) {
-        const ssize_t count = ::read(descriptor, buffer, sizeof(buffer));
-        if (count < 0 && errno == EINTR) {
-            continue;
-        }
-        if (count < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
-            if (state.stop_requested.load(std::memory_order_acquire)) {
+    try {
+        for (;;) {
+            const ssize_t count = ::read(descriptor, buffer, sizeof(buffer));
+            if (count < 0 && errno == EINTR) {
+                continue;
+            }
+            if (count < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+                if (state.stop_requested.load(std::memory_order_acquire)) {
+                    break;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(1U));
+                continue;
+            }
+            if (count < 0) {
+                state.native_error.store(errno, std::memory_order_release);
                 break;
             }
-            std::this_thread::sleep_for(std::chrono::milliseconds(1U));
-            continue;
+            if (count == 0) {
+                break;
+            }
+            append_captured_bytes(
+                output, buffer, static_cast<std::size_t>(count), limit, state);
+            if (state.limit_exceeded.load(std::memory_order_acquire)) {
+                break;
+            }
         }
-        if (count < 0) {
-            state.native_error.store(errno, std::memory_order_release);
-            break;
-        }
-        if (count == 0) {
-            break;
-        }
-        append_captured_bytes(
-            output, buffer, static_cast<std::size_t>(count), limit, state);
-        if (state.limit_exceeded.load(std::memory_order_acquire)) {
-            break;
-        }
+    } catch (...) {
+        state.native_error.store(ENOMEM, std::memory_order_release);
     }
     (void)::close(descriptor);
 }

--- a/tests/test_bounded_process.cpp
+++ b/tests/test_bounded_process.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstdio>
 #include <exception>
 #include <filesystem>
 #include <fstream>
@@ -24,6 +25,8 @@
 #endif
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <fcntl.h>
+#include <io.h>
 #else
 #include <sys/types.h>
 #include <unistd.h>
@@ -51,6 +54,13 @@ void expect(const bool condition, const std::string& message) {
 void write_marker(const std::filesystem::path& path, const std::string& value) {
     std::ofstream output(path, std::ios::binary | std::ios::trunc);
     output << value;
+}
+
+void configure_binary_standard_streams() {
+#if defined(_WIN32)
+    (void)::_setmode(::_fileno(stdout), _O_BINARY);
+    (void)::_setmode(::_fileno(stderr), _O_BINARY);
+#endif
 }
 
 #if defined(_WIN32)
@@ -141,6 +151,7 @@ int run_helper(
         return 0;
     }
     if (arguments[0] == "--emit" && arguments.size() == 1U) {
+        configure_binary_standard_streams();
         const std::string stdout_bytes{"out\0\xFF\n", 6U};
         const std::string stderr_bytes{"err\r\n", 5U};
         std::cout.write(stdout_bytes.data(), static_cast<std::streamsize>(stdout_bytes.size()));
@@ -148,6 +159,7 @@ int run_helper(
         return 0;
     }
     if (arguments[0] == "--flood" && arguments.size() == 3U) {
+        configure_binary_standard_streams();
         std::ostream& output = arguments[1] == "stdout" ? std::cout : std::cerr;
         const std::size_t count = static_cast<std::size_t>(std::stoul(arguments[2]));
         const std::string block(8192U, arguments[1] == "stdout" ? 'O' : 'E');
@@ -161,6 +173,7 @@ int run_helper(
         return 0;
     }
     if (arguments[0] == "--flood-both" && arguments.size() == 2U) {
+        configure_binary_standard_streams();
         const std::size_t count = static_cast<std::size_t>(std::stoul(arguments[1]));
         const std::string stdout_block(4096U, 'O');
         const std::string stderr_block(4096U, 'E');
@@ -177,6 +190,7 @@ int run_helper(
     }
     if (arguments[0] == "--emit-sleep" &&
         (arguments.size() == 2U || arguments.size() == 3U)) {
+        configure_binary_standard_streams();
         std::cout << "before-wait" << std::flush;
         std::cerr << "diagnostic" << std::flush;
         if (arguments.size() == 3U) {

--- a/tests/test_bounded_process.cpp
+++ b/tests/test_bounded_process.cpp
@@ -6,6 +6,7 @@
 #include "copperfin/platform/environment.h"
 #include "copperfin/platform/path.h"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <exception>
@@ -139,6 +140,47 @@ int run_helper(
         std::this_thread::sleep_for(std::chrono::milliseconds(std::stoi(arguments[1])));
         return 0;
     }
+    if (arguments[0] == "--emit" && arguments.size() == 1U) {
+        const std::string stdout_bytes{"out\0\xFF\n", 6U};
+        const std::string stderr_bytes{"err\r\n", 5U};
+        std::cout.write(stdout_bytes.data(), static_cast<std::streamsize>(stdout_bytes.size()));
+        std::cerr.write(stderr_bytes.data(), static_cast<std::streamsize>(stderr_bytes.size()));
+        return 0;
+    }
+    if (arguments[0] == "--flood" && arguments.size() == 3U) {
+        std::ostream& output = arguments[1] == "stdout" ? std::cout : std::cerr;
+        const std::size_t count = static_cast<std::size_t>(std::stoul(arguments[2]));
+        const std::string block(8192U, arguments[1] == "stdout" ? 'O' : 'E');
+        std::size_t written = 0U;
+        while (written < count) {
+            const std::size_t next = std::min(block.size(), count - written);
+            output.write(block.data(), static_cast<std::streamsize>(next));
+            output.flush();
+            written += next;
+        }
+        return 0;
+    }
+    if (arguments[0] == "--flood-both" && arguments.size() == 2U) {
+        const std::size_t count = static_cast<std::size_t>(std::stoul(arguments[1]));
+        const std::string stdout_block(4096U, 'O');
+        const std::string stderr_block(4096U, 'E');
+        std::size_t written = 0U;
+        while (written < count) {
+            const std::size_t next = std::min(stdout_block.size(), count - written);
+            std::cout.write(stdout_block.data(), static_cast<std::streamsize>(next));
+            std::cout.flush();
+            std::cerr.write(stderr_block.data(), static_cast<std::streamsize>(next));
+            std::cerr.flush();
+            written += next;
+        }
+        return 0;
+    }
+    if (arguments[0] == "--emit-sleep" && arguments.size() == 2U) {
+        std::cout << "before-wait" << std::flush;
+        std::cerr << "diagnostic" << std::flush;
+        std::this_thread::sleep_for(std::chrono::milliseconds(std::stoi(arguments[1])));
+        return 0;
+    }
     if (arguments[0] == "--grandchild" && arguments.size() == 2U) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1200));
         write_marker(copperfin::platform::path_from_utf8_string(arguments[1]), "orphaned");
@@ -191,6 +233,82 @@ int run_tests(const std::filesystem::path& executable) {
            "#4700: direct invocation should preserve the candidate exit code");
     expect(exited.process_tree_closed && exited.error_code == "polyglot.process.exited",
            "#4700: normal completion should close the owned process tree");
+    expect(exited.standard_output.empty() && exited.standard_error.empty(),
+           "#4700: a silent candidate should capture empty output streams");
+
+    const auto emitted = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {"--emit"},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 2000U,
+        .poll_interval_ms = 5U,
+        .stdout_limit_bytes = 1024U,
+        .stderr_limit_bytes = 1024U,
+        .cancellation_requested = {}});
+    expect(emitted.completed() && emitted.exit_code == 0,
+           "#4700: exact-byte output helper should complete");
+    expect(emitted.standard_output == std::string{"out\0\xFF\n", 6U},
+           "#4700: stdout capture should preserve NUL, high-byte, and newline bytes");
+    expect(emitted.standard_error == std::string{"err\r\n", 5U},
+           "#4700: stderr capture should preserve exact CRLF bytes separately");
+
+    constexpr std::uint32_t saturation_bytes = 256U * 1024U;
+    const auto saturated = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {"--flood-both", std::to_string(saturation_bytes)},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 5000U,
+        .poll_interval_ms = 5U,
+        .stdout_limit_bytes = saturation_bytes,
+        .stderr_limit_bytes = saturation_bytes,
+        .cancellation_requested = {}});
+    expect(saturated.completed() && saturated.exit_code == 0,
+           "#4700: concurrent stdout/stderr pipe saturation should not deadlock");
+    expect(saturated.standard_output == std::string(saturation_bytes, 'O') &&
+               saturated.standard_error == std::string(saturation_bytes, 'E'),
+           "#4700: saturation capture should retain both streams exactly to their limits");
+
+    const auto stdout_overflow = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {"--flood", "stdout", "65536"},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 5000U,
+        .poll_interval_ms = 5U,
+        .stdout_limit_bytes = 4096U,
+        .stderr_limit_bytes = 4096U,
+        .cancellation_requested = {}});
+    expect(
+        stdout_overflow.status ==
+                copperfin::platform::BoundedProcessStatus::output_limit_exceeded &&
+            stdout_overflow.error_code == "polyglot.process.stdout_limit_exceeded" &&
+            stdout_overflow.standard_output == std::string(4096U, 'O') &&
+            stdout_overflow.process_tree_closed,
+        "#4700: stdout overflow should retain only the admitted prefix and close the tree");
+    expect(
+        std::string{copperfin::platform::bounded_process_status_name(
+            stdout_overflow.status)} == "output-limit-exceeded",
+        "#4700: output-limit status text should remain invariant");
+
+    const auto stderr_overflow = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {"--flood", "stderr", "65536"},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 5000U,
+        .poll_interval_ms = 5U,
+        .stdout_limit_bytes = 4096U,
+        .stderr_limit_bytes = 4096U,
+        .cancellation_requested = {}});
+    expect(
+        stderr_overflow.status ==
+                copperfin::platform::BoundedProcessStatus::output_limit_exceeded &&
+            stderr_overflow.error_code == "polyglot.process.stderr_limit_exceeded" &&
+            stderr_overflow.standard_error == std::string(4096U, 'E') &&
+            stderr_overflow.process_tree_closed,
+        "#4700: stderr overflow should retain only the admitted prefix and close the tree");
 
     const fs::path record_path = root / "record.txt";
     const auto recorded = copperfin::platform::run_bounded_process({
@@ -234,7 +352,7 @@ int run_tests(const std::filesystem::path& executable) {
     std::atomic_int cancellation_polls{0};
     const auto cancelled = copperfin::platform::run_bounded_process({
         .executable_path = executable_path,
-        .arguments = {"--sleep", "2000"},
+        .arguments = {"--emit-sleep", "2000"},
         .working_directory = root_path,
         .environment = {},
         .timeout_ms = 3000U,
@@ -247,6 +365,26 @@ int run_tests(const std::filesystem::path& executable) {
            "#4700: live cancellation should stop the owned process tree");
     expect(cancelled.elapsed_ms < 1000U,
            "#4700: cancellation should not wait for the candidate sleep to finish");
+    expect(cancelled.standard_output == "before-wait" &&
+               cancelled.standard_error == "diagnostic",
+           "#4700: cancellation should retain exact bytes captured before tree shutdown");
+
+    const auto output_timed_out = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {"--emit-sleep", "2000"},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 100U,
+        .poll_interval_ms = 5U,
+        .stdout_limit_bytes = 1024U,
+        .stderr_limit_bytes = 1024U,
+        .cancellation_requested = {}});
+    expect(
+        output_timed_out.status == copperfin::platform::BoundedProcessStatus::timed_out &&
+            output_timed_out.process_tree_closed &&
+            output_timed_out.standard_output == "before-wait" &&
+            output_timed_out.standard_error == "diagnostic",
+        "#4700: timeout should retain bounded bytes emitted before tree shutdown");
 
     std::atomic_int throwing_cancellation_polls{0};
     const auto callback_failed = copperfin::platform::run_bounded_process({
@@ -338,6 +476,38 @@ int run_tests(const std::filesystem::path& executable) {
     expect(invalid.status == copperfin::platform::BoundedProcessStatus::invalid_request &&
                !invalid.started,
            "#4700: a zero execution budget should be rejected");
+
+    const auto zero_output_limit = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 100U,
+        .poll_interval_ms = 1U,
+        .stdout_limit_bytes = 0U,
+        .stderr_limit_bytes = 1024U,
+        .cancellation_requested = {}});
+    expect(
+        zero_output_limit.status ==
+                copperfin::platform::BoundedProcessStatus::invalid_request &&
+            !zero_output_limit.started,
+        "#4700: a zero output budget should reject before launch");
+
+    const auto excessive_output_limit = copperfin::platform::run_bounded_process({
+        .executable_path = executable_path,
+        .arguments = {},
+        .working_directory = root_path,
+        .environment = {},
+        .timeout_ms = 100U,
+        .poll_interval_ms = 1U,
+        .stdout_limit_bytes = 1024U,
+        .stderr_limit_bytes = 16U * 1024U * 1024U + 1U,
+        .cancellation_requested = {}});
+    expect(
+        excessive_output_limit.status ==
+                copperfin::platform::BoundedProcessStatus::invalid_request &&
+            !excessive_output_limit.started,
+        "#4700: an above-hard-ceiling output budget should reject before launch");
 
     const auto invalid_environment = copperfin::platform::run_bounded_process({
         .executable_path = executable_path,

--- a/tests/test_bounded_process.cpp
+++ b/tests/test_bounded_process.cpp
@@ -175,9 +175,14 @@ int run_helper(
         }
         return 0;
     }
-    if (arguments[0] == "--emit-sleep" && arguments.size() == 2U) {
+    if (arguments[0] == "--emit-sleep" &&
+        (arguments.size() == 2U || arguments.size() == 3U)) {
         std::cout << "before-wait" << std::flush;
         std::cerr << "diagnostic" << std::flush;
+        if (arguments.size() == 3U) {
+            write_marker(
+                copperfin::platform::path_from_utf8_string(arguments[2]), "flushed");
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds(std::stoi(arguments[1])));
         return 0;
     }
@@ -349,16 +354,19 @@ int run_tests(const std::filesystem::path& executable) {
         record_suffix_matches && !equivalent_error && working_directory_matches,
         "#4700: argv, working directory, and explicit environment should survive without shell parsing or ambient PATH inheritance");
 
-    std::atomic_int cancellation_polls{0};
+    const fs::path output_flushed_marker = root / "output-flushed.txt";
     const auto cancelled = copperfin::platform::run_bounded_process({
         .executable_path = executable_path,
-        .arguments = {"--emit-sleep", "2000"},
+        .arguments = {
+            "--emit-sleep", "2000",
+            copperfin::platform::path_to_utf8_string(output_flushed_marker)},
         .working_directory = root_path,
         .environment = {},
         .timeout_ms = 3000U,
         .poll_interval_ms = 10U,
-        .cancellation_requested = [&cancellation_polls]() {
-            return cancellation_polls.fetch_add(1) >= 3;
+        .cancellation_requested = [&output_flushed_marker]() {
+            std::error_code marker_error;
+            return fs::exists(output_flushed_marker, marker_error) && !marker_error;
         }});
     expect(cancelled.status == copperfin::platform::BoundedProcessStatus::cancelled &&
                cancelled.started && cancelled.process_tree_closed,


### PR DESCRIPTION
## What changed

- capture child stdout and stderr as separate exact-byte strings
- enforce independent positive 1 MiB defaults and fixed 16 MiB hard ceilings
- terminate the complete owned process tree on stream overflow while retaining only the admitted prefix
- drain both streams concurrently to prevent cross-pipe deadlock
- use nonblocking POSIX drains with an explicit shutdown signal so a retained writer cannot stall cleanup
- restrict Windows inheritance to null stdin and the two explicit pipe writers
- retain output emitted before timeout or cooperative cancellation
- document the transport contract and its explicit nonclaims

## Why

The existing #4700 process boundary could contain a child and the existing envelope boundary could validate already-captured bytes, but there was no bounded transport between them. This supplies that prerequisite without authorizing an artifact or exposing external execution to PRG.

## Validation

- GCC: `test_package_document_install`, `test_native_test_isolation_contract`, and `test_bounded_process` pass 3/3
- GCC: `test_bounded_process` passes 20 consecutive executions
- Clang 21 ASan/UBSan: focused target passes
- Clang 21 ThreadSanitizer: focused target passes with no race or deadlock finding
- Clang analyzer: no finding
- exact product/test candidate `93350a1a6`: Linux Native `31334334063` and macOS Native `31334334101` pass 331/331; macOS locales pass 8/8
- exact product/test candidate `93350a1a6`: Windows Native `31334334089` passes 330/330
- `test_bounded_process` passes in all three hosted native matrices
- all eight protected checks pass on both the exact product/test candidate and the final evidence-only head
- `git diff --check`

## Deliberate nonclaims

This PR does not authorize or hash an artifact, write the invocation request, validate the captured response envelope, select a route, apply fallback or telemetry, expose PRG dispatch, or connect any external language runtime.
