### PR TITLE
Compose portable polyglot route execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+- 2026-08-10: Added the #4937 portable polyglot route-execution coordinator
+  under #4700. It applies the existing `off`, `shadow`, deterministic `canary`,
+  `on`, and `retire-legacy` decisions without introducing a second routing
+  model. Native work runs synchronously through a caller-owned callback on the
+  calling thread; candidate work can run only through the existing admitted-
+  artifact adapter. Shadow invokes each path once, preserves native authority,
+  compares caller-normalized values, and records parity. Candidate-primary
+  failure may execute native exactly once only when route and bridge policy
+  both permit it; retire-legacy never invokes native, and a configured second-
+  artifact fallback is reported as unsupported rather than executed. Results
+  preserve stable status/reason IDs, authority, exact invocation counts,
+  adapter evidence, parity, selected-fallback telemetry, and a distinct
+  `polyglot.fallback.executed` event for work actually performed. Invalid
+  registry/request/callback configuration fails before either path. Local GCC
+  focused and adjacent contracts pass `9/9`, the regression repeats `20/20`,
+  Clang 21 ASan/UBSan passes, focused static analysis reports no diagnostic,
+  and the isolation contract records a portable, process-owned, bounded-child,
+  network-free test. Hosted Linux/macOS/Windows validation is pending. This is
+  not PRG dispatch, inline foreign source, language hosting, mutable-runtime
+  worker callbacks, retry, second-artifact fallback, or atomic handle-bound
+  launch; no runtime stub or no-op was added.
+
 - 2026-08-10: Connected the #4700 admitted-artifact invocation boundary. One
   opaque admission token now composes with deterministic request
   serialization, exact bounded stdin/stdout/stderr transport, strict response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   failure may execute native exactly once only when route and bridge policy
   both permit it; retire-legacy never invokes native, and a configured second-
   artifact fallback is reported as unsupported rather than executed. Results
+  distinguish terminal propagated cancellation from ignored cancellation that
+  bridge policy converts to fail-fast or fallback handling. They also
   preserve stable status/reason IDs, authority, exact invocation counts,
   adapter evidence, parity, selected-fallback telemetry, and a distinct
   `polyglot.fallback.executed` event for work actually performed. Invalid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@
   focused and adjacent contracts pass `9/9`, the regression repeats `20/20`,
   Clang 21 ASan/UBSan passes, focused static analysis reports no diagnostic,
   and the isolation contract records a portable, process-owned, bounded-child,
-  network-free test. Hosted Linux/macOS/Windows validation is pending. This is
-  not PRG dispatch, inline foreign source, language hosting, mutable-runtime
-  worker callbacks, retry, second-artifact fallback, or atomic handle-bound
-  launch; no runtime stub or no-op was added.
+  network-free test. Exact candidate `7aa16ffc4` passes Linux Native
+  `31415789574` and macOS Native `31415789554` at `334/334`, the macOS locale
+  matrix at `8/8`, and Windows Native `31415789688` at `333/333`; the focused
+  regression and all eight candidate-head protected checks pass. This is not
+  PRG dispatch, inline foreign source, language hosting, mutable-runtime worker
+  callbacks, retry, second-artifact fallback, or atomic handle-bound launch; no
+  runtime stub or no-op was added.
 
 - 2026-08-10: Connected the #4700 admitted-artifact invocation boundary. One
   opaque admission token now composes with deterministic request

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ add_library(cf_platform_profile
     src/platform/polyglot_interop_envelope.cpp
     src/platform/polyglot_migration_telemetry.cpp
     src/platform/polyglot_parity_comparator.cpp
+    src/platform/polyglot_route_execution.cpp
     src/platform/polyglot_route_registry.cpp
     src/platform/query_translator.cpp
 )

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -28,8 +28,10 @@ Local GCC focused plus adjacent package/isolation/polyglot contracts pass
 `9/9`, and the focused regression repeats `20/20`. Clang 21 ASan/UBSan passes;
 focused `clang-tidy` reports no diagnostic and `git diff --check` is clean. The
 test is portable, parallel-safe, synthetic, process-owned, bounded-child, and
-network-free. Hosted Linux/macOS/Windows validation remains pending before this
-candidate can merge.
+network-free. Exact candidate `7aa16ffc4` passes Linux Native `31415789574` and
+macOS Native `31415789554` at `334/334`, the macOS locale matrix at `8/8`, and
+Windows Native `31415789688` at `333/333`; the focused regression passes on all
+three hosts and all eight candidate-head protected checks pass.
 
 This is not PRG dispatch, a second task lifecycle, inline foreign source,
 language-specific hosting, retry, a second-artifact fallback, a foreign-thread

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -12,6 +12,8 @@ Candidate-selected `canary` and `on` return candidate on success; a candidate
 failure executes native at most once only when both the route and bridge policy
 permit it. `retire-legacy` never invokes native. A selected second-artifact
 fallback is preserved as policy evidence but is not executed.
+Propagated cancellation remains terminal; ignored cancellation follows the
+bridge's fail-fast or fallback decision without being mislabeled as propagated.
 
 The result records invariant status and reason IDs, native/candidate authority,
 exact invocation counts, adapter evidence, parity, route/bridge telemetry, and

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,40 @@
 # Agent Handoff
 
+## V1 polyglot route-execution candidate
+
+The approved #4937/#4700 slice now composes the existing route registry,
+admitted-artifact adapter, bridge policy, parity comparator, and telemetry as
+one portable execution contract. `off` and native-selected `canary` invoke only
+a synchronous caller-owned native callback on the calling thread. `shadow`
+invokes native and candidate once each, keeps native authoritative even when
+candidate fails or mismatches, and compares caller-supplied normalized values.
+Candidate-selected `canary` and `on` return candidate on success; a candidate
+failure executes native at most once only when both the route and bridge policy
+permit it. `retire-legacy` never invokes native. A selected second-artifact
+fallback is preserved as policy evidence but is not executed.
+
+The result records invariant status and reason IDs, native/candidate authority,
+exact invocation counts, adapter evidence, parity, route/bridge telemetry, and
+whether native fallback actually ran. `polyglot.fallback.applied` retains its
+existing meaning of a selected policy response; new
+`polyglot.fallback.executed` distinguishes performed native work. Missing or
+malformed registry state, noncanonical capability/sample, missing admission or
+required callback, and callback exceptions fail closed. Denied or changed
+artifact identity still fails through the existing adapter without launch.
+
+Local GCC focused plus adjacent package/isolation/polyglot contracts pass
+`9/9`, and the focused regression repeats `20/20`. Clang 21 ASan/UBSan passes;
+focused `clang-tidy` reports no diagnostic and `git diff --check` is clean. The
+test is portable, parallel-safe, synthetic, process-owned, bounded-child, and
+network-free. Hosted Linux/macOS/Windows validation remains pending before this
+candidate can merge.
+
+This is not PRG dispatch, a second task lifecycle, inline foreign source,
+language-specific hosting, retry, a second-artifact fallback, a foreign-thread
+callback into mutable runtime state, or atomic handle-bound launch. PRG-facing
+routing and language adapters remain under the broader polyglot workstream; no
+runtime stub or no-op was added.
+
 ## V1 polyglot artifact invocation adapter candidate
 
 The approved #4700 composition slice now connects one opaque admitted-artifact
@@ -35,12 +70,13 @@ pass. Final local package-document, package-signer, isolation, and adapter
 selection passes `4/4`; Clang 21 ASan/UBSan focused passes. The superseded runs
 are not final evidence.
 
-This is not route execution, native/shadow invocation, fallback execution,
-retry, PRG dispatch, a mutable-runtime callback, or a language-specific
-runtime. Adjacent path revalidation narrows TOCTOU exposure but does not make
-the launch atomic or handle-bound; that stronger operating-system binding
-remains separate work. No runtime stub or no-op was added, so the runtime stub
-inventory is unchanged.
+The newer route-execution candidate above now consumes this adapter for native,
+shadow, candidate-primary, and permitted native-fallback composition. This
+adapter itself still does not choose a route or execute fallback. Neither layer
+adds retry, PRG dispatch, a mutable-runtime worker callback, or a language-
+specific runtime. Adjacent path revalidation narrows TOCTOU exposure but does
+not make launch atomic or handle-bound. No runtime stub or no-op was added, so
+the runtime stub inventory is unchanged.
 
 ## V1 polyglot artifact-admission candidate
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -453,9 +453,12 @@ Retire-legacy never invokes native, and no second artifact is executed. Stable
 status, authority, invocation counts, route/bridge/parity events, and distinct
 selected-versus-executed fallback evidence are retained. Local GCC focused and
 adjacent contracts pass `9/9`, the regression repeats `20/20`, and Clang 21
