### PR TITLE
Fix POSIX Studio launch failure reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+- 2026-08-09: Began the macOS/Linux standalone-host portability lane by making
+  Studio command-launch failure reporting invariant across native platforms.
+  POSIX now uses `posix_spawnp`, so a missing or otherwise unlaunchable
+  executable returns `-1` like the existing Windows `CreateProcessW` path,
+  while a real child that exits with status 127 remains distinguishable as
+  `127`. Direct argument transport, `PATH` lookup, inherited environment,
+  EINTR-safe wait/reap behavior, ordinary exit status, signal mapping, and the
+  Windows implementation remain unchanged. Focused GCC Release and Clang 21
+  ASan/UBSan tests pass, and static analysis reports no finding. Exact
+  product/test head `d08c1aa61` passes Linux Native `31344376346` and macOS
+  Native `31344376360` at `331/331`, the macOS four-locale SET POINT matrix at
+  `8/8`, and Windows Native `31344376357` at `330/330`;
+  `test_studio_host_shell_command` passes on every platform. All eight
+  candidate-head protected checks pass. Broader macOS/Linux standalone-host
+  functionality remains open.
+
 - 2026-08-09: Extended the #4700 bounded artifact-process transport with exact
   caller-supplied stdin bytes under an independent 1 MiB default and fixed
   16 MiB hard ceiling. A dedicated writer runs concurrently with both output

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,31 @@
 # Agent Handoff
 
+## V1 POSIX Studio launch-failure parity candidate
+
+The first bounded macOS/Linux standalone-host portability seam is complete at
+exact product/test head `d08c1aa61`. The POSIX Studio command runner now uses
+`posix_spawnp`, allowing the parent to distinguish failure to start an
+executable (`-1`) from a real child that returns status 127 (`127`). Windows
+continues to use its unchanged `CreateProcessW` path and the same `-1`
+pre-start-failure contract. Direct argv bytes, `PATH` search, the inherited
+environment, EINTR-safe wait/reap behavior, ordinary exit values, and
+`128 + signal` mapping remain unchanged.
+
+Focused `test_studio_host_shell_command` passes under GCC Release and Clang 21
+ASan/UBSan; focused static analysis reports no finding. A clean local contract
+selection passes `test_package_document_install`,
+`test_native_test_isolation_contract`, and the focused regression at `3/3`.
+Exact-head Linux Native `31344376346` and macOS Native `31344376360` pass
+`331/331`; macOS also passes the four-locale SET POINT matrix at `8/8`.
+Windows Native `31344376357` passes `330/330`. The focused regression passes on
+all three hosts, and all eight candidate-head protected checks pass. Windows
+annotations are pre-existing warnings in unchanged runtime and launcher
+sources, with none in this slice's implementation or test.
+
+This is focused launch-contract evidence, not completion of the broader macOS
+or Linux standalone-host ports. No user-facing string, localization catalog,
+package contract, runtime behavior, or external-language integration changed.
+
 ## V1 bounded artifact-process request transport candidate
 
 The approved #4700 transport prerequisite now delivers exact caller-supplied

--- a/apps/copperfin_studio_host/studio_host_main_shell_command.cpp
+++ b/apps/copperfin_studio_host/studio_host_main_shell_command.cpp
@@ -10,8 +10,14 @@
 #if defined(_WIN32)
 #include <windows.h>
 #else
