### PR TITLE
Honor macOS process-root case semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+- 2026-08-09: Made POSIX external-process allowed-root containment follow the
+  containing filesystem's identity and case semantics. The executable's
+  canonical path prefix is now compared with the canonical allowed root using
+  filesystem equivalence instead of a raw UTF-8 string prefix. Empty,
+  unavailable, shorter, and sibling-prefix roots continue to fail closed;
+  case-equivalent existing roots are accepted only when the volume identifies
+  them as the same directory. Windows authorization behavior is unchanged.
+  Focused GCC Release tests pass `3/3`, the security regression repeats
+  `20/20`, Clang 21 ASan/UBSan passes, and focused static analysis reports no
+  finding. Exact product/test head `e36285163` passes Linux Native
+  `31348227285` and macOS Native `31348227298` at `331/331`; macOS also passes
+  the four-locale SET POINT matrix at `8/8`, and Windows Native `31348227289`
+  passes `330/330`; `test_security_controls` passes on every platform. All
+  eight candidate-head protected checks pass. Windows annotations are
+  pre-existing warnings in unchanged runtime sources. This closes one macOS
+  portable-core security seam, not the broader macOS or Linux ports.
+
 - 2026-08-09: Began the macOS/Linux standalone-host portability lane by making
   Studio command-launch failure reporting invariant across native platforms.
   POSIX now uses `posix_spawnp`, so a missing or otherwise unlaunchable

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,32 @@
 # Agent Handoff
 
+## V1 macOS external-process root identity candidate
+
+The next bounded macOS portable-core seam is complete at exact product/test
+head `e36285163`. POSIX external-process authorization now constructs the
+canonical executable prefix at the allowed root's component depth and requires
+that prefix to be filesystem-equivalent to the canonical allowed root. This
+replaces a raw UTF-8 string prefix comparison: an existing case-equivalent root
+works when the containing volume treats the spellings as identical, while a
+case-sensitive volume continues to reject the variant. Empty, unavailable,
+shorter, and sibling-prefix roots fail closed. The executable is still
+revalidated after authorization, and the Windows implementation is unchanged.
+
+The local GCC Release package, isolation, and focused security selection passes
+`3/3`; the focused regression repeats `20/20`. Clang 21 ASan/UBSan passes, and
+focused static analysis plus `git diff --check` report no finding. Exact-head
+Linux Native `31348227285` and macOS Native `31348227298` pass `331/331`, with
+`test_security_controls` passing on both. macOS also passes the four-locale SET
+POINT matrix at `8/8`. Windows Native `31348227289` passes `330/330`, including
+the focused regression. All eight candidate-head protected checks pass.
+Windows annotations are pre-existing warnings in unchanged runtime sources,
+with none in this slice's implementation or regression.
+
+This is one external-process root-identity seam, not completion of the broader
+macOS or Linux ports. It changes no user-facing string, localization catalog,
+public machine-readable contract, package format, runtime surface, artifact,
+or Windows behavior.
+
 ## V1 POSIX Studio launch-failure parity candidate
 
 The first bounded macOS/Linux standalone-host portability seam is complete at

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -28,15 +28,20 @@ Each workstream has a subgoal tree with observable acceptance criteria:
 Completed workstreams are not revisited unless a regression, new compatibility
 evidence, or release-validation failure creates a new acceptance gap.
 
-The first bounded macOS/Linux standalone-host portability seam is now
-implemented at exact product/test head `d08c1aa61`. The POSIX Studio command
-runner reports a missing or unlaunchable executable as `-1`, matching the
-unchanged Windows pre-start-failure contract, while preserving a real child
-exit status of 127. Exact-head Linux Native `31344376346` and macOS Native
-`31344376360` pass `331/331`, the macOS four-locale SET POINT matrix passes
-`8/8`, and Windows Native `31344376357` passes `330/330`; the focused Studio
-host regression passes everywhere. This closes one launch-error seam, not the
-broader macOS or Linux standalone-host ports.
+Two bounded portable-core seams are now implemented. At exact product/test head
+`d08c1aa61`, the POSIX Studio command runner reports a missing or unlaunchable
+executable as `-1`, matching the unchanged Windows pre-start-failure contract,
+while preserving a real child exit status of 127. At exact product/test head
+`e36285163`, POSIX external-process allowed-root containment uses canonical
+prefix construction and filesystem identity instead of raw UTF-8 string
+prefixes, so existing case-equivalent roots follow the containing volume's case
+semantics while empty, unavailable, shorter, and sibling roots fail closed.
+Linux Native `31348227285` and macOS Native `31348227298` pass `331/331` at the
+second seam, including its focused security regression; macOS also passes the
+four-locale SET POINT matrix at `8/8`, and Windows Native `31348227289` passes
+`330/330`. The focused security regression passes everywhere and Windows
+behavior is unchanged. These close focused launch-error and root-identity
+seams, not the broader macOS or Linux standalone-host ports.
 
 Current .NET interop security work now has a fail-closed policy-context
 candidate: trusted host state must bind actor, verified policy, audit readiness,