-ASan/UBSan plus focused static analysis pass. Hosted native matrices remain
-pending. Retry, PRG dispatch, mutable-runtime worker callbacks, language-
-specific adapters, and atomic handle-bound launch remain open.
+ASan/UBSan plus focused static analysis pass. Exact candidate `7aa16ffc4`
+passes Linux Native `31415789574` and macOS Native `31415789554` at `334/334`,
+the macOS locale matrix at `8/8`, and Windows Native `31415789688` at
+`333/333`; the focused regression and all eight candidate-head protected checks
+pass. Retry, PRG dispatch, mutable-runtime worker callbacks, language-specific
+adapters, and atomic handle-bound launch remain open.
 
 The next #91/#4700 bridge prerequisite now validates versioned candidate
 response envelopes before downstream use. Success and error shapes are

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -442,9 +442,20 @@ Clang 21 ASan/UBSan plus focused static analysis are clean. Exact candidate
 `333/333`, the macOS locale matrix at `8/8`, and Windows Native `31363043544`
 at `332/332`; the focused regression passes everywhere and all eight
 candidate-head protected checks pass. Path revalidation narrows TOCTOU exposure
-but is not atomic handle-bound execution. Route execution, native/shadow calls,
-retry, fallback execution, PRG dispatch, mutable-runtime callbacks, and
-language-specific adapters remain open.
+but is not atomic handle-bound execution.
+
+The next portable polyglot seam now composes existing route selection with
+synchronous caller-owned native work and the admitted-artifact adapter. It
+applies `off`, `shadow`, deterministic `canary`, `on`, and `retire-legacy`;
+shadow preserves native authority and records normalized parity, while native
+fallback runs at most once only when both route and bridge policy permit it.
+Retire-legacy never invokes native, and no second artifact is executed. Stable
+status, authority, invocation counts, route/bridge/parity events, and distinct
+selected-versus-executed fallback evidence are retained. Local GCC focused and
+adjacent contracts pass `9/9`, the regression repeats `20/20`, and Clang 21
+ASan/UBSan plus focused static analysis pass. Hosted native matrices remain
+pending. Retry, PRG dispatch, mutable-runtime worker callbacks, language-
+specific adapters, and atomic handle-bound launch remain open.
 
 The next #91/#4700 bridge prerequisite now validates versioned candidate
 response envelopes before downstream use. Success and error shapes are

--- a/docs/10-dotnet-interop.md
+++ b/docs/10-dotnet-interop.md
@@ -17,8 +17,10 @@ Current maturity:
 - The portable artifact-bridge foundation now composes a deterministic,
   versioned request, one admitted external artifact, bounded
   stdin/stdout/stderr execution, strict matching response admission, bridge
-  outcome reporting, and migration telemetry. It does not select a route,
-  identify a managed runtime, or expose this exchange through PRG dispatch.
+  outcome reporting, and migration telemetry. A portable coordinator now
+  applies existing native/shadow/canary/on/retire-legacy route decisions around
+  that adapter, but does not identify a managed runtime or expose this exchange
+  through PRG dispatch.
 - A portable artifact-admission prerequisite now binds a canonical capability,
   explicit rooted external-process policy, exact SHA-256, and physical file
   identity in an opaque token that is revocable on pre-execution revalidation.
@@ -48,8 +50,8 @@ runtime threads must not call directly into mutable Copperfin runtime state;
 completion must return through a controlled host/scheduler boundary.
 
 Existing `SPAWN` tasks separately provide PRG-supervised status, cooperative
-cancellation, completed result, and print-output retrieval. The artifact
-invocation adapter is not yet routed through that task boundary.
+cancellation, completed result, and print-output retrieval. The route executor
+is not yet exposed through that task boundary.
 
 The native `CFJSONVALID()`, `CFJSONTYPE()`, and `CFJSONGET()` facade gives PRG
 code a bounded way to inspect immutable structured results from that boundary.

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -234,8 +234,11 @@ artifact token is still rejected by the adapter and cannot be bypassed here.
 Local GCC focused and adjacent contracts pass `9/9`, and the focused regression
 repeats `20/20`. Clang 21 ASan/UBSan and focused static analysis pass. The
 portable isolation record is parallel-safe, synthetic, process-owned,
-bounded-child, and network-free. Hosted Linux, macOS, and Windows native
-validation is pending.
+bounded-child, and network-free. Exact candidate `7aa16ffc4` passes Linux Native
+`31415789574` and macOS Native `31415789554` at `334/334`, the macOS locale
+matrix at `8/8`, and Windows Native `31415789688` at `333/333`; the focused
+regression passes on every host and all eight candidate-head protected checks
+pass.
 
 This seam does not expose PRG dispatch, introduce a second task lifecycle,
 permit inline foreign-language source, host a language runtime, or allow a

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -201,6 +201,11 @@ can enter only through `invoke_polyglot_artifact`, retaining its exact identity
 revalidation, one-attempt process ownership, bounded transport, strict response
 admission, cancellation, timeout, and invariant bridge evidence.
 
+Propagated cancellation is terminal and never falls back. When policy
+explicitly ignores cancellation, the bridge decision instead follows its
+configured fail-fast, native-fallback, or unsupported second-artifact outcome;
+the coordinator does not misreport ignored cancellation as propagated.
+
 Lifecycle behavior is exact:
 
 - `off` and a native-selected `canary` invoke native once and no candidate;

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -25,6 +25,10 @@ Current maturity:
   descendant cleanup, and independently bounded exact-byte stdout/stderr
   capture. The artifact invocation adapter below now consumes this primitive;
   neither layer is a PRG route or language integration by itself.
+- A portable route-execution coordinator now applies the existing lifecycle
+  decision to synchronous caller-owned native work and the admitted-artifact
+  adapter. It composes shadow parity and one permitted native fallback, but is
+  not yet exposed through PRG dispatch or a language-specific adapter.
 - A separate portable admission boundary now binds a canonical capability ID
   and rooted external-process authorization to one exact lowercase SHA-256 and
   physical file identity. Its opaque token must be revalidated before a later
@@ -187,6 +191,52 @@ execute a fallback, expose PRG dispatch, call mutable runtime state, or embed a
 language runtime. Revalidation materially narrows the validation-to-use window,
 but path-based execution is not an atomic handle-bound launch; that stronger
 operating-system binding remains separate work.
+
+## Route Execution Coordinator v1
+
+`execute_polyglot_route` applies one validated route registry to a canonical
+capability and deterministic `0..99` selection sample. Native work is a
+synchronous caller-owned callback invoked on the calling thread. Candidate work
+can enter only through `invoke_polyglot_artifact`, retaining its exact identity
+revalidation, one-attempt process ownership, bounded transport, strict response
+admission, cancellation, timeout, and invariant bridge evidence.
+
+Lifecycle behavior is exact:
+
+- `off` and a native-selected `canary` invoke native once and no candidate;
+- `shadow` invokes native and candidate once each, always keeps native
+  authoritative, and passes caller-normalized values to the parity comparator;
+- a candidate-selected `canary` and `on` invoke candidate once as primary;
+- candidate failure invokes native once only when both the route decision and
+  bridge decision allow native fallback; and
+- `retire-legacy` never invokes native, even when candidate policy selects it.
+
+The coordinator never retries and never executes a second-artifact fallback.
+Its result retains route decision, native and candidate results, parity,
+authority, exact invocation counts, and whether native fallback actually ran.
+Stable `polyglot.execution.*` identifiers classify invalid configuration and
+terminal outcome. Route, adapter/bridge, parity, and final status evidence are
+one ordered stream. Existing `polyglot.fallback.applied` means policy selected
+a fallback; `polyglot.fallback.executed` separately proves that the coordinator
+actually invoked native.
+
+Missing or malformed in-memory registry state, noncanonical capability, sample
+outside `0..99`, missing candidate admission, or a missing required native or
+shadow-normalizer callback fails before either path. Native and normalization
+exceptions are contained with invariant failure codes. A mismatched or changed
+artifact token is still rejected by the adapter and cannot be bypassed here.
+
+Local GCC focused and adjacent contracts pass `9/9`, and the focused regression
+repeats `20/20`. Clang 21 ASan/UBSan and focused static analysis pass. The
+portable isolation record is parallel-safe, synthetic, process-owned,
+bounded-child, and network-free. Hosted Linux, macOS, and Windows native
+validation is pending.
+
+This seam does not expose PRG dispatch, introduce a second task lifecycle,
+permit inline foreign-language source, host a language runtime, or allow a
+foreign worker to call mutable Copperfin runtime state. It also does not provide
+retry, second-artifact fallback, discovery, dependency installation, or atomic
+handle-bound launch. Those remain separately reviewable work.
 
 ## Bounded Artifact Process Primitive
 