+#include <spawn.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#if defined(__APPLE__)
+#include <crt_externs.h>
+#else
+extern char** environ;
+#endif
 #endif
 
 namespace cf_studio_host_main_detail {
@@ -176,19 +182,28 @@ int execute_launch_command(const std::string& launch_command, const std::vector<
     launch_arguments.push_back(launch_command);
     launch_arguments.insert(launch_arguments.end(), arguments.begin(), arguments.end());
 
-    std::vector<const char*> argv;
+    std::vector<char*> argv;
     argv.reserve(launch_arguments.size() + 1U);
-    for (const auto& argument : launch_arguments) {
-        argv.push_back(argument.c_str());
+    for (auto& argument : launch_arguments) {
+        argv.push_back(argument.data());
     }
     argv.push_back(nullptr);
 
-    const pid_t child = fork();
-    if (child == 0) {
-        execvp(launch_command.c_str(), const_cast<char* const*>(argv.data()));
-        _exit(127);
-    }
-    if (child < 0) {
+    char* const* environment =
+#if defined(__APPLE__)
+        *_NSGetEnviron();
+#else
+        environ;
+#endif
+    pid_t child = 0;
+    const int spawn_result = posix_spawnp(
+        &child,
+        launch_command.c_str(),
+        nullptr,
+        nullptr,
+        argv.data(),
+        environment);
+    if (spawn_result != 0) {
         return -1;
     }
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -28,6 +28,16 @@ Each workstream has a subgoal tree with observable acceptance criteria:
 Completed workstreams are not revisited unless a regression, new compatibility
 evidence, or release-validation failure creates a new acceptance gap.
 
+The first bounded macOS/Linux standalone-host portability seam is now
+implemented at exact product/test head `d08c1aa61`. The POSIX Studio command
+runner reports a missing or unlaunchable executable as `-1`, matching the
+unchanged Windows pre-start-failure contract, while preserving a real child
+exit status of 127. Exact-head Linux Native `31344376346` and macOS Native
+`31344376360` pass `331/331`, the macOS four-locale SET POINT matrix passes
+`8/8`, and Windows Native `31344376357` passes `330/330`; the focused Studio
+host regression passes everywhere. This closes one launch-error seam, not the
+broader macOS or Linux standalone-host ports.
+
 Current .NET interop security work now has a fail-closed policy-context
 candidate: trusted host state must bind actor, verified policy, audit readiness,
 and exact capability scope before a managed route can be allowed. Reflection,
@@ -671,8 +681,9 @@ cover:
    boundary.)*
 5. Port standalone/core host behavior to macOS and Linux while preserving the
    portable native contracts. *(This is lane **J** — `J1`/`#35` portable core
-   boundary, `J2`/`#36` macOS port, `J3`/`#37` Linux port. Still open with no
-   shipped evidence as of this writing.)*
+   boundary, `J2`/`#36` macOS port, `J3`/`#37` Linux port. The first bounded
+   Studio launch-error seam is shipped with three-platform evidence; the
+   broader ports remain open.)*
 6. Build the requirements-to-code-to-test traceability matrix from validated
    VFP9 behavior, shipped documentation, and documented Copperfin exceptions.
    *(No lane letter was ever assigned. The durable matrix has begun in
@@ -719,7 +730,7 @@ standalone Studio shell, and FoxPro language-service layer."
 | G | `#112` (`G1`/`#27`, `G2`/`#28`, `G3`/`#29`) | FoxPro language service: semantic resolution, navigation/refactoring, IntelliSense metadata | Recorded G1/G2/G3 slices closed; broader MVP scope remains under the live tree | Phase C |
 | H | `#113` (`H1`/`#30`, `H2`/`#31`, `H3`/`#32`) | Relational backend translators, document/vector + AI planning, .NET/MCP/polyglot outputs | Contract/model foundation, bounded process, deterministic request serialization, and response admission implemented; artifact trust, transport, and PRG-controlled dispatch remain | v1 item 3 |
 | I | `#113` (`I1`/`#33`, `I2`/`#34`) | Runtime/project security depth, extension/host/AI-MCP security boundary | Seeded (see gap analysis) | v1 item 4 |
-| J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | Open, no shipped evidence | v1 item 5 |
+| J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | First Studio launch-error seam shipped; broader ports open | v1 item 5 |
 
 Current G1 evidence includes #4874 at product/test head `e70c89e87`: editor
 project-symbol discovery follows the unquoted `#INCLUDE` form used by the real

--- a/tests/test_studio_host_shell_command.cpp
+++ b/tests/test_studio_host_shell_command.cpp
@@ -107,6 +107,20 @@ void test_execute_launch_command_retries_interrupted_wait() {
     expect(exit_code == 0,
            "#4325: POSIX Studio-host should retry an EINTR wait and reap the child successfully");
 }
+
+void test_execute_launch_command_distinguishes_spawn_failure_from_exit_127() {
+    const int missing_exit_code = cf_studio_host_main_detail::execute_launch_command(
+        "/copperfin/missing/studio-host-tool",
+        {});
+    expect(missing_exit_code == -1,
+           "#196: POSIX Studio-host should report a missing executable as a launch failure");
+
+    const int child_exit_code = cf_studio_host_main_detail::execute_launch_command(
+        "/bin/sh",
+        {"-c", "exit 127"});
+    expect(child_exit_code == 127,
+           "#196: POSIX Studio-host should preserve an actual child exit code of 127");
+}
 #else
 void test_execute_launch_command_preserves_unicode_paths_and_percent_arguments() {
     namespace fs = std::filesystem;
@@ -168,6 +182,7 @@ int main(int argc, char** argv) {
 #if !defined(_WIN32)
     test_execute_launch_command_handles_paths_and_arguments_with_spaces();
     test_execute_launch_command_retries_interrupted_wait();
+    test_execute_launch_command_distinguishes_spawn_failure_from_exit_127();
 #else
     test_execute_launch_command_preserves_unicode_paths_and_percent_arguments();
 #endif


### PR DESCRIPTION
## What changed\n\n- replace the POSIX Studio-host fork/exec launch path with posix_spawnp\n- return the existing invariant -1 launch-failure result when the executable cannot be started\n- preserve a real child exit code of 127, ordinary exit and signal mappings, PATH lookup, inherited environment behavior, direct argument transport, and EINTR-safe wait/reap behavior\n- keep the Windows CreateProcessW path unchanged\n- record exact three-platform evidence and correct the stale portability-roadmap status\n\n## Why\n\nThe previous POSIX child converted execvp failure into exit 127, so callers could not distinguish a missing or unlaunchable tool from a real tool that intentionally returned 127. Windows already reports pre-start failure as -1.\n\n## Validation\n\nExact product/test candidate: d08c1aa610c0605ab05f48203cb4656a55d99545\n\n- Linux Native 31344376346: 331/331; focused test passed\n- macOS Native 31344376360: 331/331; focused test passed; locale matrix 8/8\n- Windows Native 31344376357: 330/330; focused test passed\n- all eight candidate-head protected checks: pass\n- GCC Release focused test: pass\n- Clang 21 ASan/UBSan focused test: pass\n- Clang 21 static analysis: no findings\n- clean local package-document, native-isolation, and focused selection: 3/3\n- git diff --check: pass\n\nWindows annotations are pre-existing warnings in unchanged runtime and launcher sources, with none in this slice implementation or test. Broader macOS/Linux standalone-host functionality remains open.\n\nAdvances #196.