### PR TITLE
Add fail-closed polyglot artifact admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+- 2026-08-09: Added the #4700 portable artifact-admission prerequisite. A
+  canonical capability ID, explicit rooted external-process policy, exact
+  lowercase SHA-256, and physical file identity now produce an opaque token;
+  revalidation repeats policy, identity, and hashing and revokes the token in
+  place on any failure. File SHA-256 now streams in fixed 64 KiB chunks through
+  incremental BCrypt on Windows or the portable implementation elsewhere.
+  Focused GCC/adjacent coverage passes `12/12` plus `100/100` repeated admission;
+  Clang 21 ASan/UBSan passes `2/2`, static analysis is clean, and standard
+  vectors, root denial, digest mismatch, mutation, and identity-stable physical
+  replacement regressions pass. This does not launch an artifact, choose a
+  route, connect transport or envelopes, expose PRG dispatch, or add an
+  external-language adapter. Exact candidate `e5f974df2` passes Linux Native
+  `31354311198` and macOS Native `31354312629` at `332/332`, the macOS locale
+  matrix at `8/8`, and Windows Native `31354314025` at `331/331`; the focused
+  regression passes everywhere and all eight candidate-head protected checks
+  are green.
+
 - 2026-08-09: Made POSIX external-process allowed-root containment follow the
   containing filesystem's identity and case semantics. The executable's
   canonical path prefix is now compared with the canonical allowed root using

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ add_library(cf_platform_profile
     src/platform/extensibility_model.cpp
     src/platform/federation_execution.cpp
     src/platform/localized_text.cpp
+    src/platform/polyglot_artifact_admission.cpp
     src/platform/polyglot_bridge_invocation.cpp
     src/platform/polyglot_interop_envelope.cpp
     src/platform/polyglot_migration_telemetry.cpp
@@ -255,7 +256,7 @@ else()
     target_compile_options(cf_platform_profile PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 
-target_link_libraries(cf_platform_profile PRIVATE cf_localization)
+target_link_libraries(cf_platform_profile PRIVATE cf_localization cf_security)
 
 add_library(cf_vfp_assets
     src/vfp/asset_inspector.cpp

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,42 @@
 # Agent Handoff
 
+## V1 polyglot artifact-admission candidate
+
+The approved #4700 prerequisite now admits one external executable only after
+canonical capability-ID validation, an explicit rooted external-process policy,
+an exact lowercase SHA-256 match, and post-hash physical-identity revalidation.
+The returned token is opaque and cannot be default-constructed. Its
+pre-execution revalidation repeats the original policy, requires the same
+physical identity, rehashes the file, checks identity again, and revokes the
+token in place on any failure. SHA-256 file reads use bounded 64 KiB chunks;
+Windows uses incremental BCrypt and other native hosts use the portable
+incremental implementation.
+
+Local GCC focused and adjacent contracts pass `12/12`, and the final admission
+regression repeats `100/100`. Clang 21 ASan/UBSan passes `2/2`; focused static
+analysis reports no diagnostic in either owned implementation file, and
+`git diff --check` passes. Coverage includes standard SHA-256 vectors, valid
+rooted admission, noncanonical identity and digest rejection, missing/sibling
+roots, digest mismatch, in-place mutation, and identical-byte physical
+replacement. The replacement fixture retains the admitted file under a new
+name before creating its successor, preventing filesystem inode reuse from
+weakening the distinct-identity precondition.
+
+Exact candidate `e5f974df2` passes Linux Native `31354311198` and macOS Native
+`31354312629` at `332/332`; macOS also passes the four-locale SET POINT matrix
+at `8/8`. Windows Native `31354314025` passes `331/331`. The artifact-admission
+regression passes on every host, and all eight candidate-head protected checks
+pass. The earlier Linux run `31352961239` is excluded from evidence: it exposed
+the fixture's remove/copy inode-reuse precondition and led to the retained-file
+correction above. The earlier macOS pass and cancelled Windows run at that
+superseded head are likewise not final evidence.
+
+This prerequisite does not launch an artifact, connect the bounded-process
+transport or request/response contracts, select a route, apply fallback or
+telemetry, expose PRG dispatch, or connect an external-language runtime. A
+future adapter must place token revalidation immediately beside its owned
+launch boundary.
+
 ## V1 macOS external-process root identity candidate
 
 The next bounded macOS portable-core seam is complete at exact product/test

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -402,10 +402,23 @@ diagnostic in the owned files and one pre-existing dead store in unchanged
 `31340579206` and macOS Native `31340580178` pass `331/331`, macOS also passes
 the four-locale SET POINT matrix at `8/8`, and Windows Native `31340581094`
 passes `330/330`; all three execute `test_bounded_process` successfully. All
-eight candidate-head protected checks pass. These slices still do not
-authorize/hash an artifact, automatically connect the serializer or response
-parser, implement fallback/telemetry, select a route, or connect external code
-to PRG execution.
+eight candidate-head protected checks pass. A separate artifact-admission seam
+now authorizes and hashes an exact rooted executable, but it is not yet
+connected to this transport. Automatic serializer/response-parser connection,
+fallback/telemetry, route selection, and external-code PRG dispatch remain.
+
+The artifact-admission prerequisite binds a canonical capability ID, explicit
+rooted external-process authorization, exact lowercase SHA-256, and physical
+file identity in an opaque token. Revalidation repeats the original policy,
+identity, and exact-byte hash and revokes the token in place on any failure.
+File hashing is incremental and fixed-memory on Windows and POSIX. This closes
+the trust-admission prerequisite only: no process is launched, no route is
+selected, no serializer/parser is connected, and no external language enters
+the PRG runtime. Exact candidate `e5f974df2` passes Linux Native
+`31354311198` and macOS Native `31354312629` at `332/332`, the macOS locale
+matrix at `8/8`, and Windows Native `31354314025` at `331/331`; the focused
+regression passes everywhere and all eight candidate-head protected checks are
+green.
 
 The next #91/#4700 bridge prerequisite now validates versioned candidate
 response envelopes before downstream use. Success and error shapes are
@@ -733,7 +746,7 @@ standalone Studio shell, and FoxPro language-service layer."
 | E | `#111` (`E1`/`#22`, `E2`/`#23`, `E3`/`#24`) | Shared design model and designer fidelity (`E3` = report/label parity, the single largest lane in the repo) | Closed 2026-07-24 | Phase C |
 | F | `#112` (`F1`/`#25`, `F2`/`#26`) | VS extension parity + utility panes; standalone Studio as a full IDE | MVP implementation complete for standalone shell; hosted UI evidence remains under the RC gate | Phase C |
 | G | `#112` (`G1`/`#27`, `G2`/`#28`, `G3`/`#29`) | FoxPro language service: semantic resolution, navigation/refactoring, IntelliSense metadata | Recorded G1/G2/G3 slices closed; broader MVP scope remains under the live tree | Phase C |
-| H | `#113` (`H1`/`#30`, `H2`/`#31`, `H3`/`#32`) | Relational backend translators, document/vector + AI planning, .NET/MCP/polyglot outputs | Contract/model foundation, bounded process, deterministic request serialization, and response admission implemented; artifact trust, transport, and PRG-controlled dispatch remain | v1 item 3 |
+| H | `#113` (`H1`/`#30`, `H2`/`#31`, `H3`/`#32`) | Relational backend translators, document/vector + AI planning, .NET/MCP/polyglot outputs | Contract/model foundation, bounded process, artifact admission, deterministic request serialization, and response admission implemented; seam connection and PRG-controlled dispatch remain | v1 item 3 |
 | I | `#113` (`I1`/`#33`, `I2`/`#34`) | Runtime/project security depth, extension/host/AI-MCP security boundary | Seeded (see gap analysis) | v1 item 4 |
 | J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | Studio launch-error and POSIX root-identity seams shipped; broader ports open | v1 item 5 |
 

--- a/docs/10-dotnet-interop.md
+++ b/docs/10-dotnet-interop.md
@@ -15,6 +15,11 @@ Current maturity:
 - The managed `DECLARE` path is tested on Win32 and x64 for absolute, explicit-relative, and parentless loader-resolved paths, sibling dependency resolution, integer/floating/string values, repeat success/failure, localized failures, and mixed-mode assemblies whose native export must take precedence. It is not a general managed object, event, callback, or by-reference interop surface.
 - The build pipeline can also generate a C# launcher/stub that is invoked as a child process by the native runtime pipeline in `src/runtime/runtime_pipeline.cpp`.
 - The portable artifact-bridge foundation can now serialize a deterministic, versioned invocation request and admit its matching structured response. It does not yet connect that exchange to the runtime host or expose PRG dispatch, asynchronous status, cancellation, or result retrieval.
+- A portable artifact-admission prerequisite now binds a canonical capability,
+  explicit rooted external-process policy, exact SHA-256, and physical file
+  identity in an opaque token that is revocable on pre-execution revalidation.
+  It does not load or launch managed code and is not yet connected to the
+  bounded-process transport or PRG control plane.
 - Generated C# transpilation output is currently an emitted artifact, not code executed by the runtime host.
 - macOS and Linux builds do not compile or host this Windows .NET Framework `DECLARE` path; their native runtime and packaging paths remain guarded from the Windows-only implementation. Broader cross-platform CLR/.NET hosting, managed wrappers, object lifetime, callbacks, policy enforcement, and generated strongly typed bindings remain v1 work.
 

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -25,6 +25,10 @@ Current maturity:
   descendant cleanup, and independently bounded exact-byte stdout/stderr
   capture. It is infrastructure for a future artifact adapter, not a runtime
   route or language integration by itself.
+- A separate portable admission boundary now binds a canonical capability ID
+  and rooted external-process authorization to one exact lowercase SHA-256 and
+  physical file identity. Its opaque token must be revalidated before a later
+  execution boundary; admission itself does not launch the artifact.
 - A portable serializer now emits the versioned invocation request in fixed,
   compact field order after strict identity and arguments-object admission; the
   matching response parser admits only the checked-in success/error shapes.
@@ -113,6 +117,41 @@ primitive described below supplies a low-level execution boundary; adapter-speci
 retry and the connection from policy decisions to an authorized artifact remain
 outside the policy model.
 
+## Artifact Admission v1
+
+`admit_polyglot_artifact` validates one configured external executable before a
+future adapter may consider it trusted. The request must contain a canonical
+capability ID, an explicit nonempty allowed-root list in the existing
+external-process policy, and an exact 64-character lowercase SHA-256. Admission
+first applies the existing path, executable, signature, and publisher policy;
+it then hashes the resolved file and revalidates its physical identity after
+the read. Stable `polyglot.artifact.*` codes distinguish invalid identity,
+missing root, policy denial, hashing failure, digest mismatch, and detected
+change. Any denial clears the trusted digest and revokes the embedded process
+authorization.
+
+The result is an opaque, non-default-constructible token. Immediately before a
+future execution boundary, `revalidate_polyglot_artifact_admission` repeats the
+original external-process policy, requires the same physical file identity,
+rehashes the exact bytes, and revalidates identity again after hashing. A
+failure revokes the token in place and a revoked token cannot be restored by a
+later revalidation. SHA-256 file reads use fixed 64 KiB chunks rather than
+buffering the whole artifact in memory; Windows uses incremental BCrypt and
+other native hosts use the portable incremental SHA-256 implementation.
+
+Focused coverage includes standard SHA-256 vectors, valid rooted admission,
+noncanonical capability/digest rejection, missing and sibling roots, digest
+mismatch, same-file content mutation, and identical-byte physical replacement.
+Exact candidate `e5f974df2` passes Linux Native `31354311198` and macOS Native
+`31354312629` at `332/332`, the macOS four-locale SET POINT matrix at `8/8`,
+and Windows Native `31354314025` at `331/331`; the artifact-admission
+regression passes on every host. All eight candidate-head protected checks
+pass.
+This seam does not launch a process, choose a route, connect the request or
+response contracts, apply fallback or telemetry, expose PRG dispatch, or add a
+language adapter. Revalidation narrows the validation-to-use interval but a
+future adapter must still keep it immediately adjacent to its owned launch.
+
 ## Bounded Artifact Process Primitive
 
 `run_bounded_process` is the first execution prerequisite for an artifact-invoked
@@ -185,11 +224,12 @@ pre-existing dead store in unchanged `query_translator.cpp`. Exact candidate hea
 `31340581094` at `330/330`; the bounded-process regression passes on every
 platform. All eight candidate-head protected checks pass.
 
-This primitive does **not** authorize or hash an artifact, validate migration
-contracts or typed envelopes, automatically connect the request serializer or response
-parser, implement retries or fallback, choose a route, emit migration telemetry, or
-connect any external language to the PRG runtime. Those remain separately reviewable
-adapter and dispatch work.
+This primitive does **not** itself authorize or hash an artifact. The separate
+admission boundary above now supplies that prerequisite, but it is not yet
+connected to this process primitive. Migration-contract and typed-envelope
+validation, automatic serializer/parser connection, retries or fallback, route
+selection, migration telemetry, PRG dispatch, and external-language adapters
+remain separately reviewable work.
 
 ## Invocation Request Serialization v1
 

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -335,9 +335,12 @@ and Windows restricts inherited handles to the three explicit standard handles.
 Exact candidate `301d74bf5` passes the full Linux and macOS native suites at
 `331/331`, the macOS locale matrix at `8/8`, and the Windows native suite at
 `330/330`; the bounded-process regression and all eight protected checks pass.
-This is transport evidence only: caller-supplied request and captured response
-bytes are not yet tied to an admitted artifact, serializer/parser connection,
-route, or PRG dispatch.
+The portable artifact-admission prerequisite separately binds a canonical
+capability, explicit rooted external-process policy, exact SHA-256, and
+physical file identity in an opaque, revocable token. It repeats policy,
+identity, and exact-byte hashing before future execution. The admission and
+transport seams are not yet connected to each other, the serializer/parser,
+a route, or PRG dispatch.
 It also exposes bounded native JSON validation, type inspection, and JSON
 Pointer selection so PRG can examine immutable structured completion payloads
 without embedding foreign source or losing exact number spelling.
@@ -347,8 +350,8 @@ remain unsupported unless a future separately approved route supplies them.
 The native payload facade also exposes bounded exact-byte SHA-256,
 HMAC-SHA256 generation/verification, and strict canonical Base64 encode/decode
 for PRG-controlled immutable results,
-without claiming sender authentication, encryption, or artifact admission.
-External artifact admission, dispatch, and managed execution remain absent.
+without claiming sender authentication, encryption, or executable trust.
+Artifact dispatch and managed execution remain absent.
 
 **What it will take:** none of the four named native execution/marshaling
 modules exist yet. What exists today, per `docs/28-repository-ontology.md` §3, is

--- a/include/copperfin/platform/polyglot_artifact_admission.h
+++ b/include/copperfin/platform/polyglot_artifact_admission.h
@@ -1,0 +1,86 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#pragma once
+
+#include "copperfin/security/external_process_policy.h"
+
+#include <string>
+
+namespace copperfin::platform {
+
+enum class PolyglotArtifactAdmissionError {
+    none,
+    invalid_capability_id,
+    invalid_expected_sha256,
+    allowed_root_required,
+    authorization_denied,
+    hash_failed,
+    hash_mismatch,
+    artifact_changed
+};
+
+struct PolyglotArtifactAdmissionRequest {
+    std::string capability_id;
+    security::ExternalProcessPolicy process_policy;
+    std::string expected_sha256;
+};
+
+class PolyglotArtifactAdmissionResult;
+
+[[nodiscard]] PolyglotArtifactAdmissionResult admit_polyglot_artifact(
+    const PolyglotArtifactAdmissionRequest& request);
+[[nodiscard]] bool revalidate_polyglot_artifact_admission(
+    PolyglotArtifactAdmissionResult& admission);
+
+class PolyglotArtifactAdmissionResult {
+public:
+    [[nodiscard]] bool ok() const noexcept {
+        return admitted_ && error_ == PolyglotArtifactAdmissionError::none;
+    }
+
+    [[nodiscard]] PolyglotArtifactAdmissionError error() const noexcept {
+        return error_;
+    }
+
+    [[nodiscard]] const std::string& error_code() const noexcept {
+        return error_code_;
+    }
+
+    [[nodiscard]] const std::string& capability_id() const noexcept {
+        return capability_id_;
+    }
+
+    [[nodiscard]] const std::string& artifact_sha256() const noexcept {
+        return artifact_sha256_;
+    }
+
+    [[nodiscard]] const security::ExternalProcessAuthorizationResult& authorization()
+        const noexcept {
+        return authorization_;
+    }
+
+private:
+    bool admitted_ = false;
+    PolyglotArtifactAdmissionError error_ = PolyglotArtifactAdmissionError::none;
+    std::string error_code_;
+    std::string capability_id_;
+    std::string artifact_sha256_;
+    security::ExternalProcessPolicy process_policy_;
+    security::ExternalProcessAuthorizationResult authorization_;
+
+    PolyglotArtifactAdmissionResult() = default;
+
+    friend PolyglotArtifactAdmissionResult admit_polyglot_artifact(
+        const PolyglotArtifactAdmissionRequest& request);
+    friend bool revalidate_polyglot_artifact_admission(
+        PolyglotArtifactAdmissionResult& admission);
+};
+
+// Authorize and hash one external executable without launching it. The caller
+// must revalidate the returned admission immediately before execution.
+// Revalidation repeats the original process policy, physical identity, and
+// exact-byte digest checks. A failure revokes the token in place.
+
+}  // namespace copperfin::platform

--- a/src/platform/polyglot_artifact_admission.cpp
+++ b/src/platform/polyglot_artifact_admission.cpp
@@ -1,0 +1,186 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/polyglot_artifact_admission.h"
+
+#include "copperfin/platform/polyglot_route_registry.h"
+#include "copperfin/security/sha256.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <utility>
+
+namespace copperfin::platform {
+
+namespace {
+
+bool valid_capability_id(std::string_view capability_id) {
+    const auto validation = load_polyglot_route_registry({
+        PolyglotRouteConfig{
+            .capability_id = std::string(capability_id),
+            .state = "off",
+            .canary_percentage = 0U}});
+    return validation.ok();
+}
+
+bool valid_sha256(std::string_view digest) noexcept {
+    return digest.size() == 64U &&
+        std::all_of(digest.begin(), digest.end(), [](char character) {
+            return (character >= '0' && character <= '9') ||
+                (character >= 'a' && character <= 'f');
+        });
+}
+
+bool constant_time_equal(
+    std::string_view left,
+    std::string_view right) noexcept {
+    if (left.size() != right.size()) {
+        return false;
+    }
+    std::uint8_t difference = 0U;
+    for (std::size_t index = 0U; index < left.size(); ++index) {
+        difference |= static_cast<std::uint8_t>(left[index]) ^
+            static_cast<std::uint8_t>(right[index]);
+    }
+    return difference == 0U;
+}
+
+bool same_file_identity(
+    const security::ExternalProcessFileIdentity& left,
+    const security::ExternalProcessFileIdentity& right) noexcept {
+    return left.first == right.first && left.second == right.second;
+}
+
+}  // namespace
+
+PolyglotArtifactAdmissionResult admit_polyglot_artifact(
+    const PolyglotArtifactAdmissionRequest& request) {
+    PolyglotArtifactAdmissionResult result;
+    result.capability_id_ = request.capability_id;
+    result.process_policy_ = request.process_policy;
+    const auto deny = [&](
+                          PolyglotArtifactAdmissionError error,
+                          const char* error_code) {
+        result.admitted_ = false;
+        result.error_ = error;
+        result.error_code_ = error_code;
+        result.artifact_sha256_.clear();
+        result.authorization_.allowed = false;
+        return result;
+    };
+
+    if (!valid_capability_id(request.capability_id)) {
+        return deny(
+            PolyglotArtifactAdmissionError::invalid_capability_id,
+            "polyglot.artifact.invalid_capability_id");
+    }
+    if (!valid_sha256(request.expected_sha256)) {
+        return deny(
+            PolyglotArtifactAdmissionError::invalid_expected_sha256,
+            "polyglot.artifact.invalid_expected_sha256");
+    }
+    if (request.process_policy.allowed_path_roots.empty()) {
+        return deny(
+            PolyglotArtifactAdmissionError::allowed_root_required,
+            "polyglot.artifact.allowed_root_required");
+    }
+
+    result.authorization_ =
+        security::authorize_external_process(result.process_policy_);
+    if (!result.authorization_.allowed) {
+        return deny(
+            PolyglotArtifactAdmissionError::authorization_denied,
+            "polyglot.artifact.authorization_denied");
+    }
+
+    const auto digest =
+        security::sha256_hex_for_file(result.authorization_.resolved_path);
+    if (!digest.ok) {
+        return deny(
+            PolyglotArtifactAdmissionError::hash_failed,
+            "polyglot.artifact.hash_failed");
+    }
+    if (!security::revalidate_external_process_authorization(
+            result.authorization_)) {
+        return deny(
+            PolyglotArtifactAdmissionError::artifact_changed,
+            "polyglot.artifact.changed_during_admission");
+    }
+    if (!constant_time_equal(digest.hex_digest, request.expected_sha256)) {
+        return deny(
+            PolyglotArtifactAdmissionError::hash_mismatch,
+            "polyglot.artifact.sha256_mismatch");
+    }
+
+    result.admitted_ = true;
+    result.error_ = PolyglotArtifactAdmissionError::none;
+    result.error_code_ = "polyglot.artifact.admitted";
+    result.artifact_sha256_ = digest.hex_digest;
+    return result;
+}
+
+bool revalidate_polyglot_artifact_admission(
+    PolyglotArtifactAdmissionResult& admission) {
+    if (!admission.ok()) {
+        return false;
+    }
+    const auto revoke = [&](
+                            PolyglotArtifactAdmissionError error,
+                            const char* error_code) {
+        admission.admitted_ = false;
+        admission.error_ = error;
+        admission.error_code_ = error_code;
+        admission.artifact_sha256_.clear();
+        admission.authorization_.allowed = false;
+        return false;
+    };
+    if (admission.authorization_.resolved_path.empty() ||
+        !valid_capability_id(admission.capability_id_) ||
+        !valid_sha256(admission.artifact_sha256_) ||
+        admission.process_policy_.allowed_path_roots.empty()) {
+        return revoke(
+            PolyglotArtifactAdmissionError::artifact_changed,
+            "polyglot.artifact.invalid_admission");
+    }
+
+    auto current_authorization =
+        security::authorize_external_process(admission.process_policy_);
+    if (!current_authorization.allowed) {
+        return revoke(
+            PolyglotArtifactAdmissionError::authorization_denied,
+            "polyglot.artifact.policy_denied_before_execution");
+    }
+    if (!same_file_identity(
+            current_authorization.file_identity,
+            admission.authorization_.file_identity)) {
+        return revoke(
+            PolyglotArtifactAdmissionError::artifact_changed,
+            "polyglot.artifact.changed_before_execution");
+    }
+
+    const auto digest = security::sha256_hex_for_file(
+        current_authorization.resolved_path);
+    if (!digest.ok) {
+        return revoke(
+            PolyglotArtifactAdmissionError::hash_failed,
+            "polyglot.artifact.revalidation_hash_failed");
+    }
+    if (!constant_time_equal(digest.hex_digest, admission.artifact_sha256_)) {
+        return revoke(
+            PolyglotArtifactAdmissionError::artifact_changed,
+            "polyglot.artifact.contents_changed_before_execution");
+    }
+    if (!security::revalidate_external_process_authorization(
+            current_authorization)) {
+        return revoke(
+            PolyglotArtifactAdmissionError::artifact_changed,
+            "polyglot.artifact.changed_during_revalidation");
+    }
+    admission.authorization_ = std::move(current_authorization);
+    return true;
+}
+
+}  // namespace copperfin::platform

--- a/src/security/sha256.cpp
+++ b/src/security/sha256.cpp
@@ -13,15 +13,20 @@
 #include <bcrypt.h>
 #endif
 
+#include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
-#include <sstream>
+#include <limits>
 #include <vector>
 
 namespace copperfin::security {
 
 namespace {
+
+constexpr std::size_t kSha256BlockSize = 64U;
+constexpr std::size_t kFileReadChunkSize = 64U * 1024U;
 
 std::string to_hex(const std::uint8_t* bytes, std::size_t size) {
     static constexpr char kHex[] = "0123456789abcdef";
@@ -35,70 +40,211 @@ std::string to_hex(const std::uint8_t* bytes, std::size_t size) {
     return result;
 }
 
+Sha256Result file_read_failure(const std::string& path) {
+    return {
+        .ok = false,
+        .hex_digest = {},
+        .error = security_text(
+            "Security.Sha256.Error.OpenFileFailed",
+            {{"path", path}})};
+}
+
 #ifdef _WIN32
-Sha256Result hash_bytes(const std::uint8_t* bytes, std::size_t size) {
+
+struct WindowsSha256Context {
     BCRYPT_ALG_HANDLE algorithm = nullptr;
     BCRYPT_HASH_HANDLE hash = nullptr;
     std::vector<std::uint8_t> object_buffer;
-    std::array<std::uint8_t, 32U> digest{};
 
-    if (BCryptOpenAlgorithmProvider(&algorithm, BCRYPT_SHA256_ALGORITHM, nullptr, 0) != 0) {
-        return {.ok = false, .hex_digest = {}, .error = security_text("Security.Sha256.Error.BCryptOpenAlgorithmProviderFailed")};
+    ~WindowsSha256Context() {
+        if (hash != nullptr) {
+            BCryptDestroyHash(hash);
+        }
+        if (algorithm != nullptr) {
+            BCryptCloseAlgorithmProvider(algorithm, 0);
+        }
+    }
+
+    WindowsSha256Context() = default;
+    WindowsSha256Context(const WindowsSha256Context&) = delete;
+    WindowsSha256Context& operator=(const WindowsSha256Context&) = delete;
+};
+
+Sha256Result initialize_hash(WindowsSha256Context& context) {
+    if (BCryptOpenAlgorithmProvider(
+            &context.algorithm,
+            BCRYPT_SHA256_ALGORITHM,
+            nullptr,
+            0) != 0) {
+        return {
+            .ok = false,
+            .hex_digest = {},
+            .error = security_text(
+                "Security.Sha256.Error.BCryptOpenAlgorithmProviderFailed")};
     }
 
     DWORD object_size = 0;
     DWORD bytes_written = 0;
-    if (BCryptGetProperty(algorithm, BCRYPT_OBJECT_LENGTH, reinterpret_cast<PUCHAR>(&object_size), sizeof(object_size), &bytes_written, 0) != 0) {
-        BCryptCloseAlgorithmProvider(algorithm, 0);
-        return {.ok = false, .hex_digest = {}, .error = security_text("Security.Sha256.Error.BCryptGetPropertyObjectLengthFailed")};
+    if (BCryptGetProperty(
+            context.algorithm,
+            BCRYPT_OBJECT_LENGTH,
+            reinterpret_cast<PUCHAR>(&object_size),
+            sizeof(object_size),
+            &bytes_written,
+            0) != 0) {
+        return {
+            .ok = false,
+            .hex_digest = {},
+            .error = security_text(
+                "Security.Sha256.Error.BCryptGetPropertyObjectLengthFailed")};
     }
 
-    object_buffer.resize(object_size);
-
-    if (BCryptCreateHash(algorithm, &hash, object_buffer.data(), object_size, nullptr, 0, 0) != 0) {
-        BCryptCloseAlgorithmProvider(algorithm, 0);
-        return {.ok = false, .hex_digest = {}, .error = security_text("Security.Sha256.Error.BCryptCreateHashFailed")};
+    context.object_buffer.resize(object_size);
+    if (BCryptCreateHash(
+            context.algorithm,
+            &context.hash,
+            context.object_buffer.data(),
+            object_size,
+            nullptr,
+            0,
+            0) != 0) {
+        return {
+            .ok = false,
+            .hex_digest = {},
+            .error = security_text(
+                "Security.Sha256.Error.BCryptCreateHashFailed")};
     }
-
-    if (BCryptHashData(hash, const_cast<PUCHAR>(bytes), static_cast<ULONG>(size), 0) != 0) {
-        BCryptDestroyHash(hash);
-        BCryptCloseAlgorithmProvider(algorithm, 0);
-        return {.ok = false, .hex_digest = {}, .error = security_text("Security.Sha256.Error.BCryptHashDataFailed")};
-    }
-
-    if (BCryptFinishHash(hash, digest.data(), static_cast<ULONG>(digest.size()), 0) != 0) {
-        BCryptDestroyHash(hash);
-        BCryptCloseAlgorithmProvider(algorithm, 0);
-        return {.ok = false, .hex_digest = {}, .error = security_text("Security.Sha256.Error.BCryptFinishHashFailed")};
-    }
-
-    BCryptDestroyHash(hash);
-    BCryptCloseAlgorithmProvider(algorithm, 0);
-
-    return {.ok = true, .hex_digest = to_hex(digest.data(), digest.size()), .error = {}};
+    return {.ok = true, .hex_digest = {}, .error = {}};
 }
-#endif
 
-#ifndef _WIN32
+bool update_hash(
+    WindowsSha256Context& context,
+    const std::uint8_t* bytes,
+    std::size_t size) {
+    while (size > 0U) {
+        const ULONG chunk_size = static_cast<ULONG>(std::min<std::size_t>(
+            size,
+            std::numeric_limits<ULONG>::max()));
+        if (BCryptHashData(
+                context.hash,
+                const_cast<PUCHAR>(bytes),
+                chunk_size,
+                0) != 0) {
+            return false;
+        }
+        bytes += chunk_size;
+        size -= chunk_size;
+    }
+    return true;
+}
+
+Sha256Result finish_hash(WindowsSha256Context& context) {
+    std::array<std::uint8_t, 32U> digest{};
+    if (BCryptFinishHash(
+            context.hash,
+            digest.data(),
+            static_cast<ULONG>(digest.size()),
+            0) != 0) {
+        return {
+            .ok = false,
+            .hex_digest = {},
+            .error = security_text(
+                "Security.Sha256.Error.BCryptFinishHashFailed")};
+    }
+    return {
+        .ok = true,
+        .hex_digest = to_hex(digest.data(), digest.size()),
+        .error = {}};
+}
+
+Sha256Result hash_bytes(const std::uint8_t* bytes, std::size_t size) {
+    WindowsSha256Context context;
+    const auto initialized = initialize_hash(context);
+    if (!initialized.ok) {
+        return initialized;
+    }
+    if (!update_hash(context, bytes, size)) {
+        return {
+            .ok = false,
+            .hex_digest = {},
+            .error = security_text(
+                "Security.Sha256.Error.BCryptHashDataFailed")};
+    }
+    return finish_hash(context);
+}
+
+Sha256Result hash_file_stream(std::ifstream& input, const std::string& path) {
+    WindowsSha256Context context;
+    const auto initialized = initialize_hash(context);
+    if (!initialized.ok) {
+        return initialized;
+    }
+
+    std::array<std::uint8_t, kFileReadChunkSize> buffer{};
+    for (;;) {
+        input.read(
+            reinterpret_cast<char*>(buffer.data()),
+            static_cast<std::streamsize>(buffer.size()));
+        const auto count = input.gcount();
+        if (count > 0 && !update_hash(
+                context,
+                buffer.data(),
+                static_cast<std::size_t>(count))) {
+            return {
+                .ok = false,
+                .hex_digest = {},
+                .error = security_text(
+                    "Security.Sha256.Error.BCryptHashDataFailed")};
+        }
+        if (input.eof()) {
+            break;
+        }
+        if (!input) {
+            return file_read_failure(path);
+        }
+    }
+    return finish_hash(context);
+}
+
+#else
+
 std::uint32_t rotate_right(std::uint32_t value, unsigned int bits) {
     return (value >> bits) | (value << (32U - bits));
 }
 
-std::uint32_t read_be_u32(const std::vector<std::uint8_t>& bytes, std::size_t offset) {
-    return (static_cast<std::uint32_t>(bytes[offset]) << 24U) |
-        (static_cast<std::uint32_t>(bytes[offset + 1U]) << 16U) |
-        (static_cast<std::uint32_t>(bytes[offset + 2U]) << 8U) |
-        static_cast<std::uint32_t>(bytes[offset + 3U]);
+std::uint32_t read_be_u32(const std::uint8_t* bytes) {
+    return (static_cast<std::uint32_t>(bytes[0]) << 24U) |
+        (static_cast<std::uint32_t>(bytes[1]) << 16U) |
+        (static_cast<std::uint32_t>(bytes[2]) << 8U) |
+        static_cast<std::uint32_t>(bytes[3]);
 }
 
-void write_be_u32(std::array<std::uint8_t, 32U>& bytes, std::size_t offset, std::uint32_t value) {
+void write_be_u32(
+    std::array<std::uint8_t, 32U>& bytes,
+    std::size_t offset,
+    std::uint32_t value) {
     bytes[offset] = static_cast<std::uint8_t>((value >> 24U) & 0xFFU);
     bytes[offset + 1U] = static_cast<std::uint8_t>((value >> 16U) & 0xFFU);
     bytes[offset + 2U] = static_cast<std::uint8_t>((value >> 8U) & 0xFFU);
     bytes[offset + 3U] = static_cast<std::uint8_t>(value & 0xFFU);
 }
 
-Sha256Result hash_bytes(const std::uint8_t* bytes, std::size_t size) {
+struct PortableSha256Context {
+    std::array<std::uint32_t, 8U> state{
+        0x6a09e667U,
+        0xbb67ae85U,
+        0x3c6ef372U,
+        0xa54ff53aU,
+        0x510e527fU,
+        0x9b05688cU,
+        0x1f83d9abU,
+        0x5be0cd19U};
+    std::array<std::uint8_t, kSha256BlockSize> buffered{};
+    std::size_t buffered_size = 0U;
+    std::uint64_t total_bytes = 0U;
+};
+
+void process_block(PortableSha256Context& context, const std::uint8_t* block) {
     static constexpr std::array<std::uint32_t, 64U> kRoundConstants{
         0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U,
         0x3956c25bU, 0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U,
@@ -115,89 +261,170 @@ Sha256Result hash_bytes(const std::uint8_t* bytes, std::size_t size) {
         0x19a4c116U, 0x1e376c08U, 0x2748774cU, 0x34b0bcb5U,
         0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU, 0x682e6ff3U,
         0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U,
-        0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U
-    };
+        0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U};
 
-    std::vector<std::uint8_t> message(bytes, bytes + size);
-    const std::uint64_t bit_length = static_cast<std::uint64_t>(size) * 8ULL;
-    message.push_back(0x80U);
-    while ((message.size() % 64U) != 56U) {
-        message.push_back(0U);
+    std::array<std::uint32_t, 64U> schedule{};
+    for (std::size_t index = 0U; index < 16U; ++index) {
+        schedule[index] = read_be_u32(block + index * 4U);
     }
-    for (int shift = 56; shift >= 0; shift -= 8) {
-        message.push_back(static_cast<std::uint8_t>((bit_length >> shift) & 0xFFU));
+    for (std::size_t index = 16U; index < 64U; ++index) {
+        const std::uint32_t s0 = rotate_right(schedule[index - 15U], 7U) ^
+            rotate_right(schedule[index - 15U], 18U) ^
+            (schedule[index - 15U] >> 3U);
+        const std::uint32_t s1 = rotate_right(schedule[index - 2U], 17U) ^
+            rotate_right(schedule[index - 2U], 19U) ^
+            (schedule[index - 2U] >> 10U);
+        schedule[index] = schedule[index - 16U] + s0 +
+            schedule[index - 7U] + s1;
     }
 
-    std::array<std::uint32_t, 8U> hash{
-        0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U, 0xa54ff53aU,
-        0x510e527fU, 0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U
-    };
+    std::uint32_t a = context.state[0];
+    std::uint32_t b = context.state[1];
+    std::uint32_t c = context.state[2];
+    std::uint32_t d = context.state[3];
+    std::uint32_t e = context.state[4];
+    std::uint32_t f = context.state[5];
+    std::uint32_t g = context.state[6];
+    std::uint32_t h = context.state[7];
 
-    for (std::size_t offset = 0U; offset < message.size(); offset += 64U) {
-        std::array<std::uint32_t, 64U> schedule{};
-        for (std::size_t index = 0U; index < 16U; ++index) {
-            schedule[index] = read_be_u32(message, offset + index * 4U);
-        }
-        for (std::size_t index = 16U; index < 64U; ++index) {
-            const std::uint32_t s0 = rotate_right(schedule[index - 15U], 7U) ^
-                rotate_right(schedule[index - 15U], 18U) ^
-                (schedule[index - 15U] >> 3U);
-            const std::uint32_t s1 = rotate_right(schedule[index - 2U], 17U) ^
-                rotate_right(schedule[index - 2U], 19U) ^
-                (schedule[index - 2U] >> 10U);
-            schedule[index] = schedule[index - 16U] + s0 + schedule[index - 7U] + s1;
-        }
+    for (std::size_t index = 0U; index < 64U; ++index) {
+        const std::uint32_t s1 = rotate_right(e, 6U) ^
+            rotate_right(e, 11U) ^ rotate_right(e, 25U);
+        const std::uint32_t ch = (e & f) ^ ((~e) & g);
+        const std::uint32_t temp1 = h + s1 + ch +
+            kRoundConstants[index] + schedule[index];
+        const std::uint32_t s0 = rotate_right(a, 2U) ^
+            rotate_right(a, 13U) ^ rotate_right(a, 22U);
+        const std::uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+        const std::uint32_t temp2 = s0 + maj;
 
-        std::uint32_t a = hash[0];
-        std::uint32_t b = hash[1];
-        std::uint32_t c = hash[2];
-        std::uint32_t d = hash[3];
-        std::uint32_t e = hash[4];
-        std::uint32_t f = hash[5];
-        std::uint32_t g = hash[6];
-        std::uint32_t h = hash[7];
-
-        for (std::size_t index = 0U; index < 64U; ++index) {
-            const std::uint32_t s1 = rotate_right(e, 6U) ^ rotate_right(e, 11U) ^ rotate_right(e, 25U);
-            const std::uint32_t ch = (e & f) ^ ((~e) & g);
-            const std::uint32_t temp1 = h + s1 + ch + kRoundConstants[index] + schedule[index];
-            const std::uint32_t s0 = rotate_right(a, 2U) ^ rotate_right(a, 13U) ^ rotate_right(a, 22U);
-            const std::uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
-            const std::uint32_t temp2 = s0 + maj;
-
-            h = g;
-            g = f;
-            f = e;
-            e = d + temp1;
-            d = c;
-            c = b;
-            b = a;
-            a = temp1 + temp2;
-        }
-
-        hash[0] += a;
-        hash[1] += b;
-        hash[2] += c;
-        hash[3] += d;
-        hash[4] += e;
-        hash[5] += f;
-        hash[6] += g;
-        hash[7] += h;
+        h = g;
+        g = f;
+        f = e;
+        e = d + temp1;
+        d = c;
+        c = b;
+        b = a;
+        a = temp1 + temp2;
     }
+
+    context.state[0] += a;
+    context.state[1] += b;
+    context.state[2] += c;
+    context.state[3] += d;
+    context.state[4] += e;
+    context.state[5] += f;
+    context.state[6] += g;
+    context.state[7] += h;
+}
+
+void update_hash(
+    PortableSha256Context& context,
+    const std::uint8_t* bytes,
+    std::size_t size) {
+    context.total_bytes += static_cast<std::uint64_t>(size);
+
+    if (context.buffered_size != 0U) {
+        const std::size_t copied = std::min(
+            size,
+            kSha256BlockSize - context.buffered_size);
+        std::copy_n(
+            bytes,
+            copied,
+            context.buffered.begin() +
+                static_cast<std::ptrdiff_t>(context.buffered_size));
+        context.buffered_size += copied;
+        bytes += copied;
+        size -= copied;
+        if (context.buffered_size == kSha256BlockSize) {
+            process_block(context, context.buffered.data());
+            context.buffered_size = 0U;
+        }
+    }
+
+    while (size >= kSha256BlockSize) {
+        process_block(context, bytes);
+        bytes += kSha256BlockSize;
+        size -= kSha256BlockSize;
+    }
+    if (size != 0U) {
+        std::copy_n(bytes, size, context.buffered.begin());
+        context.buffered_size = size;
+    }
+}
+
+Sha256Result finish_hash(PortableSha256Context& context) {
+    const std::uint64_t bit_length = context.total_bytes * 8ULL;
+    context.buffered[context.buffered_size++] = 0x80U;
+    if (context.buffered_size > 56U) {
+        std::fill(
+            context.buffered.begin() +
+                static_cast<std::ptrdiff_t>(context.buffered_size),
+            context.buffered.end(),
+            0U);
+        process_block(context, context.buffered.data());
+        context.buffered_size = 0U;
+    }
+    std::fill(
+        context.buffered.begin() +
+            static_cast<std::ptrdiff_t>(context.buffered_size),
+        context.buffered.begin() + 56,
+        0U);
+    for (std::size_t index = 0U; index < 8U; ++index) {
+        const unsigned int shift = static_cast<unsigned int>((7U - index) * 8U);
+        context.buffered[56U + index] =
+            static_cast<std::uint8_t>((bit_length >> shift) & 0xFFU);
+    }
+    process_block(context, context.buffered.data());
 
     std::array<std::uint8_t, 32U> digest{};
-    for (std::size_t index = 0U; index < hash.size(); ++index) {
-        write_be_u32(digest, index * 4U, hash[index]);
+    for (std::size_t index = 0U; index < context.state.size(); ++index) {
+        write_be_u32(digest, index * 4U, context.state[index]);
     }
-
-    return {.ok = true, .hex_digest = to_hex(digest.data(), digest.size()), .error = {}};
+    return {
+        .ok = true,
+        .hex_digest = to_hex(digest.data(), digest.size()),
+        .error = {}};
 }
+
+Sha256Result hash_bytes(const std::uint8_t* bytes, std::size_t size) {
+    PortableSha256Context context;
+    update_hash(context, bytes, size);
+    return finish_hash(context);
+}
+
+Sha256Result hash_file_stream(std::ifstream& input, const std::string& path) {
+    PortableSha256Context context;
+    std::array<std::uint8_t, kFileReadChunkSize> buffer{};
+    for (;;) {
+        input.read(
+            reinterpret_cast<char*>(buffer.data()),
+            static_cast<std::streamsize>(buffer.size()));
+        const auto count = input.gcount();
+        if (count > 0) {
+            update_hash(
+                context,
+                buffer.data(),
+                static_cast<std::size_t>(count));
+        }
+        if (input.eof()) {
+            break;
+        }
+        if (!input) {
+            return file_read_failure(path);
+        }
+    }
+    return finish_hash(context);
+}
+
 #endif
 
 }  // namespace
 
 Sha256Result sha256_hex_for_text(const std::string& text) {
-    return hash_bytes(reinterpret_cast<const std::uint8_t*>(text.data()), text.size());
+    return hash_bytes(
+        reinterpret_cast<const std::uint8_t*>(text.data()),
+        text.size());
 }
 
 Sha256Result sha256_hex_for_file(const std::string& path) {
@@ -205,13 +432,9 @@ Sha256Result sha256_hex_for_file(const std::string& path) {
         copperfin::platform::path_from_utf8_string(path),
         std::ios::binary);
     if (!input) {
-        return {.ok = false, .hex_digest = {}, .error = security_text("Security.Sha256.Error.OpenFileFailed", {{"path", path}})};
+        return file_read_failure(path);
     }
-
-    std::ostringstream stream;
-    stream << input.rdbuf();
-    const std::string contents = stream.str();
-    return sha256_hex_for_text(contents);
+    return hash_file_stream(input, path);
 }
 
 }  // namespace copperfin::security

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4676,6 +4676,11 @@ copperfin_add_test(test_polyglot_bridge_invocation cf_platform_profile
     test_polyglot_bridge_invocation.cpp
 )
 
+copperfin_add_test(test_polyglot_artifact_admission
+    "cf_security;cf_platform_profile;cf_platform_support"
+    test_polyglot_artifact_admission.cpp
+)
+
 copperfin_add_test(test_polyglot_interop_envelope cf_platform_profile
     test_polyglot_interop_envelope.cpp
 )

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -128,6 +128,16 @@ function(copperfin_configure_native_test_isolation)
             AUDIT complete
         )
     endforeach()
+    copperfin_set_test_isolation(test_polyglot_artifact_admission
+        PARALLEL_SAFE
+        FILESYSTEM test-owned-unique
+        ENVIRONMENT none
+        CHILD_PROCESSES none
+        NETWORK none
+        SAMPLES none
+        PLATFORM portable
+        AUDIT complete
+    )
     copperfin_set_test_isolation(test_bounded_process
         PARALLEL_SAFE
         FILESYSTEM process-owned

--- a/tests/test_polyglot_artifact_admission.cpp
+++ b/tests/test_polyglot_artifact_admission.cpp
@@ -101,6 +101,16 @@ void test_streaming_sha256(const std::filesystem::path& temp_root) {
                 "b00361a396177a9cb410ff61f20015ad",
         "short SHA-256 should match the standard vector; observed=" +
             abc.hex_digest);
+    const auto two_block_padding = copperfin::security::sha256_hex_for_text(
+        "abcdbcdecdefdefgefghfghighijhijk"
+        "ijkljklmklmnlmnomnopnopq");
+    expect(
+        two_block_padding.ok &&
+            two_block_padding.hex_digest ==
+                "248d6a61d20638b8e5c026930c3e6039"
+                "a33ce45964ff2167f6ecedd419db06c1",
+        "56-byte SHA-256 should match the two-block padding vector; observed=" +
+            two_block_padding.hex_digest);
 
     const auto million_a_path = temp_root / "million-a.bin";
     std::ofstream output(million_a_path, std::ios::binary | std::ios::trunc);

--- a/tests/test_polyglot_artifact_admission.cpp
+++ b/tests/test_polyglot_artifact_admission.cpp
@@ -1,0 +1,287 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/executable_path.h"
+#include "copperfin/platform/path.h"
+#include "copperfin/platform/polyglot_artifact_admission.h"
+#include "copperfin/security/sha256.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+static_assert(
+    !std::is_default_constructible_v<
+        copperfin::platform::PolyglotArtifactAdmissionResult>);
+static_assert(
+    !std::is_aggregate_v<
+        copperfin::platform::PolyglotArtifactAdmissionResult>);
+
+namespace {
+
+int failures = 0;
+
+void expect(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << "\n";
+        ++failures;
+    }
+}
+
+std::filesystem::path unique_temp_root() {
+    const auto nonce = std::chrono::steady_clock::now()
+                           .time_since_epoch()
+                           .count();
+    return std::filesystem::temp_directory_path() /
+        ("copperfin_polyglot_artifact_admission_" +
+         std::to_string(nonce));
+}
+
+std::string utf8_path(const std::filesystem::path& path) {
+    return copperfin::platform::path_to_utf8_string(path);
+}
+
+copperfin::platform::PolyglotArtifactAdmissionRequest admission_request(
+    const std::filesystem::path& artifact,
+    const std::filesystem::path& allowed_root,
+    std::string expected_sha256) {
+    return {
+        .capability_id = "interop.sample-v1",
+        .process_policy = {
+            .executable_name = utf8_path(artifact),
+            .allowed_path_roots = {utf8_path(allowed_root)},
+            .allowed_publishers = {},
+            .require_trusted_signature = false},
+        .expected_sha256 = std::move(expected_sha256)};
+}
+
+bool copy_executable(
+    const std::filesystem::path& source,
+    const std::filesystem::path& destination) {
+    std::error_code error;
+    std::filesystem::copy_file(
+        source,
+        destination,
+        std::filesystem::copy_options::overwrite_existing,
+        error);
+    if (error) {
+        return false;
+    }
+#ifndef _WIN32
+    std::filesystem::permissions(
+        destination,
+        std::filesystem::perms::owner_read |
+            std::filesystem::perms::owner_write |
+            std::filesystem::perms::owner_exec,
+        std::filesystem::perm_options::add,
+        error);
+#endif
+    return !error;
+}
+
+void test_streaming_sha256(const std::filesystem::path& temp_root) {
+    const auto empty = copperfin::security::sha256_hex_for_text("");
+    expect(
+        empty.ok &&
+            empty.hex_digest ==
+                "e3b0c44298fc1c149afbf4c8996fb924"
+                "27ae41e4649b934ca495991b7852b855",
+        "empty SHA-256 should match the standard vector; observed=" +
+            empty.hex_digest);
+    const auto abc = copperfin::security::sha256_hex_for_text("abc");
+    expect(
+        abc.ok &&
+            abc.hex_digest ==
+                "ba7816bf8f01cfea414140de5dae2223"
+                "b00361a396177a9cb410ff61f20015ad",
+        "short SHA-256 should match the standard vector; observed=" +
+            abc.hex_digest);
+
+    const auto million_a_path = temp_root / "million-a.bin";
+    std::ofstream output(million_a_path, std::ios::binary | std::ios::trunc);
+    const std::string chunk(1000U, 'a');
+    for (std::size_t index = 0U; index < 1000U && output; ++index) {
+        output.write(chunk.data(), static_cast<std::streamsize>(chunk.size()));
+    }
+    output.close();
+    expect(static_cast<bool>(output), "large SHA-256 fixture should be written");
+    const auto million_a =
+        copperfin::security::sha256_hex_for_file(utf8_path(million_a_path));
+    expect(
+        million_a.ok &&
+            million_a.hex_digest ==
+                "cdc76e5c9914fb9281a1c7e284d73e67"
+                "f1809a48a497200e046d39ccc7112cd0",
+        "streaming file SHA-256 should match the million-a vector; observed=" +
+            million_a.hex_digest);
+}
+
+void test_artifact_admission(const std::filesystem::path& running_executable) {
+    namespace fs = std::filesystem;
+    const fs::path temp_root = unique_temp_root();
+    const fs::path artifact =
+        temp_root /
+        (std::string("candidate") + running_executable.extension().string());
+    std::error_code ignored;
+    fs::remove_all(temp_root, ignored);
+    fs::create_directories(temp_root, ignored);
+    expect(!ignored, "artifact admission root should be created");
+    if (ignored || !copy_executable(running_executable, artifact)) {
+        expect(false, "artifact admission executable fixture should be copied");
+        fs::remove_all(temp_root, ignored);
+        return;
+    }
+
+    test_streaming_sha256(temp_root);
+    const auto artifact_digest =
+        copperfin::security::sha256_hex_for_file(utf8_path(artifact));
+    expect(artifact_digest.ok, "artifact fixture should have a SHA-256 digest");
+    if (!artifact_digest.ok) {
+        fs::remove_all(temp_root, ignored);
+        return;
+    }
+
+    const auto request = admission_request(
+        artifact,
+        temp_root,
+        artifact_digest.hex_digest);
+    auto admitted = copperfin::platform::admit_polyglot_artifact(request);
+    expect(
+        admitted.ok() &&
+            admitted.error_code() == "polyglot.artifact.admitted" &&
+            admitted.capability_id() == request.capability_id &&
+            admitted.artifact_sha256() == artifact_digest.hex_digest &&
+            admitted.authorization().allowed,
+        "matching rooted artifact identity and digest should be admitted");
+    expect(
+        copperfin::platform::revalidate_polyglot_artifact_admission(admitted),
+        "unchanged artifact admission should revalidate");
+
+    auto invalid_capability = request;
+    invalid_capability.capability_id = "Interop.Sample";
+    const auto invalid_capability_result =
+        copperfin::platform::admit_polyglot_artifact(invalid_capability);
+    expect(
+        !invalid_capability_result.ok() &&
+            invalid_capability_result.error_code() ==
+                "polyglot.artifact.invalid_capability_id",
+        "noncanonical capability id should fail before authorization");
+
+    auto invalid_digest = request;
+    invalid_digest.expected_sha256[0] = 'A';
+    const auto invalid_digest_result =
+        copperfin::platform::admit_polyglot_artifact(invalid_digest);
+    expect(
+        !invalid_digest_result.ok() &&
+            invalid_digest_result.error_code() ==
+                "polyglot.artifact.invalid_expected_sha256",
+        "uppercase digest should fail canonical admission");
+
+    auto missing_root = request;
+    missing_root.process_policy.allowed_path_roots.clear();
+    const auto missing_root_result =
+        copperfin::platform::admit_polyglot_artifact(missing_root);
+    expect(
+        !missing_root_result.ok() &&
+            missing_root_result.error_code() ==
+                "polyglot.artifact.allowed_root_required",
+        "artifact admission should require an explicit allowed root on every platform");
+
+    auto wrong_root = request;
+    wrong_root.process_policy.allowed_path_roots = {
+        utf8_path(temp_root / "sibling")};
+    const auto wrong_root_result =
+        copperfin::platform::admit_polyglot_artifact(wrong_root);
+    expect(
+        !wrong_root_result.ok() &&
+            wrong_root_result.error_code() ==
+                "polyglot.artifact.authorization_denied" &&
+            !wrong_root_result.authorization().allowed,
+        "artifact outside the configured root should fail closed");
+
+    auto wrong_digest = request;
+    wrong_digest.expected_sha256[0] =
+        wrong_digest.expected_sha256[0] == '0' ? '1' : '0';
+    const auto wrong_digest_result =
+        copperfin::platform::admit_polyglot_artifact(wrong_digest);
+    expect(
+        !wrong_digest_result.ok() &&
+            wrong_digest_result.error_code() ==
+                "polyglot.artifact.sha256_mismatch" &&
+            wrong_digest_result.artifact_sha256().empty() &&
+            !wrong_digest_result.authorization().allowed,
+        "digest mismatch should revoke authorization metadata");
+
+    auto content_admission =
+        copperfin::platform::admit_polyglot_artifact(request);
+    std::ofstream append(artifact, std::ios::binary | std::ios::app);
+    append.write("changed", 7);
+    append.close();
+    expect(
+        static_cast<bool>(append),
+        "artifact content-change fixture should be written");
+    expect(
+        !copperfin::platform::revalidate_polyglot_artifact_admission(
+            content_admission) &&
+            !content_admission.ok() &&
+            content_admission.error_code() ==
+                "polyglot.artifact.contents_changed_before_execution" &&
+            content_admission.artifact_sha256().empty() &&
+            !content_admission.authorization().allowed,
+        "in-place artifact content change should revoke admission");
+    const std::string content_change_error = content_admission.error_code();
+    expect(
+        !copperfin::platform::revalidate_polyglot_artifact_admission(
+            content_admission) &&
+            content_admission.error_code() == content_change_error,
+        "revoked admission should remain revoked without losing its reason");
+
+    expect(
+        copy_executable(running_executable, artifact),
+        "artifact fixture should be restored after content-change case");
+    const auto restored_digest =
+        copperfin::security::sha256_hex_for_file(utf8_path(artifact));
+    auto identity_admission = copperfin::platform::admit_polyglot_artifact(
+        admission_request(artifact, temp_root, restored_digest.hex_digest));
+    fs::remove(artifact, ignored);
+    expect(!ignored, "artifact replacement fixture should remove admitted identity");
+    expect(
+        copy_executable(running_executable, artifact),
+        "artifact replacement fixture should create a new physical identity");
+    expect(
+        !copperfin::platform::revalidate_polyglot_artifact_admission(
+            identity_admission) &&
+            identity_admission.error_code() ==
+                "polyglot.artifact.changed_before_execution",
+        "physical artifact replacement should revoke admission even for identical bytes");
+
+    fs::remove_all(temp_root, ignored);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    const std::filesystem::path running_executable =
+        copperfin::platform::resolve_running_executable_path(
+            argc > 0 && argv[0] != nullptr
+                ? std::filesystem::path(argv[0])
+                : std::filesystem::path{});
+    expect(
+        !running_executable.empty(),
+        "running test executable path should resolve");
+    if (!running_executable.empty()) {
+        test_artifact_admission(running_executable);
+    }
+    if (failures != 0) {
+        std::cerr << failures
+                  << " polyglot artifact admission test(s) failed\n";
+        return 1;
+    }
+    std::cout << "All polyglot artifact admission tests passed\n";
+    return 0;
+}

--- a/tests/test_polyglot_artifact_admission.cpp
+++ b/tests/test_polyglot_artifact_admission.cpp
@@ -258,8 +258,11 @@ void test_artifact_admission(const std::filesystem::path& running_executable) {
         copperfin::security::sha256_hex_for_file(utf8_path(artifact));
     auto identity_admission = copperfin::platform::admit_polyglot_artifact(
         admission_request(artifact, temp_root, restored_digest.hex_digest));
-    fs::remove(artifact, ignored);
-    expect(!ignored, "artifact replacement fixture should remove admitted identity");
+    const fs::path retained_identity = temp_root / "retained-admitted-identity";
+    fs::rename(artifact, retained_identity, ignored);
+    expect(
+        !ignored,
+        "artifact replacement fixture should retain the admitted physical identity");
     expect(
         copy_executable(running_executable, artifact),
         "artifact replacement fixture should create a new physical identity");


### PR DESCRIPTION
## What changed

- add an opaque, fail-closed admission token for external polyglot executable artifacts
- require a canonical capability ID, an explicit allowed root, existing external-process authorization, and an exact lowercase SHA-256
- revalidate policy, physical file identity, and exact bytes immediately before a future execution boundary
- replace whole-file SHA-256 buffering with fixed-memory incremental hashing on Windows and POSIX
- add portable regression and isolation coverage for denial, mutation, replacement, and standard SHA-256 vectors

## Why

The existing polyglot foundations define routes, envelopes, and bounded process behavior, but did not yet bind a configured capability to an approved, exact external executable artifact. This supplies that prerequisite without launching a process or claiming route-dispatch completion.

## Validation

- GCC focused/adjacent suite: 12/12
- admission repeat: 20/20 consecutive runs
- Clang 21 ASan/UBSan: 2/2
- Clang static analyzer: zero diagnostics for both owned implementation files
- `git diff --check`

Exact candidate `e5f974df2` passes Linux Native `31354311198` and macOS Native
`31354312629` at 332/332, the macOS four-locale matrix at 8/8, and Windows
Native `31354314025` at 331/331. The focused regression passes on every host;
all eight candidate-head protected checks passed. Evidence-only head
`caf652a99` records those results and is undergoing final protected checks.

Closes part of #4700; the umbrella remains open for route dispatch and execution integration.
