### PR TITLE
Suppress failed native polyglot payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
   old unconditional copy makes that exact assertion fail. No current native
   callback was known to populate failure payloads, so this is a fail-closed
   defense before future native adapters make the latent path reachable.
+  Local Release focused and adjacent tests pass `5/5`, the focused target
+  repeats `20/20`, Clang 21 ASan/UBSan passes with leak detection, and the
+  mutation check proves the new assertion is load-bearing. Exact product/test
+  head `edbcecfeb` passes Linux Native `31465221620` and macOS Native
+  `31465221684` at `337/337`, Windows Native `31465221686` at `336/336`, the
+  focused regression on every host, and the macOS locale matrix at `8/8`; all
+  eleven protected checks pass at that head.
 
 - 2026-08-11: Added the first real cross-platform language target for the
   artifact-first polyglot bridge. The checked-in C# sample publishes with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+- 2026-08-11: Hardened the trusted polyglot runtime-host result boundary after
+  review found a latent native-failure asymmetry. Native-authoritative success
+  still publishes its opaque payload, but a failed native callback can no
+  longer place caller-supplied bytes in the PRG-visible payload field. Status,
+  error identity, authority, route selection, invocation counts, and fallback
+  evidence remain unchanged. A focused regression supplies nonempty synthetic
+  failure bytes and requires an empty mapped payload; temporarily restoring the
+  old unconditional copy makes that exact assertion fail. No current native
+  callback was known to populate failure payloads, so this is a fail-closed
+  defense before future native adapters make the latent path reachable.
+
 - 2026-08-11: Added the first real cross-platform language target for the
   artifact-first polyglot bridge. The checked-in C# sample publishes with the
   .NET 10 SDK as one self-contained Native AOT executable for supported

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -20,6 +20,14 @@ check restoring the old unconditional copy fails that exact assertion. This
 changes no route, status, reason, telemetry, localization, process, package,
 debug, or successful-payload contract.
 
+Local Release focused and adjacent tests pass `5/5`; the focused target repeats
+`20/20`; and Clang 21 ASan/UBSan passes with leak detection. Exact product/test
+head `edbcecfeb` passes Linux Native `31465221620` and macOS Native
+`31465221684` at `337/337`, Windows Native `31465221686` at `336/336`, the
+focused regression on every host, and the macOS four-locale matrix at `8/8`.
+All eleven protected checks pass at that implementation head. The follow-up
+documentation commit changes no product or test source.
+
 ## V1 .NET polyglot leaf-candidate implementation
 
 The current #4700/#91 slice supplies the first real language target over the

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,25 @@
 # Agent Handoff
 
+## V1 native-failure payload fail-closed correction
+
+Review of the trusted polyglot runtime-host composition found a latent mapping
+asymmetry: candidate payloads crossed into `RuntimePolyglotDispatchResult` only
+after a successful response, while native-authoritative payload bytes were
+copied without checking `PolyglotNativeInvocationResult::success`. No current
+native invoker populated failure payloads, but a future adapter could otherwise
+have exposed caller-controlled failure bytes through the ordinary PRG evidence
+document.
+
+`map_result()` now publishes native payload bytes only when native authority and
+native success are both true. The native result contract identifies the field
+as success bytes and forbids downstream publication on failure. The focused
+runtime-host regression returns a failed native result with a nonempty
+synthetic payload and proves that status, error, authority, selection, counts,
+and fallback evidence are retained while `payload_json` is empty. A mutation
+check restoring the old unconditional copy fails that exact assertion. This
+changes no route, status, reason, telemetry, localization, process, package,
+debug, or successful-payload contract.
+
 ## V1 .NET polyglot leaf-candidate implementation
 
 The current #4700/#91 slice supplies the first real language target over the

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -502,6 +502,14 @@ candidate `b66e6085f` passes Linux Native `31453166584` and macOS Native
 `31453166506` at `336/336`, Windows Native `31453166516` at `335/335`, the
 focused regression on every host, the macOS locale matrix at `8/8`, and all
 eight candidate-head protected checks without a blocking result.
+Follow-up review found that the runtime-host mapper gated candidate payloads on
+success but copied native-authoritative payload bytes even when the native
+callback reported failure. The fail-closed correction now requires native
+success before publishing those bytes while retaining the existing failure
+status, error, authority, route, counts, and fallback evidence. A focused
+regression supplies nonempty synthetic failure bytes and a mutation check proves
+the guard is load-bearing; no current native callback was known to exercise the
+latent path.
 Language-specific hosting, discovery,
 retry, second-artifact fallback, and atomic handle-bound launch remain separate.
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -509,7 +509,12 @@ success before publishing those bytes while retaining the existing failure
 status, error, authority, route, counts, and fallback evidence. A focused
 regression supplies nonempty synthetic failure bytes and a mutation check proves
 the guard is load-bearing; no current native callback was known to exercise the