@@ -730,7 +735,7 @@ standalone Studio shell, and FoxPro language-service layer."
 | G | `#112` (`G1`/`#27`, `G2`/`#28`, `G3`/`#29`) | FoxPro language service: semantic resolution, navigation/refactoring, IntelliSense metadata | Recorded G1/G2/G3 slices closed; broader MVP scope remains under the live tree | Phase C |
 | H | `#113` (`H1`/`#30`, `H2`/`#31`, `H3`/`#32`) | Relational backend translators, document/vector + AI planning, .NET/MCP/polyglot outputs | Contract/model foundation, bounded process, deterministic request serialization, and response admission implemented; artifact trust, transport, and PRG-controlled dispatch remain | v1 item 3 |
 | I | `#113` (`I1`/`#33`, `I2`/`#34`) | Runtime/project security depth, extension/host/AI-MCP security boundary | Seeded (see gap analysis) | v1 item 4 |
-| J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | First Studio launch-error seam shipped; broader ports open | v1 item 5 |
+| J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | Studio launch-error and POSIX root-identity seams shipped; broader ports open | v1 item 5 |
 
 Current G1 evidence includes #4874 at product/test head `e70c89e87`: editor
 project-symbol discovery follows the unquoted `#INCLUDE` form used by the real

--- a/src/security/external_process_policy.cpp
+++ b/src/security/external_process_policy.cpp
@@ -289,13 +289,11 @@ std::string resolve_executable_from_path(const std::string& executable_name) {
     return {};
 }
 