@@ -360,13 +410,16 @@ mismatch count:
 | --- | --- | --- |
 | `polyglot.route.selected` | Route registry selected native, shadow, canary, on, or retire-legacy | `capability_id`, `reason_code`, `detail` |
 | `polyglot.fallback.applied` | A configured native or artifact fallback was selected | `capability_id`, `reason_code`, `detail` |
+| `polyglot.fallback.executed` | The route coordinator actually invoked native fallback | `capability_id`, `reason_code`, `detail` |
 | `polyglot.parity.checked` | Native/candidate comparison completed | `capability_id`, `reason_code`, `mismatch_count` |
 | `polyglot.parity.mismatch` | Comparison found a parity difference | `capability_id`, `reason_code`, `mismatch_count` |
 | `polyglot.latency.outcome` | Invocation latency or terminal outcome was classified | `capability_id`, `reason_code`, `latency_ms`, `detail` |
+| `polyglot.execution.completed` | One route execution reached a terminal authoritative outcome | `capability_id`, `reason_code`, `detail` |
 
 These event names, fields, reason codes, and enum values are machine contracts and are
-not localized. The telemetry model only records decisions; it does not make a route,
-start a bridge, or alter existing PRG runtime events by itself.
+not localized. The telemetry helpers only record evidence; the coordinator above is
+the separate component that applies a route and never alters existing PRG runtime
+events by itself.
 
 ## Developer Migration Playbook v1
 

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -308,8 +308,9 @@ matches the events `cf_security`'s `audit_stream` emits today.
 
 ### docs/11 — Engineering Spec: Copperfin .NET Bridge
 
-**Status: spec'd in full, with a portable policy gateway and one artifact-first
-invocation adapter; CLR hosting and parity-call execution remain absent.** The
+**Status: spec'd in full, with a portable policy gateway, artifact-first
+invocation adapter, and route executor; CLR hosting and PRG-facing parity-call
+execution remain absent.** The
 document specs four native modules (`cf_dotnet_host`, `cf_dotnet_marshaler`,
 `cf_dotnet_policy`,
 `cf_dotnet_codegen`), three managed surfaces, a typed marshaling contract for 11
@@ -340,13 +341,17 @@ The portable artifact-admission prerequisite separately binds a canonical
 capability, explicit rooted external-process policy, exact SHA-256, and
 physical file identity in an opaque, revocable token. It repeats policy,
 identity, and exact-byte hashing before execution. The portable artifact
-invocation adapter now connects that token to deterministic request
+invocation adapter connects that token to deterministic request
 serialization, one bounded child-process attempt, strict response admission,
 bridge outcome/fallback reporting, and migration telemetry. It revalidates
 immediately beside its owned path-based launch, but this is not an atomic
-handle-bound execution primitive. It does not select a route, invoke native or
-shadow behavior, execute fallback, retry, expose PRG dispatch, call mutable
-runtime state, or supply a language-specific adapter.
+handle-bound execution primitive. The portable route executor now applies the
+existing lifecycle decisions, invokes synchronous caller-owned native work,
+uses only that adapter for candidate work, preserves native authority during
+shadow comparison, and performs one native fallback only when route and bridge
+policy both allow it. It does not retry, execute a second artifact, expose PRG
+dispatch, call mutable runtime state from a foreign worker, or supply a
+language-specific adapter.
 It also exposes bounded native JSON validation, type inspection, and JSON
 Pointer selection so PRG can examine immutable structured completion payloads
 without embedding foreign source or losing exact number spelling.
@@ -357,7 +362,7 @@ The native payload facade also exposes bounded exact-byte SHA-256,
 HMAC-SHA256 generation/verification, and strict canonical Base64 encode/decode
 for PRG-controlled immutable results,
 without claiming sender authentication, encryption, or executable trust.
-Artifact dispatch and managed execution remain absent.
+PRG-facing artifact dispatch and managed execution remain absent.
 
 **What it will take:** none of the four named native execution/marshaling
 modules exist yet. What exists today, per `docs/28-repository-ontology.md` §3, is
@@ -461,11 +466,11 @@ excluded from the compliance map above:
 | 01 | Product Charter | Partial | Empty exception registry makes the Compatibility Fidelity Rule unfalsifiable |
 | 03 | Compatibility And Migration | Scaffold-only (migrator) | Zero code toward the 9-file migration tool output contract |
 | 04 | Security Model | Scaffold (aspirational) | No enterprise identity/Shield product surface distinct from `cf_security` |
-| 11 | .NET Bridge Spec | Partial (Windows DECLARE plus portable policy/adapter) | None of the four named native `cf_dotnet_*` modules exist |
+| 11 | .NET Bridge Spec | Partial (Windows DECLARE plus portable policy/adapter/route executor) | None of the four named native `cf_dotnet_*` modules exist |
 | 12 | VFP Asset Editing And Execution | Partial | xAsset execution is first-pass, bounded by language-surface coverage |
 | 13 | Index Format Notes | Partial | No index write fidelity; collation hints are heuristic, not named |
 | 18 | Native Security And RBAC | Partial (real baseline) | Not yet verified against docs/04's fuller vision |
-| 19 | Polyglot And AI Subprojects | Partial (portable artifact boundary) | No PRG route or language-specific runtime hook; AI/MCP policy has little to govern yet |
+| 19 | Polyglot And AI Subprojects | Partial (portable artifact boundary and route executor) | No PRG dispatch or language-specific runtime hook; AI/MCP policy has little to govern yet |
 | 20 | Runtime Build And Debug Pipeline | Partial | Engine is PRG-first, not the full command surface |
 | 21 | Database Federation And Query Translation | Partial (real seed) | No live connector execution behind the translator/planner |
 | 22 | VFP Language Reference Coverage | Partial, measured | 1,411 documented items; official surface exceeds current runtime |

--- a/include/copperfin/platform/polyglot_route_execution.h
+++ b/include/copperfin/platform/polyglot_route_execution.h
@@ -1,0 +1,95 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#pragma once
+
+#include "copperfin/platform/polyglot_artifact_adapter.h"
+#include "copperfin/platform/polyglot_parity_comparator.h"
+#include "copperfin/platform/polyglot_route_registry.h"
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace copperfin::platform {
+
+enum class PolyglotRouteExecutionStatus : std::uint8_t {
+    success,
+    invalid_request,
+    native_failed,
+    candidate_failed,
+    cancelled,
+    parity_failed
+};
+
+enum class PolyglotRouteResultAuthority : std::uint8_t {
+    none,
+    native,
+    candidate
+};
+
+struct PolyglotNativeInvocationResult {
+    bool success = false;
+    std::string error_code;
+    // Opaque caller-owned result bytes. The coordinator does not parse or
+    // reinterpret native runtime state.
+    std::string payload;
+};
+
+struct PolyglotShadowParityValues {
+    std::vector<PolyglotParityField> fields;
+    std::vector<std::string> native_order;
+    std::vector<std::string> candidate_order;
+};
+
+using PolyglotNativeInvoker = std::function<PolyglotNativeInvocationResult()>;
+using PolyglotShadowParityNormalizer = std::function<PolyglotShadowParityValues(
+    const PolyglotNativeInvocationResult&,
+    const PolyglotArtifactInvocationResult&)>;
+
+struct PolyglotRouteExecutionRequest {
+    const PolyglotRouteRegistry* registry = nullptr;
+    std::string capability_id;
+    std::uint8_t selection_sample = 0U;
+    PolyglotArtifactAdmissionResult* artifact_admission = nullptr;
+    PolyglotArtifactInvocationRequest candidate_request;
+    PolyglotNativeInvoker invoke_native;
+    PolyglotShadowParityNormalizer normalize_shadow_parity;
+    PolyglotParityPolicy parity_policy;
+};
+
+struct PolyglotRouteExecutionResult {
+    PolyglotRouteExecutionStatus status =
+        PolyglotRouteExecutionStatus::invalid_request;
+    PolyglotRouteResultAuthority authority = PolyglotRouteResultAuthority::none;
+    std::string error_code = "polyglot.execution.invalid_request";
+    PolyglotRouteDecision route;
+    PolyglotNativeInvocationResult native;
+    PolyglotArtifactInvocationResult candidate;
+    PolyglotParityComparisonResult parity;
+    bool parity_evaluated = false;
+    bool native_fallback_executed = false;
+    std::uint32_t native_invocation_count = 0U;
+    std::uint32_t candidate_invocation_count = 0U;
+    PolyglotMigrationTelemetryStream telemetry;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return status == PolyglotRouteExecutionStatus::success;
+    }
+};
+
+// Applies one already-validated registry decision. Native work is invoked
+// synchronously through the caller-owned callback on this calling thread.
+// Candidate work can run only through invoke_polyglot_artifact. No retry or
+// second-artifact fallback is performed.
+[[nodiscard]] PolyglotRouteExecutionResult execute_polyglot_route(
+    const PolyglotRouteExecutionRequest& request);
+
+[[nodiscard]] const char* polyglot_route_execution_status_name(
+    PolyglotRouteExecutionStatus status) noexcept;
+[[nodiscard]] const char* polyglot_route_result_authority_name(
+    PolyglotRouteResultAuthority authority) noexcept;
+
+}  // namespace copperfin::platform