-latent path.
+latent path. Local Release focused and adjacent tests pass `5/5`, the focused
+target repeats `20/20`, and Clang 21 ASan/UBSan passes with leak detection.
+Exact product/test head `edbcecfeb` passes Linux Native `31465221620` and macOS
+Native `31465221684` at `337/337`, Windows Native `31465221686` at `336/336`,
+the focused regression everywhere, the macOS locale matrix at `8/8`, and all
+eleven protected checks.
 Language-specific hosting, discovery,
 retry, second-artifact fallback, and atomic handle-bound launch remain separate.
 

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -311,7 +311,12 @@ evidence while publishing an empty payload, matching the existing candidate
 failure behavior. Focused coverage supplies nonempty synthetic native-failure
 bytes, and a mutation check confirms the former unconditional copy fails that
 regression. No current native invoker was known to populate failure payloads;
-the guard is fail-closed preparation for future adapters.
+the guard is fail-closed preparation for future adapters. Local Release
+focused and adjacent tests pass `5/5`, the focused target repeats `20/20`, and
+Clang 21 ASan/UBSan passes with leak detection. Exact product/test head
+`edbcecfeb` passes Linux Native `31465221620` and macOS Native `31465221684` at
+`337/337`, Windows Native `31465221686` at `336/336`, the focused regression on
+every host, the macOS locale matrix at `8/8`, and all eleven protected checks.
 
 The host does not discover artifacts or language runtimes, authorize inline
 foreign source, retry, promote routes, invoke a second artifact, introduce a

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -304,6 +304,15 @@ candidate `b66e6085f` passes Linux Native `31453166584` and macOS Native
 focused regression on every host, the macOS locale matrix at `8/8`, and all
 eight candidate-head protected checks without a blocking result.
 
+Native payload bytes cross from this host into the PRG result only when the
+native callback reports success. A failed native-authoritative result retains
+its status, reason, authority, selection, invocation counts, and fallback
+evidence while publishing an empty payload, matching the existing candidate
+failure behavior. Focused coverage supplies nonempty synthetic native-failure
+bytes, and a mutation check confirms the former unconditional copy fails that
+regression. No current native invoker was known to populate failure payloads;
+the guard is fail-closed preparation for future adapters.
+
 The host does not discover artifacts or language runtimes, authorize inline
 foreign source, retry, promote routes, invoke a second artifact, introduce a
 task model, or permit a foreign worker to enter mutable PRG state. Artifact

--- a/docs/42-prg-polyglot-dispatch.md
+++ b/docs/42-prg-polyglot-dispatch.md
@@ -176,7 +176,13 @@ retains its canonical status, reason, authority, route selection, invocation
 counts, and fallback flag but exposes an empty payload, matching the existing
 candidate-failure rule. The focused regression supplies nonempty synthetic
 failure bytes; restoring the former unconditional copy makes that exact check
-fail. No current native callback was known to populate failure payloads.
+fail. No current native callback was known to populate failure payloads. Local
+Release focused and adjacent tests pass `5/5`, the focused target repeats
+`20/20`, and Clang 21 ASan/UBSan passes with leak detection. Exact product/test
+head `edbcecfeb` passes Linux Native `31465221620` and macOS Native
+`31465221684` at `337/337`, Windows Native `31465221686` at `336/336`, the
+focused regression on every host, the macOS locale matrix at `8/8`, and all
+eleven protected checks.
 
 This PRG integration itself adds no language-specific runtime,
 discovery/install, inline foreign source, retry, second artifact, new task

--- a/docs/42-prg-polyglot-dispatch.md
+++ b/docs/42-prg-polyglot-dispatch.md
@@ -169,6 +169,15 @@ candidate `b66e6085f` passes Linux Native `31453166584` and macOS Native
 focused regression on every host, the macOS locale matrix at `8/8`, and all
 eight candidate-head protected checks without a blocking result.
 
+Follow-up review identified a latent native-failure mapping asymmetry. The host
+now copies native-authoritative payload bytes into the PRG evidence document
+only when `PolyglotNativeInvocationResult::success` is true. Failed native work
+retains its canonical status, reason, authority, route selection, invocation
+counts, and fallback flag but exposes an empty payload, matching the existing
+candidate-failure rule. The focused regression supplies nonempty synthetic
+failure bytes; restoring the former unconditional copy makes that exact check
+fail. No current native callback was known to populate failure payloads.
+
 This PRG integration itself adds no language-specific runtime,
 discovery/install, inline foreign source, retry, second artifact, new task
 lifecycle, mutable PRG callback, or atomic handle-bound launch. The separate