-std::string path_to_utf8_generic_string(const std::filesystem::path& path) {
-    std::string result = copperfin::platform::path_to_utf8_string(path);
-    std::replace(result.begin(), result.end(), '\\', '/');
-    return result;
-}
-
 bool path_under_root(const std::filesystem::path& path, const std::filesystem::path& root) {
+    if (path.empty() || root.empty()) {
+        return false;
+    }
+
     std::error_code path_error;
     const auto canonical_path = std::filesystem::weakly_canonical(path, path_error);
     if (path_error) {
@@ -308,12 +306,23 @@ bool path_under_root(const std::filesystem::path& path, const std::filesystem::p
         return false;
     }
 
-    const auto path_string = path_to_utf8_generic_string(canonical_path);
-    std::string root_string = path_to_utf8_generic_string(canonical_root);
-    if (!root_string.empty() && root_string.back() != '/') {
-        root_string.push_back('/');
+    auto path_component = canonical_path.begin();
+    std::filesystem::path candidate_root;
+    for (auto root_component = canonical_root.begin();
+         root_component != canonical_root.end();
+         ++root_component, ++path_component) {
+        if (path_component == canonical_path.end()) {
+            return false;
+        }
+        candidate_root /= *path_component;
     }
-    return path_string == root_string || path_string.rfind(root_string, 0) == 0;
+
+    std::error_code equivalent_error;
+    return std::filesystem::equivalent(
+               candidate_root,
+               canonical_root,
+               equivalent_error) &&
+        !equivalent_error;
 }
 #endif
 

--- a/tests/test_security_controls.cpp
+++ b/tests/test_security_controls.cpp
@@ -826,6 +826,65 @@ void test_external_process_authorization_rejects_replacement() {
 
     fs::remove_all(temp_root, ignored);
 }
+
+void test_external_process_authorization_follows_posix_volume_case_semantics() {
+    namespace fs = std::filesystem;
+    const fs::path temp_root = fs::temp_directory_path() /
+        "copperfin_external_process_root_case_tests";
+    const fs::path allowed_root = temp_root / "AllowedRoot";
+    const fs::path fixture_path = allowed_root / "authorized-tool";
+    std::error_code ignored;
+    fs::remove_all(temp_root, ignored);
+    fs::create_directories(allowed_root, ignored);
+    fs::copy_file("/bin/sh", fixture_path, fs::copy_options::overwrite_existing, ignored);
+    if (ignored) {
+        expect(false, "#197: POSIX allowed-root case fixture should be created");
+        fs::remove_all(temp_root, ignored);
+        return;
+    }
+    fs::permissions(
+        fixture_path,
+        fs::perms::owner_exec | fs::perms::owner_read,
+        fs::perm_options::add,
+        ignored);
+
+    const copperfin::security::ExternalProcessPolicy exact_policy{
+        .executable_name = fixture_path.string(),
+        .allowed_path_roots = {allowed_root.string()},
+        .allowed_publishers = {},
+        .require_trusted_signature = false
+    };
+    expect(copperfin::security::authorize_external_process(exact_policy).allowed,
+           "#197: POSIX external-process policy should accept its exact allowed root");
+
+    const fs::path sibling_root = temp_root / "AllowedRoot-sibling";
+    const copperfin::security::ExternalProcessPolicy sibling_policy{
+        .executable_name = fixture_path.string(),
+        .allowed_path_roots = {sibling_root.string()},
+        .allowed_publishers = {},
+        .require_trusted_signature = false
+    };
+    expect(!copperfin::security::authorize_external_process(sibling_policy).allowed,
+           "#197: POSIX external-process policy should reject a sibling-prefix root");
+
+    const fs::path case_variant_root = temp_root / "aLLOWEDrOOT";
+    std::error_code equivalent_error;
+    const bool volume_is_case_insensitive =
+        fs::equivalent(case_variant_root, allowed_root, equivalent_error) &&
+        !equivalent_error;
+    const copperfin::security::ExternalProcessPolicy case_variant_policy{
+        .executable_name = fixture_path.string(),
+        .allowed_path_roots = {case_variant_root.string()},
+        .allowed_publishers = {},
+        .require_trusted_signature = false
+    };
+    const auto case_variant_authorization =
+        copperfin::security::authorize_external_process(case_variant_policy);
+    expect(case_variant_authorization.allowed == volume_is_case_insensitive,
+           "#197: POSIX allowed-root comparison should follow the containing volume's case semantics");
+
+    fs::remove_all(temp_root, ignored);
+}
 #endif
 
 #ifdef _WIN32
@@ -1306,6 +1365,7 @@ int main() {
     test_external_process_and_process_hardening_diagnostics();
 #ifndef _WIN32
     test_external_process_authorization_rejects_replacement();
+    test_external_process_authorization_follows_posix_volume_case_semantics();
 #endif
 #ifdef _WIN32
     test_external_process_policy_preserves_unicode_paths();


### PR DESCRIPTION
## What changed

- replace the POSIX external-process allowed-root raw UTF-8 prefix check with canonical filesystem-identity containment
- accept a case-variant existing root only when the containing filesystem reports it equivalent to the executable's canonical root prefix
- retain exact-case behavior on case-sensitive POSIX volumes
- reject empty roots, shorter paths, unavailable roots, and sibling-prefix roots
- keep Windows authorization and publisher/signature behavior unchanged

## Why

The previous POSIX check compared canonicalized paths as byte-string prefixes. That does not model the case-insensitive filesystem semantics commonly used by macOS volumes and can reject an allowed root that the filesystem itself identifies as the same directory.

## Validation

- GCC Release package-document, native-isolation, and security selection: 3/3
- GCC Release test_security_controls repeated: 20/20
- Clang 21 ASan/UBSan test_security_controls: pass
- Clang 21 static analysis: no findings
- git diff --check: pass
- Linux Native 31348227285: 331/331, focused regression passed
- macOS Native 31348227298: 331/331, focused regression passed, four-locale SET POINT matrix 8/8
- Windows Native 31348227289: 330/330, focused regression passed
- all eight product/test candidate-head protected checks passed

The macOS regression derives its expected result from filesystem identity, so it remains correct on either case-sensitive or case-insensitive macOS volumes. Windows annotations are pre-existing warnings in unchanged runtime sources, with none in this slice's implementation or regression.

Closes #197.