--- a/src/platform/polyglot_route_execution.cpp
+++ b/src/platform/polyglot_route_execution.cpp
@@ -124,7 +124,7 @@ void finish_candidate(PolyglotRouteExecutionResult& result) {
     if (result.candidate.ok()) {
         result.status = PolyglotRouteExecutionStatus::success;
         result.error_code = "polyglot.execution.candidate_success";
-    } else if (result.candidate.status == PolyglotArtifactInvocationStatus::cancelled) {
+    } else if (result.candidate.decision.cancellation_propagated) {
         result.status = PolyglotRouteExecutionStatus::cancelled;
         result.error_code = result.candidate.error_code;
     } else {

--- a/src/platform/polyglot_route_execution.cpp
+++ b/src/platform/polyglot_route_execution.cpp
@@ -1,0 +1,284 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/polyglot_route_execution.h"
+
+#include <exception>
+#include <string>
+#include <utility>
+
+namespace copperfin::platform {
+
+namespace {
+
+bool canonical_capability_id(const std::string& capability_id) {
+    return load_polyglot_route_registry({
+        PolyglotRouteConfig{capability_id, "off", 0U}}).ok();
+}
+
+bool valid_route_state(const PolyglotRouteState state) noexcept {
+    switch (state) {
+    case PolyglotRouteState::off:
+    case PolyglotRouteState::shadow:
+    case PolyglotRouteState::canary:
+    case PolyglotRouteState::on:
+    case PolyglotRouteState::retire_legacy:
+        return true;
+    }
+    return false;
+}
+
+bool valid_registry(const PolyglotRouteRegistry& registry) {
+    std::vector<PolyglotRouteConfig> configs;
+    configs.reserve(registry.entries.size());
+    for (const PolyglotRouteEntry& entry : registry.entries) {
+        if (!valid_route_state(entry.state)) {
+            return false;
+        }
+        configs.push_back(PolyglotRouteConfig{
+            entry.capability_id,
+            polyglot_route_state_name(entry.state),
+            entry.canary_percentage});
+    }
+    return load_polyglot_route_registry(configs).ok();
+}
+
+void append_telemetry(
+    PolyglotMigrationTelemetryStream& destination,
+    const PolyglotMigrationTelemetryStream& source) {
+    destination.events.insert(
+        destination.events.end(), source.events.begin(), source.events.end());
+}
+
+void record_execution_event(
+    PolyglotRouteExecutionResult& result,
+    const std::string& capability_id) {
+    result.telemetry.events.push_back(
+        PolyglotMigrationEvent{
+            "polyglot.execution.completed",
+            capability_id,
+            result.error_code,
+            polyglot_route_result_authority_name(result.authority),
+            0U,
+            0U,
+            result.ok()});
+}
+
+void record_fallback_execution(
+    PolyglotRouteExecutionResult& result,
+    const std::string& capability_id) {
+    result.telemetry.events.push_back(
+        PolyglotMigrationEvent{
+            "polyglot.fallback.executed",
+            capability_id,
+            result.native.success
+                ? "polyglot.execution.native_fallback_success"
+                : "polyglot.execution.native_fallback_failed",
+            "native",
+            0U,
+            0U,
+            result.native.success});
+}
+
+void invoke_native_once(
+    const PolyglotRouteExecutionRequest& request,
+    PolyglotRouteExecutionResult& result) {
+    ++result.native_invocation_count;
+    try {
+        result.native = request.invoke_native();
+        if (!result.native.success && result.native.error_code.empty()) {
+            result.native.error_code = "polyglot.execution.native_failed";
+        }
+    } catch (const std::exception&) {
+        result.native = {
+            false, "polyglot.execution.native_exception", {}};
+    } catch (...) {
+        result.native = {
+            false, "polyglot.execution.native_exception", {}};
+    }
+}
+
+void invoke_candidate_once(
+    const PolyglotRouteExecutionRequest& request,
+    PolyglotRouteExecutionResult& result) {
+    ++result.candidate_invocation_count;
+    result.candidate = invoke_polyglot_artifact(
+        *request.artifact_admission, request.candidate_request);
+    append_telemetry(result.telemetry, result.candidate.telemetry);
+}
+
+void finish_native(PolyglotRouteExecutionResult& result) {
+    result.authority = PolyglotRouteResultAuthority::native;
+    if (result.native.success) {
+        result.status = PolyglotRouteExecutionStatus::success;
+        result.error_code = "polyglot.execution.native_success";
+    } else {
+        result.status = PolyglotRouteExecutionStatus::native_failed;
+        result.error_code = result.native.error_code;
+    }
+}
+
+void finish_candidate(PolyglotRouteExecutionResult& result) {
+    result.authority = PolyglotRouteResultAuthority::candidate;
+    if (result.candidate.ok()) {
+        result.status = PolyglotRouteExecutionStatus::success;
+        result.error_code = "polyglot.execution.candidate_success";
+    } else if (result.candidate.status == PolyglotArtifactInvocationStatus::cancelled) {
+        result.status = PolyglotRouteExecutionStatus::cancelled;
+        result.error_code = result.candidate.error_code;
+    } else {
+        result.status = PolyglotRouteExecutionStatus::candidate_failed;
+        result.error_code = result.candidate.decision.use_artifact_fallback
+            ? "polyglot.execution.artifact_fallback_unsupported"
+            : result.candidate.error_code;
+    }
+}
+
+bool request_is_valid(
+    const PolyglotRouteExecutionRequest& request,
+    const PolyglotRouteDecision& route,
+    std::string& error_code) {
+    if (route.invoke_candidate && request.artifact_admission == nullptr) {
+        error_code = "polyglot.execution.artifact_admission_required";
+        return false;
+    }
+    const bool fallback_may_need_native = route.candidate_primary &&
+        route.native_fallback_allowed &&
+        request.candidate_request.policy.fallback ==
+            PolyglotFallbackPolicy::fallback_native;
+    if ((route.invoke_native || fallback_may_need_native) && !request.invoke_native) {
+        error_code = "polyglot.execution.native_invoker_required";
+        return false;
+    }
+    if (route.selection == PolyglotRouteSelection::shadow &&
+        !request.normalize_shadow_parity) {
+        error_code = "polyglot.execution.shadow_normalizer_required";
+        return false;
+    }
+    return true;
+}
+
+void compare_shadow(
+    const PolyglotRouteExecutionRequest& request,
+    PolyglotRouteExecutionResult& result) {
+    try {
+        PolyglotShadowParityValues values = request.normalize_shadow_parity(
+            result.native, result.candidate);
+        PolyglotParityComparisonRequest comparison;
+        comparison.capability_id = request.capability_id;
+        comparison.native_success = result.native.success;
+        comparison.candidate_success = result.candidate.ok();
+        comparison.native_error_code = result.native.error_code;
+        comparison.candidate_error_code = result.candidate.error_code;
+        comparison.fields = std::move(values.fields);
+        comparison.native_order = std::move(values.native_order);
+        comparison.candidate_order = std::move(values.candidate_order);
+        result.parity = compare_polyglot_outputs(
+            request.parity_policy, comparison);
+        result.parity_evaluated = true;
+        record_polyglot_parity_events(result.telemetry, comparison, result.parity);
+    } catch (const std::exception&) {
+        result.status = PolyglotRouteExecutionStatus::parity_failed;
+        result.error_code = "polyglot.execution.shadow_normalizer_exception";
+    } catch (...) {
+        result.status = PolyglotRouteExecutionStatus::parity_failed;
+        result.error_code = "polyglot.execution.shadow_normalizer_exception";
+    }
+}
+
+}  // namespace
+
+PolyglotRouteExecutionResult execute_polyglot_route(
+    const PolyglotRouteExecutionRequest& request) {
+    PolyglotRouteExecutionResult result;
+    if (request.registry == nullptr) {
+        result.error_code = "polyglot.execution.registry_required";
+        return result;
+    }
+
+    if (!canonical_capability_id(request.capability_id)) {
+        result.error_code = "polyglot.execution.invalid_capability_id";
+        return result;
+    }
+    if (request.selection_sample > 99U) {
+        result.error_code = "polyglot.execution.invalid_selection_sample";
+        return result;
+    }
+    if (!valid_registry(*request.registry)) {
+        result.error_code = "polyglot.execution.invalid_registry";
+        return result;
+    }
+
+    result.route = evaluate_polyglot_route(
+        *request.registry, request.capability_id, request.selection_sample);
+    if (!request_is_valid(request, result.route, result.error_code)) {
+        return result;
+    }
+    record_polyglot_route_event(
+        result.telemetry, request.capability_id, result.route);
+
+    if (result.route.selection == PolyglotRouteSelection::native) {
+        invoke_native_once(request, result);
+        finish_native(result);
+        record_execution_event(result, request.capability_id);
+        return result;
+    }
+
+    if (result.route.selection == PolyglotRouteSelection::shadow) {
+        invoke_native_once(request, result);
+        invoke_candidate_once(request, result);
+        finish_native(result);
+        compare_shadow(request, result);
+        record_execution_event(result, request.capability_id);
+        return result;
+    }
+
+    invoke_candidate_once(request, result);
+    if (!result.candidate.ok() &&
+        result.candidate.decision.use_native_fallback &&
+        result.route.native_fallback_allowed) {
+        invoke_native_once(request, result);
+        result.native_fallback_executed = true;
+        finish_native(result);
+        record_fallback_execution(result, request.capability_id);
+    } else {
+        finish_candidate(result);
+    }
+    record_execution_event(result, request.capability_id);
+    return result;
+}
+
+const char* polyglot_route_execution_status_name(
+    const PolyglotRouteExecutionStatus status) noexcept {
+    switch (status) {
+    case PolyglotRouteExecutionStatus::success:
+        return "success";
+    case PolyglotRouteExecutionStatus::invalid_request:
+        return "invalid-request";
+    case PolyglotRouteExecutionStatus::native_failed:
+        return "native-failed";
+    case PolyglotRouteExecutionStatus::candidate_failed:
+        return "candidate-failed";
+    case PolyglotRouteExecutionStatus::cancelled:
+        return "cancelled";
+    case PolyglotRouteExecutionStatus::parity_failed:
+        return "parity-failed";
+    }
+    return "invalid-request";
+}
+
+const char* polyglot_route_result_authority_name(
+    const PolyglotRouteResultAuthority authority) noexcept {
+    switch (authority) {
+    case PolyglotRouteResultAuthority::none:
+        return "none";
+    case PolyglotRouteResultAuthority::native:
+        return "native";
+    case PolyglotRouteResultAuthority::candidate:
+        return "candidate";
+    }
+    return "none";
+}
+
+}  // namespace copperfin::platform

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4686,6 +4686,11 @@ copperfin_add_test(test_polyglot_artifact_adapter
     test_polyglot_artifact_adapter.cpp
 )
 
+copperfin_add_test(test_polyglot_route_execution
+    "cf_security;cf_platform_profile;cf_platform_support"
+    test_polyglot_route_execution.cpp
+)
+
 copperfin_add_test(test_polyglot_interop_envelope cf_platform_profile
     test_polyglot_interop_envelope.cpp
 )

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -148,6 +148,16 @@ function(copperfin_configure_native_test_isolation)
         PLATFORM portable
         AUDIT complete
     )
+    copperfin_set_test_isolation(test_polyglot_route_execution
+        PARALLEL_SAFE
+        FILESYSTEM process-owned
+        ENVIRONMENT scoped-process
+        CHILD_PROCESSES bounded
+        NETWORK none
+        SAMPLES none
+        PLATFORM portable
+        AUDIT complete
+    )
     copperfin_set_test_isolation(test_bounded_process
         PARALLEL_SAFE
         FILESYSTEM process-owned

--- a/tests/test_polyglot_route_execution.cpp
+++ b/tests/test_polyglot_route_execution.cpp
@@ -454,6 +454,38 @@ void test_timeout_and_cancellation(
                cancelled.candidate_invocation_count == 1U &&
                cancelled.candidate.process.process_tree_closed,
            "#4937: propagated cancellation should close candidate and never fall back");
+
+    polls.store(0U);
+    auto ignored = base_request(
+        routes, &admission, root, "--route-sleep");
+    ignored.candidate_request.policy.cancellation =
+        PolyglotCancellationPolicy::ignore;
+    ignored.candidate_request.policy.fallback =
+        PolyglotFallbackPolicy::fallback_native;
+    ignored.candidate_request.cancellation_requested = [&polls]() {
+        return polls.fetch_add(1U) >= 2U;
+    };
+    const auto ignored_native = execute_polyglot_route(ignored);
+    expect(ignored_native.ok() && ignored_native.native_fallback_executed &&
+               ignored_native.candidate.decision.failure ==
+                   PolyglotBridgeFailure::cancellation &&
+               !ignored_native.candidate.decision.cancellation_propagated &&
+               ignored_native.native_invocation_count == 1U &&
+               ignored_native.candidate_invocation_count == 1U,
+           "#4937: ignored cancellation may use one policy-permitted native fallback");
+
+    polls.store(0U);
+    auto ignored_artifact = ignored;
+    ignored_artifact.candidate_request.policy.fallback =
+        PolyglotFallbackPolicy::fallback_artifact;
+    const auto unsupported = execute_polyglot_route(ignored_artifact);
+    expect(unsupported.status == PolyglotRouteExecutionStatus::candidate_failed &&
+               unsupported.error_code ==
+                   "polyglot.execution.artifact_fallback_unsupported" &&
+               unsupported.native_invocation_count == 0U &&
+               unsupported.candidate_invocation_count == 1U &&
+               !has_event(unsupported, "polyglot.fallback.executed"),
+           "#4937: ignored cancellation must not disguise unsupported artifact fallback");
 }
 
 void test_fail_closed_configuration(

--- a/tests/test_polyglot_route_execution.cpp
+++ b/tests/test_polyglot_route_execution.cpp
@@ -1,0 +1,628 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/executable_path.h"
+#include "copperfin/platform/path.h"
+#include "copperfin/platform/polyglot_route_execution.h"
+#include "copperfin/security/sha256.h"
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <fcntl.h>
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace {
+
+using namespace copperfin::platform;
+
+constexpr const char* capability_id = "interop.route-v1";
+constexpr const char* correlation_id = "route-corr-001";
+constexpr const char* protocol_version = "1.0.0";
+constexpr const char* arguments_json = R"json({"value":"route"})json";
+constexpr const char* expected_request =
+    R"json({"envelope_version":"1.0","kind":"invocation","capability_id":"interop.route-v1","correlation_id":"route-corr-001","protocol_version":"1.0.0","arguments":{"value":"route"}})json";
+constexpr const char* success_response =
+    R"json({"envelope_version":"1.0","kind":"success","capability_id":"interop.route-v1","correlation_id":"route-corr-001","protocol_version":"1.0.0","payload":{"value":"ok"}})json";
+constexpr const char* error_response =
+    R"json({"envelope_version":"1.0","kind":"error","capability_id":"interop.route-v1","correlation_id":"route-corr-001","protocol_version":"1.0.0","error":{"code":"candidate.synthetic","message":"expected","retryable":false}})json";
+
+int failures = 0;
+
+void expect(const bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        ++failures;
+    }
+}
+
+void configure_binary_standard_streams() {
+#if defined(_WIN32)
+    (void)::_setmode(::_fileno(stdin), _O_BINARY);
+    (void)::_setmode(::_fileno(stdout), _O_BINARY);
+    (void)::_setmode(::_fileno(stderr), _O_BINARY);
+#endif
+}
+
+int run_artifact(const std::string& mode) {
+    configure_binary_standard_streams();
+    const std::string request{
+        std::istreambuf_iterator<char>(std::cin),
+        std::istreambuf_iterator<char>()};
+    if (request != expected_request) {
+        return 23;
+    }
+    if (mode == "--route-success") {
+        std::cout << success_response;
+        return 0;
+    }
+    if (mode == "--route-error") {
+        std::cout << error_response;
+        return 0;
+    }
+    if (mode == "--route-sleep") {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        std::cout << success_response;
+        return 0;
+    }
+    return 24;
+}
+
+unsigned long process_id() {
+#if defined(_WIN32)
+    return static_cast<unsigned long>(::GetCurrentProcessId());
+#else
+    return static_cast<unsigned long>(::getpid());
+#endif
+}
+
+std::filesystem::path unique_root() {
+    return std::filesystem::temp_directory_path() /
+        ("copperfin_polyglot_route_execution_" +
+         std::to_string(process_id()) + "_" +
+         std::to_string(
+             std::chrono::steady_clock::now().time_since_epoch().count()));
+}
+
+std::string utf8_path(const std::filesystem::path& path) {
+    return copperfin::platform::path_to_utf8_string(path);
+}
+
+bool copy_executable(
+    const std::filesystem::path& source,
+    const std::filesystem::path& destination) {
+    std::error_code error;
+    std::filesystem::copy_file(
+        source, destination,
+        std::filesystem::copy_options::overwrite_existing, error);
+    if (error) {
+        return false;
+    }
+#if !defined(_WIN32)
+    std::filesystem::permissions(
+        destination,
+        std::filesystem::perms::owner_read |
+            std::filesystem::perms::owner_write |
+            std::filesystem::perms::owner_exec,
+        std::filesystem::perm_options::add,
+        error);
+#endif
+    return !error;
+}
+
+PolyglotArtifactAdmissionResult admit(
+    const std::filesystem::path& artifact,
+    const std::filesystem::path& root,
+    const std::string& admitted_capability = capability_id) {
+    const auto digest = copperfin::security::sha256_hex_for_file(
+        utf8_path(artifact));
+    expect(digest.ok, "route fixture should have a readable digest");
+    return admit_polyglot_artifact({
+        .capability_id = admitted_capability,
+        .process_policy = {
+            .executable_name = utf8_path(artifact),
+            .allowed_path_roots = {utf8_path(root)},
+            .allowed_publishers = {},
+            .require_trusted_signature = false},
+        .expected_sha256 = digest.hex_digest});
+}
+
+PolyglotArtifactInvocationRequest candidate(
+    const std::filesystem::path& root,
+    const std::string& mode,
+    const PolyglotFallbackPolicy fallback = PolyglotFallbackPolicy::fail_fast) {
+    return {
+        .invocation = {
+            .capability_id = capability_id,
+            .correlation_id = correlation_id,
+            .protocol_version = protocol_version,
+            .arguments_json = arguments_json},
+        .policy = {
+            .timeout_ms = 5000U,
+            .latency_budget_ms = 4500U,
+            .cancellation = PolyglotCancellationPolicy::propagate,
+            .fallback = fallback,
+            .max_attempts = 1U},
+        .artifact_arguments = {mode},
+        .working_directory = utf8_path(root),
+        .environment = {},
+        .poll_interval_ms = 5U,
+        .stdin_limit_bytes = 1024U * 1024U,
+        .stdout_limit_bytes = 1024U * 1024U,
+        .stderr_limit_bytes = 1024U * 1024U,
+        .cancellation_requested = {}};
+}
+
+PolyglotRouteRegistry registry_for(
+    const std::string& state,
+    const std::uint8_t canary_percentage = 0U) {
+    const auto loaded = load_polyglot_route_registry({
+        {capability_id, state, canary_percentage}});
+    expect(loaded.ok(), "route execution registry should load");
+    return loaded.registry;
+}
+
+PolyglotNativeInvocationResult native_success() {
+    return {true, {}, "native-ok"};
+}
+
+PolyglotShadowParityValues parity_values(
+    const PolyglotNativeInvocationResult& native,
+    const PolyglotArtifactInvocationResult& artifact,
+    const std::string& candidate_value = "ok") {
+    return {
+        {{"$.value", "string", "string",
+          native.success ? "ok" : "", artifact.ok() ? candidate_value : ""}},
+        {"$.value"},
+        {"$.value"}};
+}
+
+bool has_event(
+    const PolyglotRouteExecutionResult& result,
+    const std::string& category) {
+    for (const auto& event : result.telemetry.events) {
+        if (event.category == category) {
+            return true;
+        }
+    }
+    return false;
+}
+
+const PolyglotMigrationEvent* find_event(
+    const PolyglotRouteExecutionResult& result,
+    const std::string& category) {
+    for (const auto& event : result.telemetry.events) {
+        if (event.category == category) {
+            return &event;
+        }
+    }
+    return nullptr;
+}
+
+PolyglotRouteExecutionRequest base_request(
+    const PolyglotRouteRegistry& routes,
+    PolyglotArtifactAdmissionResult* admission,
+    const std::filesystem::path& root,
+    const std::string& mode = "--route-success") {
+    PolyglotRouteExecutionRequest request;
+    request.registry = &routes;
+    request.capability_id = capability_id;
+    request.artifact_admission = admission;
+    request.candidate_request = candidate(root, mode);
+    request.invoke_native = native_success;
+    request.normalize_shadow_parity = [](
+        const PolyglotNativeInvocationResult& native,
+        const PolyglotArtifactInvocationResult& artifact) {
+        return parity_values(native, artifact);
+    };
+    return request;
+}
+
+void test_native_and_canary_routes(
+    PolyglotArtifactAdmissionResult& admission,
+    const std::filesystem::path& root) {
+    const auto off_routes = registry_for("off");
+    const auto canary_routes = registry_for("canary", 50U);
+    const std::thread::id calling_thread = std::this_thread::get_id();
+    std::thread::id native_thread;
+    auto off_request = base_request(off_routes, nullptr, root);
+    off_request.invoke_native = [&]() {
+        native_thread = std::this_thread::get_id();
+        return native_success();
+    };
+    const auto off = execute_polyglot_route(off_request);
+    expect(off.ok() && off.authority == PolyglotRouteResultAuthority::native &&
+               off.native_invocation_count == 1U &&
+               off.candidate_invocation_count == 0U &&
+               native_thread == calling_thread,
+           "#4937: off should synchronously invoke only native on the caller thread");
+    const auto* off_completion = find_event(
+        off, "polyglot.execution.completed");
+    expect(off.telemetry.events.size() == 2U && off_completion != nullptr &&
+               off_completion->capability_id == capability_id &&
+               off_completion->reason_code ==
+                   "polyglot.execution.native_success" &&
+               off_completion->detail == "native" &&
+               std::string(polyglot_route_execution_status_name(off.status)) ==
+                   "success" &&
+               std::string(polyglot_route_result_authority_name(off.authority)) ==
+                   "native",
+           "#4937: native completion evidence and public names should be invariant");
+
+    const PolyglotRouteRegistry empty_routes;
+    auto default_off_request = base_request(empty_routes, nullptr, root);
+    const auto default_off = execute_polyglot_route(default_off_request);
+    expect(default_off.ok() &&
+               default_off.route.reason_code == "polyglot.route.default_off" &&
+               default_off.native_invocation_count == 1U &&
+               default_off.candidate_invocation_count == 0U,
+           "#4937: an absent capability should retain the registry's safe default-off path");
+
+    auto canary_native_request = base_request(
+        canary_routes, nullptr, root);
+    canary_native_request.selection_sample = 50U;
+    const auto canary_native = execute_polyglot_route(canary_native_request);
+    expect(canary_native.ok() &&
+               canary_native.route.selection == PolyglotRouteSelection::native &&
+               canary_native.native_invocation_count == 1U &&
+               canary_native.candidate_invocation_count == 0U,
+           "#4937: canary percentage boundary should remain native");
+
+    auto canary_candidate_request = base_request(
+        canary_routes, &admission, root);
+    canary_candidate_request.selection_sample = 49U;
+    const auto canary_candidate = execute_polyglot_route(canary_candidate_request);
+    expect(canary_candidate.ok() &&
+               canary_candidate.authority == PolyglotRouteResultAuthority::candidate &&
+               canary_candidate.native_invocation_count == 0U &&
+               canary_candidate.candidate_invocation_count == 1U,
+           "#4937: sample below the canary boundary should invoke candidate once");
+}
+
+void test_shadow_routes(
+    PolyglotArtifactAdmissionResult& admission,
+    const std::filesystem::path& root) {
+    const auto routes = registry_for("shadow");
+    auto matching_request = base_request(
+        routes, &admission, root);
+    const auto matching = execute_polyglot_route(matching_request);
+    expect(matching.ok() &&
+               matching.authority == PolyglotRouteResultAuthority::native &&
+               matching.native.payload == "native-ok" &&
+               matching.native_invocation_count == 1U &&
+               matching.candidate_invocation_count == 1U &&
+               matching.parity_evaluated && matching.parity.parity_match,
+           "#4937: shadow match should invoke both once and keep native authoritative");
+    expect(has_event(matching, "polyglot.parity.checked"),
+           "#4937: shadow match should emit deterministic parity evidence");
+
+    auto mismatch_request = matching_request;
+    mismatch_request.normalize_shadow_parity = [](
+        const PolyglotNativeInvocationResult& native,
+        const PolyglotArtifactInvocationResult& artifact) {
+        return parity_values(native, artifact, "different");
+    };
+    const auto mismatch = execute_polyglot_route(mismatch_request);
+    expect(mismatch.ok() &&
+               mismatch.authority == PolyglotRouteResultAuthority::native &&
+               mismatch.parity_evaluated && !mismatch.parity.parity_match &&
+               has_event(mismatch, "polyglot.parity.mismatch"),
+           "#4937: shadow mismatch should remain native and record the mismatch");
+
+    auto candidate_failure = base_request(
+        routes, &admission, root, "--route-error");
+    const auto failed_candidate = execute_polyglot_route(candidate_failure);
+    expect(failed_candidate.ok() &&
+               failed_candidate.authority == PolyglotRouteResultAuthority::native &&
+               failed_candidate.parity.first_mismatch ==
+                   PolyglotParityMismatchCategory::candidate_failure,
+           "#4937: shadow candidate failure should not displace native authority");
+
+    auto native_failure = matching_request;
+    native_failure.invoke_native = [] {
+        return PolyglotNativeInvocationResult{
+            false, "native.synthetic", {}};
+    };
+    const auto failed_native = execute_polyglot_route(native_failure);
+    expect(failed_native.status == PolyglotRouteExecutionStatus::native_failed &&
+               failed_native.authority == PolyglotRouteResultAuthority::native &&
+               failed_native.candidate_invocation_count == 1U &&
+               failed_native.parity.first_mismatch ==
+                   PolyglotParityMismatchCategory::native_failure,
+           "#4937: shadow should return a failed native result even when candidate succeeds");
+}
+
+void test_candidate_and_fallback_routes(
+    PolyglotArtifactAdmissionResult& admission,
+    const std::filesystem::path& root) {
+    const auto on_routes = registry_for("on");
+    const auto retired_routes = registry_for("retire-legacy");
+    auto on = base_request(on_routes, &admission, root);
+    const auto candidate_success = execute_polyglot_route(on);
+    expect(candidate_success.ok() &&
+               candidate_success.authority == PolyglotRouteResultAuthority::candidate &&
+               candidate_success.native_invocation_count == 0U &&
+               candidate_success.candidate_invocation_count == 1U,
+           "#4937: on should return one successful candidate invocation");
+
+    auto fallback = base_request(
+        on_routes, &admission, root, "--route-error");
+    fallback.candidate_request.policy.fallback =
+        PolyglotFallbackPolicy::fallback_native;
+    const auto native_fallback = execute_polyglot_route(fallback);
+    const auto* executed = find_event(
+        native_fallback, "polyglot.fallback.executed");
+    expect(native_fallback.ok() && native_fallback.native_fallback_executed &&
+               native_fallback.authority == PolyglotRouteResultAuthority::native &&
+               native_fallback.native_invocation_count == 1U &&
+               native_fallback.candidate_invocation_count == 1U &&
+               executed != nullptr &&
+               executed->reason_code ==
+                   "polyglot.execution.native_fallback_success" &&
+               executed->detail == "native" && executed->successful,
+           "#4937: permitted native fallback should execute exactly once and be explicit");
+
+    auto fallback_failure = fallback;
+    fallback_failure.invoke_native = [] {
+        return PolyglotNativeInvocationResult{false, "native.fallback.failed", {}};
+    };
+    const auto failed_fallback = execute_polyglot_route(fallback_failure);
+    expect(failed_fallback.status == PolyglotRouteExecutionStatus::native_failed &&
+               failed_fallback.native_fallback_executed &&
+               failed_fallback.native_invocation_count == 1U &&
+               failed_fallback.candidate_invocation_count == 1U,
+           "#4937: a failed native fallback should remain bounded and authoritative");
+
+    auto fail_fast = base_request(
+        on_routes, &admission, root, "--route-error");
+    const auto failed = execute_polyglot_route(fail_fast);
+    expect(failed.status == PolyglotRouteExecutionStatus::candidate_failed &&
+               failed.authority == PolyglotRouteResultAuthority::candidate &&
+               failed.native_invocation_count == 0U &&
+               failed.candidate_invocation_count == 1U,
+           "#4937: candidate fail-fast should not invoke native");
+
+    auto second_artifact = fail_fast;
+    second_artifact.candidate_request.policy.fallback =
+        PolyglotFallbackPolicy::fallback_artifact;
+    const auto unsupported = execute_polyglot_route(second_artifact);
+    expect(unsupported.error_code ==
+               "polyglot.execution.artifact_fallback_unsupported" &&
+               unsupported.native_invocation_count == 0U &&
+               unsupported.candidate_invocation_count == 1U &&
+               has_event(unsupported, "polyglot.fallback.applied") &&
+               !has_event(unsupported, "polyglot.fallback.executed"),
+           "#4937: second-artifact fallback should be reported but never executed");
+
+    auto retired = base_request(
+        retired_routes, &admission, root, "--route-error");
+    retired.candidate_request.policy.fallback =
+        PolyglotFallbackPolicy::fallback_native;
+    const auto retired_failure = execute_polyglot_route(retired);
+    expect(retired_failure.status == PolyglotRouteExecutionStatus::candidate_failed &&
+               !retired_failure.native_fallback_executed &&
+               retired_failure.native_invocation_count == 0U &&
+               retired_failure.candidate_invocation_count == 1U &&
+               !has_event(retired_failure, "polyglot.fallback.executed"),
+           "#4937: retire-legacy must never return to native");
+}
+
+void test_timeout_and_cancellation(
+    PolyglotArtifactAdmissionResult& admission,
+    const std::filesystem::path& root) {
+    const auto routes = registry_for("on");
+    auto timeout = base_request(
+        routes, &admission, root, "--route-sleep");
+    timeout.candidate_request.policy.timeout_ms = 50U;
+    timeout.candidate_request.policy.latency_budget_ms = 40U;
+    timeout.candidate_request.policy.fallback =
+        PolyglotFallbackPolicy::fallback_native;
+    const auto timed_out = execute_polyglot_route(timeout);
+    expect(timed_out.ok() && timed_out.native_fallback_executed &&
+               timed_out.candidate.process.status == BoundedProcessStatus::timed_out &&
+               timed_out.native_invocation_count == 1U &&
+               timed_out.candidate_invocation_count == 1U,
+           "#4937: timed-out candidate should close then use one permitted native fallback");
+
+    std::atomic_uint polls{0U};
+    auto cancellation = base_request(
+        routes, &admission, root, "--route-sleep");
+    cancellation.candidate_request.cancellation_requested = [&polls]() {
+        return polls.fetch_add(1U) >= 2U;
+    };
+    const auto cancelled = execute_polyglot_route(cancellation);
+    expect(cancelled.status == PolyglotRouteExecutionStatus::cancelled &&
+               cancelled.authority == PolyglotRouteResultAuthority::candidate &&
+               cancelled.native_invocation_count == 0U &&
+               cancelled.candidate_invocation_count == 1U &&
+               cancelled.candidate.process.process_tree_closed,
+           "#4937: propagated cancellation should close candidate and never fall back");
+}
+
+void test_fail_closed_configuration(
+    PolyglotArtifactAdmissionResult& admission,
+    const std::filesystem::path& root) {
+    const auto off_routes = registry_for("off");
+    const auto on_routes = registry_for("on");
+    const auto shadow_routes = registry_for("shadow");
+    const auto canary_routes = registry_for("canary", 50U);
+    PolyglotRouteExecutionRequest absent;
+    const auto no_registry = execute_polyglot_route(absent);
+    expect(no_registry.error_code == "polyglot.execution.registry_required" &&
+               no_registry.telemetry.events.empty(),
+           "#4937: missing registry should fail before trusted telemetry");
+
+    auto invalid_id = base_request(off_routes, nullptr, root);
+    invalid_id.capability_id = "INVALID/ROUTE";
+    const auto invalid = execute_polyglot_route(invalid_id);
+    expect(invalid.error_code == "polyglot.execution.invalid_capability_id" &&
+               invalid.native_invocation_count == 0U &&
+               invalid.telemetry.events.empty(),
+           "#4937: invalid capability should fail before callbacks or telemetry");
+
+    PolyglotRouteRegistry malformed_registry;
+    malformed_registry.entries = {
+        {capability_id, PolyglotRouteState::on, 0U},
+        {capability_id, PolyglotRouteState::off, 0U}};
+    auto invalid_registry = base_request(
+        malformed_registry, &admission, root);
+    const auto malformed = execute_polyglot_route(invalid_registry);
+    expect(malformed.error_code == "polyglot.execution.invalid_registry" &&
+               malformed.native_invocation_count == 0U &&
+               malformed.candidate_invocation_count == 0U &&
+               malformed.telemetry.events.empty(),
+           "#4937: malformed in-memory registry should fail before either path runs");
+
+    auto invalid_sample = base_request(canary_routes, nullptr, root);
+    invalid_sample.selection_sample = 100U;
+    const auto sample = execute_polyglot_route(invalid_sample);
+    expect(sample.error_code == "polyglot.execution.invalid_selection_sample" &&
+               sample.native_invocation_count == 0U,
+           "#4937: selection samples outside 0..99 should fail closed");
+
+    auto missing_admission = base_request(on_routes, nullptr, root);
+    const auto no_admission = execute_polyglot_route(missing_admission);
+    expect(no_admission.error_code ==
+               "polyglot.execution.artifact_admission_required" &&
+               no_admission.candidate_invocation_count == 0U,
+           "#4937: a candidate route should require an admission token");
+
+    auto missing_native = base_request(off_routes, nullptr, root);
+    missing_native.invoke_native = {};
+    const auto no_native = execute_polyglot_route(missing_native);
+    expect(no_native.error_code == "polyglot.execution.native_invoker_required" &&
+               no_native.native_invocation_count == 0U,
+           "#4937: a native route should require a native callback");
+
+    auto missing_normalizer = base_request(
+        shadow_routes, &admission, root);
+    missing_normalizer.normalize_shadow_parity = {};
+    const auto no_normalizer = execute_polyglot_route(missing_normalizer);
+    expect(no_normalizer.error_code ==
+               "polyglot.execution.shadow_normalizer_required" &&
+               no_normalizer.native_invocation_count == 0U &&
+               no_normalizer.candidate_invocation_count == 0U,
+           "#4937: shadow should validate its normalizer before either path runs");
+
+    auto native_exception = base_request(off_routes, nullptr, root);
+    native_exception.invoke_native = []() -> PolyglotNativeInvocationResult {
+        throw std::runtime_error("synthetic");
+    };
+    const auto thrown_native = execute_polyglot_route(native_exception);
+    expect(thrown_native.status == PolyglotRouteExecutionStatus::native_failed &&
+               thrown_native.error_code == "polyglot.execution.native_exception" &&
+               thrown_native.native_invocation_count == 1U,
+           "#4937: a native callback exception should fail closed without retry");
+
+    auto normalizer_exception = base_request(
+        shadow_routes, &admission, root);
+    normalizer_exception.normalize_shadow_parity = [](
+        const PolyglotNativeInvocationResult&,
+        const PolyglotArtifactInvocationResult&) -> PolyglotShadowParityValues {
+        throw std::runtime_error("synthetic");
+    };
+    const auto thrown_normalizer = execute_polyglot_route(normalizer_exception);
+    expect(thrown_normalizer.status == PolyglotRouteExecutionStatus::parity_failed &&
+               thrown_normalizer.authority == PolyglotRouteResultAuthority::native &&
+               thrown_normalizer.native.payload == "native-ok" &&
+               thrown_normalizer.native_invocation_count == 1U &&
+               thrown_normalizer.candidate_invocation_count == 1U,
+           "#4937: shadow normalizer failure should preserve the native result and fail closed");
+}
+
+void test_adapter_identity_cannot_be_bypassed(
+    PolyglotArtifactAdmissionResult& admission,
+    const std::filesystem::path& root,
+    const std::filesystem::path& artifact) {
+    const auto routes = registry_for("on");
+    auto mismatch = base_request(routes, &admission, root);
+    mismatch.candidate_request.invocation.capability_id = "interop.other-v1";
+    const auto denied = execute_polyglot_route(mismatch);
+    expect(denied.status == PolyglotRouteExecutionStatus::candidate_failed &&
+               denied.candidate.error_code ==
+                   "polyglot.adapter.capability_id_mismatch" &&
+               !denied.candidate.process.started &&
+               denied.native_invocation_count == 0U &&
+               denied.candidate_invocation_count == 1U,
+           "#4937: coordinator must preserve adapter capability identity rejection");
+
+    auto wrong_hash = admit(artifact, root);
+    {
+        std::ofstream output(artifact, std::ios::binary | std::ios::app);
+        output.put('\0');
+    }
+    auto changed = base_request(routes, &wrong_hash, root);
+    const auto revoked = execute_polyglot_route(changed);
+    expect(revoked.status == PolyglotRouteExecutionStatus::candidate_failed &&
+               !revoked.candidate.process.started &&
+               !wrong_hash.ok() &&
+               revoked.native_invocation_count == 0U &&
+               revoked.candidate_invocation_count == 1U,
+           "#4937: coordinator must preserve adapter byte-identity revalidation");
+}
+
+int run_tests(const std::filesystem::path& running_executable) {
+    const auto root = unique_root();
+    std::error_code error;
+    std::filesystem::create_directories(root, error);
+    expect(!error, "route execution fixture should create its root");
+    if (error) {
+        return 1;
+    }
+
+    const auto artifact = root / running_executable.filename();
+    expect(copy_executable(running_executable, artifact),
+           "route execution fixture should copy its executable");
+    auto admission = admit(artifact, root);
+    expect(admission.ok(), "route execution fixture should admit its executable");
+    if (admission.ok()) {
+        test_native_and_canary_routes(admission, root);
+        test_shadow_routes(admission, root);
+        test_candidate_and_fallback_routes(admission, root);
+        test_timeout_and_cancellation(admission, root);
+        test_fail_closed_configuration(admission, root);
+        test_adapter_identity_cannot_be_bypassed(
+            admission, root, artifact);
+    }
+
+    std::filesystem::remove_all(root, error);
+    expect(!error, "route execution fixture should remove its root");
+    return failures == 0 ? 0 : 1;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    try {
+        if (argc == 2 && std::string(argv[1]).rfind("--route-", 0U) == 0U) {
+            return run_artifact(argv[1]);
+        }
+        const auto executable = resolve_running_executable_path(
+            argc > 0 ? std::filesystem::path(argv[0]) : std::filesystem::path{});
+        if (executable.empty()) {
+            std::cerr << "FAIL: could not resolve route test executable\n";
+            return 1;
+        }
+        return run_tests(executable);
+    } catch (const std::exception& exception) {
+        std::cerr << "FAIL: unexpected exception: " << exception.what() << '\n';
+        return 1;
+    }
+}


### PR DESCRIPTION
## What changed

- add a portable route-execution coordinator over the existing registry, admitted-artifact adapter, bridge policy, parity comparator, and telemetry
- keep native invocation synchronous and caller-owned while candidate invocation remains exclusively adapter-mediated
- implement exact off, shadow, deterministic canary, on, retire-legacy, and one-permitted-native-fallback behavior
- preserve stable authority, status, reason, exact invocation-count, parity, and selected-versus-executed fallback evidence
- add portable regression/isolation coverage and update roadmap, handoff, architecture, compliance, limitations, and changelog evidence

## Why

The existing polyglot components were individually implemented but callers had no single fail-closed contract that applied a route decision across native and admitted candidate paths. This slice closes that composition gap without adding PRG dispatch or a language runtime.

## Validation

- GCC Release focused and adjacent contracts: 9/9
- focused route-execution regression: 20/20 repeat
- Clang 21 ASan/UBSan: pass
- focused clang-tidy: no diagnostics
- git diff --check: pass

Hosted Linux, macOS, and Windows native matrices are required before merge.

Relates to #4937 and #4700.