--- a/include/copperfin/platform/polyglot_route_execution.h
+++ b/include/copperfin/platform/polyglot_route_execution.h
@@ -33,8 +33,9 @@ enum class PolyglotRouteResultAuthority : std::uint8_t {
 struct PolyglotNativeInvocationResult {
     bool success = false;
     std::string error_code;
-    // Opaque caller-owned result bytes. The coordinator does not parse or
-    // reinterpret native runtime state.
+    // Opaque caller-owned success bytes. The coordinator does not parse or
+    // reinterpret native runtime state, and downstream boundaries must not
+    // publish these bytes when success is false.
     std::string payload;
 };
 

--- a/src/runtime/polyglot_runtime_host.cpp
+++ b/src/runtime/polyglot_runtime_host.cpp
@@ -127,7 +127,8 @@ RuntimePolyglotDispatchResult map_result(
         .candidate_invocation_count = source.candidate_invocation_count,
         .native_fallback_executed = source.native_fallback_executed,
         .payload_json = {}};
-    if (source.authority == PolyglotRouteResultAuthority::native) {
+    if (source.authority == PolyglotRouteResultAuthority::native &&
+        source.native.success) {
         result.payload_json = source.native.payload;
     } else if (source.authority == PolyglotRouteResultAuthority::candidate &&
                source.candidate.response.ok()) {

--- a/tests/test_polyglot_runtime_host.cpp
+++ b/tests/test_polyglot_runtime_host.cpp
@@ -395,6 +395,27 @@ void test_fallback_error_and_correlation_identity(
         !failed.native_fallback_executed,
         "fail-fast should preserve the existing candidate error identity and counts");
 
+    auto failed_native_config = configuration(admission, root, "off");
+    failed_native_config.capabilities.front().invoke_native = []() {
+        return PolyglotNativeInvocationResult{
+            false,
+            "native.synthetic.failure",
+            R"json({"sensitive":"must-not-cross-runtime-boundary"})json"};
+    };
+    auto failed_native = PolyglotRuntimeHost::create(
+        std::move(failed_native_config));
+    const auto native_failure = dispatch_once(failed_native.host);
+    expect_local(
+        native_failure.status == RuntimePolyglotDispatchStatus::native_failed &&
+        native_failure.error_code == "native.synthetic.failure" &&
+        native_failure.selection == RuntimePolyglotDispatchSelection::native &&
+        native_failure.authority == RuntimePolyglotDispatchAuthority::native &&
+        native_failure.native_invocation_count == 1U &&
+        native_failure.candidate_invocation_count == 0U &&
+        !native_failure.native_fallback_executed &&
+        native_failure.payload_json.empty(),
+        "failed native work must preserve evidence without exposing payload bytes");
+
     auto fallback = PolyglotRuntimeHost::create(configuration(
         admission, root, "on", "--host-error", 0U,
         PolyglotFallbackPolicy::fallback_native));


### PR DESCRIPTION
## What changed

- publish native-authoritative payload bytes only when the native callback reports success
- document `PolyglotNativeInvocationResult::payload` as success-only bytes at downstream boundaries
- add a focused regression with a failed native result carrying nonempty synthetic bytes
- record the fail-closed correction and exact cross-platform validation evidence

## Why

Review of the trusted runtime-host composition found a latent asymmetry: candidate payloads were gated on a successful response, while native-authoritative bytes were copied even when the native callback reported failure. No current native invoker was known to populate failure payloads, but a future adapter could have exposed those bytes through the ordinary PRG evidence document.

This correction preserves native failure status, error identity, authority, route selection, invocation counts, and fallback evidence while forcing the PRG-visible payload empty. Successful native payload behavior is unchanged.

Bounded slice under #113.

## Validation

Exact product/test head `edbcecfebdb39bfe52bd379063eff713b477fcec`:

- Linux Native `31465221620`: 337/337 pass; focused runtime-host regression passes
- macOS Native `31465221684`: 337/337 pass; focused regression passes; locale matrix 8/8
- Windows Native `31465221686`: 336/336 pass; focused regression passes in 0.56 seconds
- all eleven protected checks pass

Local evidence:

- focused and adjacent Release contracts: 5/5 pass
- focused runtime-host repeat: 20/20 pass
- Clang 21 ASan/UBSan with leak detection: pass
- mutation check: restoring the old unconditional copy fails the new assertion exactly
- `git diff --check`: pass
- implementation and evidence commits have DCO sign-off and good Ed25519 OpenPGP signatures

Evidence-only head `6cb68912951412982077f32f95ba558e6bc4fc88` changes documentation only. Static analysis was inspected but is not claimed as passing evidence: it reported existing file-level warnings and compile-command invocation errors, with no diagnostic in the newly added regression block.