### PR TITLE
Add advisory polyglot route impact strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+- 2026-08-11: Added the first #277 measured polyglot routing-strategy
+  contract. `evaluate_polyglot_route_impact()` accepts one canonical
+  capability policy plus direct-C++, C++/.NET-wrapper, and C#-service evidence;
+  hard-gates runtime availability, security approval/profile, contract parity,
+  failures, sample sufficiency, p95 latency, throughput, peak memory, and p95
+  startup; then emits a deterministic integer-weighted preferred route and
+  fallback chain. Invalid or wholly ineligible evidence retains the native
+  no-promotion default. The evaluator is advisory and never runs a workload,
+  invokes an artifact, changes the route registry, or promotes traffic.
+  Focused local Release coverage and the adjacent route/telemetry set pass;
+  Clang 21 ASan/UBSan with leak detection also passes. The representative
+  benchmark runner, checked-in workload results, and hosted matrices remain
+  separate validation before this increment can merge or the broader
+  criterion can close.
+
 - 2026-08-11: Hardened the trusted polyglot runtime-host result boundary after
   review found a latent native-failure asymmetry. Native-authoritative success
   still publishes its opaque payload, but a failed native callback can no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@
   fallback chain. Invalid or wholly ineligible evidence retains the native
   no-promotion default. The evaluator is advisory and never runs a workload,
   invokes an artifact, changes the route registry, or promotes traffic.
-  Focused local Release coverage and the adjacent route/telemetry set pass;
-  Clang 21 ASan/UBSan with leak detection also passes. The representative
-  benchmark runner, checked-in workload results, and hosted matrices remain
-  separate validation before this increment can merge or the broader
-  criterion can close.
+  Focused local Release/adjacent/isolation coverage passes `5/5`, focused
+  repeats pass `20/20`, and Clang 21 ASan/UBSan with leak detection plus focused
+  static analysis pass. Exact signed product/test head `2f21378eb` passes Linux
+  Native `31477286106` and macOS Native `31477287811` at `338/338`, Windows
+  Native `31477289323` at `337/337`, the focused route-impact and isolation
+  contracts on every host, the macOS locale matrix at `8/8`, and all eleven
+  PR-triggered checks. The representative benchmark runner and checked-in
+  workload results remain separate acceptance work before the broader criterion
+  can close.
 
 - 2026-08-11: Hardened the trusted polyglot runtime-host result boundary after
   review found a latent native-failure asymmetry. Native-authoritative success

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ add_library(cf_platform_profile
     src/platform/polyglot_interop_envelope.cpp
     src/platform/polyglot_migration_telemetry.cpp
     src/platform/polyglot_parity_comparator.cpp
+    src/platform/polyglot_route_impact.cpp
     src/platform/polyglot_route_execution.cpp
     src/platform/polyglot_route_registry.cpp
     src/platform/query_translator.cpp

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ License documents:
 - [`docs/41-prg-payload-integrity-and-base64.md`](docs/41-prg-payload-integrity-and-base64.md)
 - [`docs/42-prg-polyglot-dispatch.md`](docs/42-prg-polyglot-dispatch.md)
 - [`docs/43-dotnet-polyglot-candidate.md`](docs/43-dotnet-polyglot-candidate.md)
+- [`docs/44-polyglot-route-impact.md`](docs/44-polyglot-route-impact.md)
 - [`assets/copperfin-logo.png`](assets/copperfin-logo.png)
 
 Current implementation focus:

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,26 @@
 # Agent Handoff
 
+## V1 advisory polyglot route-impact candidate
+
+The current #277 increment adds a deterministic, advisory decision contract for
+already-captured direct-C++, C++/.NET-wrapper, and C#-service measurements. It
+hard-gates unavailable or unapproved runtimes, excessive security exposure,
+contract incompatibility, insufficient samples, execution failures, parity
+mismatches, and latency/throughput/memory/startup budget violations. Eligible
+routes receive locale-independent integer scores, a stable preferred route, and
+an ordered fallback chain. Invalid or wholly ineligible evidence fails closed
+to no recommendation and the native/no-promotion default. The evaluator cannot
+run workloads, invoke artifacts, mutate the route registry, or promote traffic.
+
+Fresh local Release coverage passes the focused target and adjacent route
+registry, route execution, and migration telemetry tests (`4/4`); the focused
+target repeats `20/20`; Clang 21 ASan/UBSan passes with leak detection; focused
+static analysis is clean; and the isolation-contract audit passes. Hosted
+Linux, macOS, and Windows evidence is still required before merge. This
+increment advances but does not close #277: the representative workload runner
+and checked-in benchmark results remain open acceptance work. See
+`docs/44-polyglot-route-impact.md`.
+
 ## V1 native-failure payload fail-closed correction
 
 Review of the trusted polyglot runtime-host composition found a latent mapping

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -12,13 +12,16 @@ an ordered fallback chain. Invalid or wholly ineligible evidence fails closed
 to no recommendation and the native/no-promotion default. The evaluator cannot
 run workloads, invoke artifacts, mutate the route registry, or promote traffic.
 
-Fresh local Release coverage passes the focused target and adjacent route
-registry, route execution, and migration telemetry tests (`4/4`); the focused
-target repeats `20/20`; Clang 21 ASan/UBSan passes with leak detection; focused
-static analysis is clean; and the isolation-contract audit passes. Hosted
-Linux, macOS, and Windows evidence is still required before merge. This
-increment advances but does not close #277: the representative workload runner
-and checked-in benchmark results remain open acceptance work. See
+Fresh local Release coverage passes the focused target, adjacent route
+registry/execution/migration-telemetry targets, and isolation audit (`5/5`);
+the focused target repeats `20/20`; Clang 21 ASan/UBSan passes with leak
+detection; and focused static analysis is clean. Exact signed product/test head
+`2f21378eb` passes Linux Native `31477286106` and macOS Native `31477287811`
+at `338/338`, Windows Native `31477289323` at `337/337`, the focused route
+impact and isolation contracts on every host, and the macOS SET POINT locale
+matrix at `8/8`. All eleven PR-triggered checks pass. This increment advances
+but does not close #277: the representative workload runner and checked-in
+benchmark results remain open acceptance work. See
 `docs/44-polyglot-route-impact.md`.
 
 ## V1 native-failure payload fail-closed correction

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -536,6 +536,17 @@ Generated Launcher Validation `31459366674` independently passes the candidate
 on Windows, Ubuntu, and macOS; all eleven protected PR checks pass at
 documentation head `d0c7ef408`.
 
+The next #277 routing-strategy increment adds a deterministic advisory impact
+evaluator for direct C++, C++/.NET-wrapper, and C#-service implementations.
+It hard-gates availability, security approval/profile, contract parity,
+failures, sample sufficiency, p95 latency, throughput, peak memory, and p95
+startup before ranking eligible routes with integer weighted scores. The
+result contains a stable preferred route and measured fallback chain but cannot
+change the live registry or promote traffic; invalid or insufficient evidence
+retains native/no-promotion behavior. This advances the measured-routing and
+fallback acceptance without claiming it complete: a representative workload
+runner and checked-in benchmark evidence remain open.
+
 The next #91/#4700 bridge prerequisite now validates versioned candidate
 response envelopes before downstream use. Success and error shapes are
 exclusive; all JSON objects have unique keys; unknown top-level/error fields,

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -544,7 +544,11 @@ startup before ranking eligible routes with integer weighted scores. The
 result contains a stable preferred route and measured fallback chain but cannot
 change the live registry or promote traffic; invalid or insufficient evidence
 retains native/no-promotion behavior. This advances the measured-routing and
-fallback acceptance without claiming it complete: a representative workload
+fallback acceptance without claiming it complete. Exact signed product/test
+head `2f21378eb` passes Linux Native `31477286106` and macOS Native
+`31477287811` at `338/338`, Windows Native `31477289323` at `337/337`, the
+focused route-impact and isolation contracts on every host, the macOS locale
+matrix at `8/8`, and all eleven PR-triggered checks. A representative workload
 runner and checked-in benchmark evidence remain open.
 
 The next #91/#4700 bridge prerequisite now validates versioned candidate

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -19,7 +19,9 @@ Everything else must integrate through explicit, auditable boundaries.
 
 Current maturity:
 
-- .NET integration currently exists as an early generated-launcher path: the native runtime pipeline can spawn a generated C# stub as a child process, but generated C# transpilation output is not executed by the runtime host.
+- Generated-launcher C# remains a separate early transpilation path and is not
+  executed by the runtime host. The production polyglot host instead exercises
+  the explicitly admitted Native AOT leaf described below.
 - A portable bounded-process primitive now provides direct executable/argument
   invocation, an explicit child environment, timeout and cancellation handling,
   descendant cleanup, and independently bounded exact-byte stdout/stderr
@@ -38,6 +40,12 @@ Current maturity:
   executable, is admitted by exact hash, and is exercised end to end through
   the production host and ordinary PRG. It is not an embedded runtime or a
   general assembly loader.
+- A deterministic advisory route-impact boundary now evaluates already-captured
+  direct-C++, C++/.NET-wrapper, and C#-service measurements against explicit
+  latency, throughput, memory, startup, security, parity, failure, and sample
+  gates. It produces a stable preferred route and fallback order but cannot
+  mutate the route registry or promote traffic. The representative benchmark
+  runner and checked-in workload results remain separate work.
 - A separate portable admission boundary now binds a canonical capability ID
   and rooted external-process authorization to one exact lowercase SHA-256 and
   physical file identity. Its opaque token must be revalidated before a later
@@ -561,6 +569,25 @@ These event names, fields, reason codes, and enum values are machine contracts a
 not localized. The telemetry helpers only record evidence; the coordinator above is
 the separate component that applies a route and never alters existing PRG runtime
 events by itself.
+
+## Route Impact Recommendation v1
+
+`evaluate_polyglot_route_impact` consumes one policy and exactly one
+already-captured measurement for direct C++, a C++/.NET wrapper, and a C#
+service. Hard gates require runtime availability, explicit security approval,
+a permitted security profile, contract compatibility, enough samples, zero
+failures and parity mismatches, and compliance with p95 latency, throughput,
+peak-memory, and p95-startup budgets. Eligible routes receive a deterministic
+integer weighted score; the lowest score is preferred and the remaining
+eligible routes form its fallback chain. Canonical route order breaks exact
+ties, so input order and locale cannot alter the machine decision.
+
+Invalid or wholly ineligible evidence returns no recommendation and retains the
+direct-C++/native no-promotion default. The evaluator is advisory only: it does
+not run workloads, invoke either route, mutate `PolyglotRouteRegistry`, or
+advance `off`/`shadow`/`canary`/`on` state. Human review remains mandatory.
+The complete contract, failure boundary, and remaining benchmark-runner gap are
+recorded in `docs/44-polyglot-route-impact.md`.
 
 ## Developer Migration Playbook v1
 

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -309,8 +309,9 @@ matches the events `cf_security`'s `audit_stream` emits today.
 ### docs/11 — Engineering Spec: Copperfin .NET Bridge
 
 **Status: spec'd in full, with a portable policy gateway, artifact-first
-invocation adapter, and route executor; CLR hosting and PRG-facing parity-call
-execution remain absent.** The
+invocation adapter, route executor, one PRG-facing Native AOT parity-call leaf,
+and an advisory measured-route decision contract; general CLR hosting remains
+absent.** The
 document specs four native modules (`cf_dotnet_host`, `cf_dotnet_marshaler`,
 `cf_dotnet_policy`,
 `cf_dotnet_codegen`), three managed surfaces, a typed marshaling contract for 11
@@ -368,6 +369,12 @@ checked-in C# sample is the first real external language target: it publishes
 as a self-contained Native AOT executable and is hash-admitted and invoked end
 to end from ordinary PRG. General CLR hosting, arbitrary managed assembly
 loading, and broader language adapters remain absent.
+
+The route-impact boundary can deterministically reject or rank already-captured
+direct-C++, C++/.NET-wrapper, and C#-service evidence and emit a measured
+fallback order. It is deliberately unable to execute benchmarks or promote a
+route. A representative workload runner and checked-in benchmark results remain
+open before the routing-strategy criterion can close.
 
 **What it will take:** none of the four named native execution/marshaling
 modules exist yet. What exists today, per `docs/28-repository-ontology.md` §3, is
@@ -472,7 +479,7 @@ excluded from the compliance map above:
 | 12 | VFP Asset Editing And Execution | Partial | xAsset execution is first-pass, bounded by language-surface coverage |
 | 13 | Index Format Notes | Partial | No index write fidelity; collation hints are heuristic, not named |
 | 18 | Native Security And RBAC | Partial (real baseline) | Not yet verified against docs/04's fuller vision |
-| 19 | Polyglot And AI Subprojects | Partial (portable artifact boundary, route executor, trusted host composition, PRG seam, and first Native AOT C# target) | No general CLR/Python/R runtime hook; AI/MCP policy has little to govern yet |
+| 19 | Polyglot And AI Subprojects | Partial (portable artifact boundary, route executor, trusted host composition, PRG seam, first Native AOT C# target, and advisory measured-route strategy) | No representative benchmark-result set or general CLR/Python/R runtime hook; AI/MCP policy has little to govern yet |
 | 20 | Runtime Build And Debug Pipeline | Partial | Engine is PRG-first, not the full command surface |
 | 21 | Database Federation And Query Translation | Partial (real seed) | No live connector execution behind the translator/planner |
 | 22 | VFP Language Reference Coverage | Partial, measured | 1,411 documented items; official surface exceeds current runtime |

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -373,8 +373,11 @@ loading, and broader language adapters remain absent.
 The route-impact boundary can deterministically reject or rank already-captured
 direct-C++, C++/.NET-wrapper, and C#-service evidence and emit a measured
 fallback order. It is deliberately unable to execute benchmarks or promote a
-route. A representative workload runner and checked-in benchmark results remain
-open before the routing-strategy criterion can close.
+route. Exact signed product/test head `2f21378eb` passes the complete native
+matrices on Linux (`338/338`), macOS (`338/338` plus `8/8` locale checks), and
+Windows (`337/337`), including the focused route-impact and isolation contracts
+on every host. A representative workload runner and checked-in benchmark
+results remain open before the routing-strategy criterion can close.
 
 **What it will take:** none of the four named native execution/marshaling
 modules exist yet. What exists today, per `docs/28-repository-ontology.md` §3, is

--- a/docs/44-polyglot-route-impact.md
+++ b/docs/44-polyglot-route-impact.md
@@ -78,8 +78,16 @@ telemetry, signing, or human review. Those remain separate reviewed boundaries.
 input-order independence, every eligibility gate, deterministic ties,
 fail-closed native/no-promotion behavior, and malformed request/policy/evidence
 rejection. Fresh local Release coverage passes with the adjacent route registry,
-route execution, and migration telemetry tests (`4/4`). Clang 21 ASan/UBSan
-with leak detection passes the focused target. The test is audited portable,
-parallel-safe, filesystem-free, environment-free, process-free, network-free,
-and sample-free. Hosted Linux, macOS, and Windows evidence remains required
-before merge.
+route execution, migration telemetry, and isolation contracts (`5/5`); the
+focused target repeats `20/20`. Clang 21 ASan/UBSan with leak detection passes
+the focused target, and focused static analysis is clean. The test is audited
+portable, parallel-safe, filesystem-free, environment-free, process-free,
+network-free, and sample-free.
+
+Exact signed product/test head `2f21378eb` passes Linux Native
+`31477286106` and macOS Native `31477287811` at `338/338`, Windows Native
+`31477289323` at `337/337`, and both `test_polyglot_route_impact` and
+`test_native_test_isolation_contract` on every host. The macOS run additionally
+passes both SET POINT display targets under `C`, `en_US.UTF-8`, `pt_BR.UTF-8`,
+and `de_DE.UTF-8` (`8/8`). All eleven PR-triggered checks pass at that exact
+head.

--- a/docs/44-polyglot-route-impact.md
+++ b/docs/44-polyglot-route-impact.md
@@ -1,0 +1,85 @@
+# Polyglot Route Impact Recommendation
+
+## Purpose
+
+`evaluate_polyglot_route_impact()` is the deterministic advisory boundary for
+choosing among the three implementation classes adopted by the .NET parity
+roadmap:
+
+- direct C++
+- a C++ wrapper into an admitted .NET process
+- a C# wrapper or service
+
+The evaluator consumes measurements that a benchmark owner has already
+captured for one canonical capability. It does not run a benchmark, invoke an
+artifact, edit the route registry, or promote traffic. Its result is evidence
+for the existing human-reviewed migration playbook, never an automatic route
+change.
+
+## Evidence Contract
+
+One request contains a canonical capability ID, one policy, and exactly one
+measurement for each implementation class. The policy declares:
+
+- minimum sample count
+- maximum p95 latency in microseconds
+- minimum throughput per second
+- maximum peak memory in KiB
+- maximum p95 startup time in milliseconds
+- the maximum permitted security-exposure profile
+- integer latency, throughput, memory, and startup weights totaling 100
+
+Each measurement records runtime availability, explicit security approval,
+security profile, contract compatibility, sample/failure/parity-mismatch
+counts, and the four impact metrics. Metric values have a fixed
+`1,000,000,000,000` arithmetic ceiling. Counts and measurements are integer
+machine data; display text and locale do not participate in the decision.
+
+## Eligibility And Ranking
+
+The evaluator applies hard gates before ranking. In order, a route must have an
+available runtime, explicit security approval, a permitted security profile,
+contract compatibility, enough samples, zero execution failures, zero parity
+mismatches, and measurements inside every declared budget. Each rejected route
+retains one stable `polyglot.impact.*` reason.
+
+For each eligible route, the four measurements are normalized against their
+budgets in integer basis points. Latency, memory, and startup use
+`measurement / maximum`; throughput uses `minimum / measurement`, so a lower
+weighted score is better in every dimension. Exact score ties use the stable
+order direct C++, C++/.NET wrapper, then C# service. Input vector order cannot
+change the output. The lowest score is preferred; remaining eligible routes
+form the ordered fallback chain.
+
+This score compares routes only under the capability-specific policy. It is not
+a universal claim that one implementation language is faster, safer, or more
+appropriate than another.
+
+## Fail-Closed Behavior
+
+Invalid identity, policy, route cardinality, duplicate routes, impossible
+counts, and excessive metrics reject the complete request. When every route is
+ineligible, the result is `polyglot.impact.no_eligible_route`,
+`recommendation_ready` is false, the fallback chain is empty, and the preferred
+field retains its direct-C++/native default. Operators must keep the live route
+unchanged; insufficient evidence is not permission to promote.
+
+## Nonclaims And Remaining Work
+
+This slice defines the decision contract and regression fixtures. It does not
+yet provide the representative workload runner or checked-in benchmark result
+documents required to close the broader routing-strategy acceptance criterion.
+It also does not replace artifact admission, parity comparison, route execution,
+telemetry, signing, or human review. Those remain separate reviewed boundaries.
+
+## Verification
+
+`test_polyglot_route_impact` covers measured route and fallback selection,
+input-order independence, every eligibility gate, deterministic ties,
+fail-closed native/no-promotion behavior, and malformed request/policy/evidence
+rejection. Fresh local Release coverage passes with the adjacent route registry,
+route execution, and migration telemetry tests (`4/4`). Clang 21 ASan/UBSan
+with leak detection passes the focused target. The test is audited portable,
+parallel-safe, filesystem-free, environment-free, process-free, network-free,
+and sample-free. Hosted Linux, macOS, and Windows evidence remains required
+before merge.

--- a/docs/diagrams/roadmap-v1-lanes-hij.md
+++ b/docs/diagrams/roadmap-v1-lanes-hij.md
@@ -25,7 +25,7 @@ flowchart TB
         direction LR
         H1["H1 Deterministic Relational<br/>Backend Translators<br/>root #30 - SEEDED:<br/>see docs/21, cf_platform_profile"]
         H2["H2 Document/Vector Backend<br/>+ AI-Assisted Planning<br/>root #31"]
-        H3["H3 .NET Outputs, MCP/AI<br/>Hooks, Python/R Sidecars<br/>root #32 - SEEDED:<br/>see docs/11, docs/19, launcher stub only"]
+        H3["H3 .NET Outputs, MCP/AI<br/>Hooks, Python/R Sidecars<br/>root #32 - SEEDED:<br/>admitted Native AOT leaf<br/>+ advisory route impact"]
         H1 --> H2 --> H3
       end
 
@@ -68,10 +68,13 @@ flowchart TB
     class V1,LANEH,LANEI,LANEJ lane;
 ```
 
-**What's done:** `H1`'s relational backend translators and `I1`'s security
-baseline both have real seeds — `cf_platform_profile`'s deterministic Fox-SQL
-translator/execution-planning lane, and `cf_security`'s RBAC/audit/secrets/
-signing baseline, respectively. **What's left, and what it takes:** this is
+**What's done:** `H1`'s relational backend translators, `H3`'s admitted Native
+AOT leaf and advisory measured-route strategy, and `I1`'s security baseline
+have real seeds — `cf_platform_profile`'s deterministic Fox-SQL
+translator/execution-planning lane, the trusted polyglot host and route-impact
+boundary, and `cf_security`'s RBAC/audit/secrets/signing baseline, respectively.
+`H3` still lacks its representative benchmark-result evidence and broader
+language/AI adapters. **What's left, and what it takes:** this is
 covered in full, document-by-document, in
 [31-specification-compliance-gap-analysis.md](../31-specification-compliance-gap-analysis.md) —
 in particular its interop/federation/trust/security and language/data-fidelity

--- a/include/copperfin/platform/polyglot_route_impact.h
+++ b/include/copperfin/platform/polyglot_route_impact.h
@@ -1,0 +1,108 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace copperfin::platform {
+
+enum class PolyglotRouteImplementation : std::uint8_t {
+    direct_cpp,
+    cpp_dotnet_wrapper,
+    csharp_service
+};
+
+enum class PolyglotRouteSecurityProfile : std::uint8_t {
+    trusted_native,
+    admitted_process,
+    remote_service
+};
+
+enum class PolyglotRouteImpactError : std::uint8_t {
+    none,
+    invalid_capability_id,
+    invalid_policy,
+    wrong_route_count,
+    duplicate_route,
+    invalid_measurement,
+    no_eligible_route
+};
+
+struct PolyglotRouteImpactWeights {
+    std::uint16_t latency = 25U;
+    std::uint16_t throughput = 25U;
+    std::uint16_t memory = 25U;
+    std::uint16_t startup = 25U;
+};
+
+struct PolyglotRouteImpactPolicy {
+    std::uint32_t minimum_sample_count = 30U;
+    std::uint64_t maximum_p95_latency_us = 0U;
+    std::uint64_t minimum_throughput_per_second = 0U;
+    std::uint64_t maximum_peak_memory_kib = 0U;
+    std::uint64_t maximum_p95_startup_ms = 0U;
+    PolyglotRouteSecurityProfile maximum_security_profile =
+        PolyglotRouteSecurityProfile::admitted_process;
+    PolyglotRouteImpactWeights weights;
+};
+
+struct PolyglotRouteImpactMeasurement {
+    PolyglotRouteImplementation implementation =
+        PolyglotRouteImplementation::direct_cpp;
+    PolyglotRouteSecurityProfile security_profile =
+        PolyglotRouteSecurityProfile::trusted_native;
+    bool runtime_available = false;
+    bool security_approved = false;
+    bool contract_compatible = false;
+    std::uint32_t sample_count = 0U;
+    std::uint32_t failure_count = 0U;
+    std::uint32_t parity_mismatch_count = 0U;
+    std::uint64_t p95_latency_us = 0U;
+    std::uint64_t throughput_per_second = 0U;
+    std::uint64_t peak_memory_kib = 0U;
+    std::uint64_t p95_startup_ms = 0U;
+};
+
+struct PolyglotRouteImpactAssessment {
+    PolyglotRouteImplementation implementation =
+        PolyglotRouteImplementation::direct_cpp;
+    bool eligible = false;
+    std::uint64_t impact_score = 0U;
+    std::string reason_code;
+};
+
+struct PolyglotRouteImpactRequest {
+    std::string capability_id;
+    PolyglotRouteImpactPolicy policy;
+    std::vector<PolyglotRouteImpactMeasurement> measurements;
+};
+
+struct PolyglotRouteImpactResult {
+    PolyglotRouteImpactError error = PolyglotRouteImpactError::none;
+    std::string error_code;
+    bool recommendation_ready = false;
+    PolyglotRouteImplementation preferred =
+        PolyglotRouteImplementation::direct_cpp;
+    std::vector<PolyglotRouteImplementation> fallback_chain;
+    std::vector<PolyglotRouteImpactAssessment> assessments;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return error == PolyglotRouteImpactError::none;
+    }
+};
+
+[[nodiscard]] const char* polyglot_route_implementation_name(
+    PolyglotRouteImplementation implementation) noexcept;
+[[nodiscard]] const char* polyglot_route_security_profile_name(
+    PolyglotRouteSecurityProfile profile) noexcept;
+
+// Evaluates already-captured benchmark evidence. This function is advisory:
+// it does not mutate a route registry, invoke a route, or promote traffic.
+[[nodiscard]] PolyglotRouteImpactResult evaluate_polyglot_route_impact(
+    const PolyglotRouteImpactRequest& request);
+
+}  // namespace copperfin::platform

--- a/src/platform/polyglot_route_impact.cpp
+++ b/src/platform/polyglot_route_impact.cpp
@@ -1,0 +1,261 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/polyglot_route_impact.h"
+
+#include "copperfin/platform/polyglot_route_registry.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <utility>
+
+namespace copperfin::platform {
+
+namespace {
+
+constexpr std::uint64_t kMaximumMetricValue = 1'000'000'000'000ULL;
+constexpr std::uint64_t kBasisPoints = 10'000U;
+
+std::size_t implementation_index(
+    const PolyglotRouteImplementation implementation) noexcept {
+    switch (implementation) {
+    case PolyglotRouteImplementation::direct_cpp:
+        return 0U;
+    case PolyglotRouteImplementation::cpp_dotnet_wrapper:
+        return 1U;
+    case PolyglotRouteImplementation::csharp_service:
+        return 2U;
+    }
+    return 3U;
+}
+
+bool valid_implementation(
+    const PolyglotRouteImplementation implementation) noexcept {
+    return implementation_index(implementation) < 3U;
+}
+
+bool valid_security_profile(
+    const PolyglotRouteSecurityProfile profile) noexcept {
+    switch (profile) {
+    case PolyglotRouteSecurityProfile::trusted_native:
+    case PolyglotRouteSecurityProfile::admitted_process:
+    case PolyglotRouteSecurityProfile::remote_service:
+        return true;
+    }
+    return false;
+}
+
+PolyglotRouteImpactResult invalid_result(
+    const PolyglotRouteImpactError error,
+    const char* error_code) {
+    PolyglotRouteImpactResult result;
+    result.error = error;
+    result.error_code = error_code;
+    return result;
+}
+
+bool valid_policy(const PolyglotRouteImpactPolicy& policy) noexcept {
+    const std::uint64_t total_weight =
+        static_cast<std::uint64_t>(policy.weights.latency) +
+        static_cast<std::uint64_t>(policy.weights.throughput) +
+        static_cast<std::uint64_t>(policy.weights.memory) +
+        static_cast<std::uint64_t>(policy.weights.startup);
+    return policy.minimum_sample_count > 0U &&
+        policy.maximum_p95_latency_us > 0U &&
+        policy.maximum_p95_latency_us <= kMaximumMetricValue &&
+        policy.minimum_throughput_per_second > 0U &&
+        policy.minimum_throughput_per_second <= kMaximumMetricValue &&
+        policy.maximum_peak_memory_kib > 0U &&
+        policy.maximum_peak_memory_kib <= kMaximumMetricValue &&
+        policy.maximum_p95_startup_ms > 0U &&
+        policy.maximum_p95_startup_ms <= kMaximumMetricValue &&
+        valid_security_profile(policy.maximum_security_profile) &&
+        total_weight == 100U;
+}
+
+bool valid_measurement(
+    const PolyglotRouteImpactMeasurement& measurement) noexcept {
+    if (!valid_implementation(measurement.implementation) ||
+        !valid_security_profile(measurement.security_profile) ||
+        measurement.failure_count > measurement.sample_count ||
+        measurement.parity_mismatch_count > measurement.sample_count ||
+        measurement.p95_latency_us > kMaximumMetricValue ||
+        measurement.throughput_per_second > kMaximumMetricValue ||
+        measurement.peak_memory_kib > kMaximumMetricValue ||
+        measurement.p95_startup_ms > kMaximumMetricValue) {
+        return false;
+    }
+    if (!measurement.runtime_available) {
+        return true;
+    }
+    return measurement.sample_count > 0U &&
+        measurement.throughput_per_second > 0U;
+}
+
+std::uint64_t ratio_score(
+    const std::uint64_t numerator,
+    const std::uint64_t denominator) noexcept {
+    return (numerator * kBasisPoints) / denominator;
+}
+
+std::uint64_t impact_score(
+    const PolyglotRouteImpactPolicy& policy,
+    const PolyglotRouteImpactMeasurement& measurement) noexcept {
+    const std::uint64_t latency = ratio_score(
+        measurement.p95_latency_us, policy.maximum_p95_latency_us);
+    const std::uint64_t throughput = ratio_score(
+        policy.minimum_throughput_per_second,
+        measurement.throughput_per_second);
+    const std::uint64_t memory = ratio_score(
+        measurement.peak_memory_kib, policy.maximum_peak_memory_kib);
+    const std::uint64_t startup = ratio_score(
+        measurement.p95_startup_ms, policy.maximum_p95_startup_ms);
+    return latency * policy.weights.latency +
+        throughput * policy.weights.throughput +
+        memory * policy.weights.memory +
+        startup * policy.weights.startup;
+}
+
+PolyglotRouteImpactAssessment assess(
+    const PolyglotRouteImpactPolicy& policy,
+    const PolyglotRouteImpactMeasurement& measurement) {
+    PolyglotRouteImpactAssessment result;
+    result.implementation = measurement.implementation;
+    if (!measurement.runtime_available) {
+        result.reason_code = "polyglot.impact.runtime_unavailable";
+    } else if (!measurement.security_approved) {
+        result.reason_code = "polyglot.impact.security_not_approved";
+    } else if (static_cast<std::uint8_t>(measurement.security_profile) >
+               static_cast<std::uint8_t>(policy.maximum_security_profile)) {
+        result.reason_code = "polyglot.impact.security_profile_exceeds_policy";
+    } else if (!measurement.contract_compatible) {
+        result.reason_code = "polyglot.impact.contract_incompatible";
+    } else if (measurement.sample_count < policy.minimum_sample_count) {
+        result.reason_code = "polyglot.impact.insufficient_samples";
+    } else if (measurement.failure_count != 0U) {
+        result.reason_code = "polyglot.impact.execution_failures";
+    } else if (measurement.parity_mismatch_count != 0U) {
+        result.reason_code = "polyglot.impact.parity_mismatch";
+    } else if (measurement.p95_latency_us > policy.maximum_p95_latency_us) {
+        result.reason_code = "polyglot.impact.latency_budget_exceeded";
+    } else if (measurement.throughput_per_second <
+               policy.minimum_throughput_per_second) {
+        result.reason_code = "polyglot.impact.throughput_budget_missed";
+    } else if (measurement.peak_memory_kib > policy.maximum_peak_memory_kib) {
+        result.reason_code = "polyglot.impact.memory_budget_exceeded";
+    } else if (measurement.p95_startup_ms > policy.maximum_p95_startup_ms) {
+        result.reason_code = "polyglot.impact.startup_budget_exceeded";
+    } else {
+        result.eligible = true;
+        result.impact_score = impact_score(policy, measurement);
+        result.reason_code = "polyglot.impact.eligible";
+    }
+    return result;
+}
+
+}  // namespace
+
+const char* polyglot_route_implementation_name(
+    const PolyglotRouteImplementation implementation) noexcept {
+    switch (implementation) {
+    case PolyglotRouteImplementation::direct_cpp:
+        return "direct-cpp";
+    case PolyglotRouteImplementation::cpp_dotnet_wrapper:
+        return "cpp-dotnet-wrapper";
+    case PolyglotRouteImplementation::csharp_service:
+        return "csharp-service";
+    }
+    return "unknown";
+}
+
+const char* polyglot_route_security_profile_name(
+    const PolyglotRouteSecurityProfile profile) noexcept {
+    switch (profile) {
+    case PolyglotRouteSecurityProfile::trusted_native:
+        return "trusted-native";
+    case PolyglotRouteSecurityProfile::admitted_process:
+        return "admitted-process";
+    case PolyglotRouteSecurityProfile::remote_service:
+        return "remote-service";
+    }
+    return "unknown";
+}
+
+PolyglotRouteImpactResult evaluate_polyglot_route_impact(
+    const PolyglotRouteImpactRequest& request) {
+    if (!load_polyglot_route_registry({
+            PolyglotRouteConfig{request.capability_id, "off", 0U}}).ok()) {
+        return invalid_result(
+            PolyglotRouteImpactError::invalid_capability_id,
+            "polyglot.impact.invalid_capability_id");
+    }
+    if (!valid_policy(request.policy)) {
+        return invalid_result(
+            PolyglotRouteImpactError::invalid_policy,
+            "polyglot.impact.invalid_policy");
+    }
+    if (request.measurements.size() != 3U) {
+        return invalid_result(
+            PolyglotRouteImpactError::wrong_route_count,
+            "polyglot.impact.wrong_route_count");
+    }
+
+    std::array<const PolyglotRouteImpactMeasurement*, 3U> ordered{};
+    for (const PolyglotRouteImpactMeasurement& measurement : request.measurements) {
+        if (!valid_measurement(measurement)) {
+            return invalid_result(
+                PolyglotRouteImpactError::invalid_measurement,
+                "polyglot.impact.invalid_measurement");
+        }
+        const std::size_t index = implementation_index(measurement.implementation);
+        if (ordered[index] != nullptr) {
+            return invalid_result(
+                PolyglotRouteImpactError::duplicate_route,
+                "polyglot.impact.duplicate_route");
+        }
+        ordered[index] = &measurement;
+    }
+    if (std::any_of(ordered.begin(), ordered.end(), [](const auto* value) {
+            return value == nullptr;
+        })) {
+        return invalid_result(
+            PolyglotRouteImpactError::duplicate_route,
+            "polyglot.impact.duplicate_route");
+    }
+
+    PolyglotRouteImpactResult result;
+    result.error_code = "polyglot.impact.recommendation_ready";
+    for (const PolyglotRouteImpactMeasurement* measurement : ordered) {
+        result.assessments.push_back(assess(request.policy, *measurement));
+    }
+
+    std::vector<const PolyglotRouteImpactAssessment*> eligible;
+    for (const PolyglotRouteImpactAssessment& assessment : result.assessments) {
+        if (assessment.eligible) {
+            eligible.push_back(&assessment);
+        }
+    }
+    if (eligible.empty()) {
+        result.error = PolyglotRouteImpactError::no_eligible_route;
+        result.error_code = "polyglot.impact.no_eligible_route";
+        return result;
+    }
+    std::stable_sort(
+        eligible.begin(), eligible.end(), [](const auto* left, const auto* right) {
+            if (left->impact_score != right->impact_score) {
+                return left->impact_score < right->impact_score;
+            }
+            return implementation_index(left->implementation) <
+                implementation_index(right->implementation);
+        });
+    result.recommendation_ready = true;
+    result.preferred = eligible.front()->implementation;
+    for (std::size_t index = 1U; index < eligible.size(); ++index) {
+        result.fallback_chain.push_back(eligible[index]->implementation);
+    }
+    return result;
+}
+
+}  // namespace copperfin::platform

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4673,6 +4673,10 @@ target_compile_definitions(
         COPPERFIN_ROUTE_REGISTRY_EXAMPLE_PATH="${CMAKE_SOURCE_DIR}/docs/contracts/polyglot-route-registry-v1.json"
 )
 
+copperfin_add_test(test_polyglot_route_impact cf_platform_profile
+    test_polyglot_route_impact.cpp
+)
+
 copperfin_add_test(test_polyglot_bridge_invocation cf_platform_profile
     test_polyglot_bridge_invocation.cpp
 )

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -116,6 +116,7 @@ function(copperfin_configure_native_test_isolation)
             test_polyglot_interop_envelope
             test_polyglot_migration_telemetry
             test_polyglot_parity_comparator
+            test_polyglot_route_impact
             test_polyglot_route_registry)
         copperfin_set_test_isolation(${test_name}
             PARALLEL_SAFE

--- a/tests/test_polyglot_route_impact.cpp
+++ b/tests/test_polyglot_route_impact.cpp
@@ -1,0 +1,312 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/polyglot_route_impact.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+using copperfin::platform::PolyglotRouteImpactMeasurement;
+using copperfin::platform::PolyglotRouteImpactPolicy;
+using copperfin::platform::PolyglotRouteImpactRequest;
+using copperfin::platform::PolyglotRouteImplementation;
+using copperfin::platform::PolyglotRouteSecurityProfile;
+
+void expect(bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+PolyglotRouteImpactPolicy policy() {
+    return {
+        .minimum_sample_count = 100U,
+        .maximum_p95_latency_us = 1000U,
+        .minimum_throughput_per_second = 1000U,
+        .maximum_peak_memory_kib = 100'000U,
+        .maximum_p95_startup_ms = 1000U,
+        .maximum_security_profile =
+            PolyglotRouteSecurityProfile::admitted_process,
+        .weights = {25U, 25U, 25U, 25U}};
+}
+
+PolyglotRouteImpactMeasurement measurement(
+    PolyglotRouteImplementation implementation,
+    PolyglotRouteSecurityProfile security_profile,
+    std::uint64_t latency,
+    std::uint64_t throughput,
+    std::uint64_t memory,
+    std::uint64_t startup) {
+    return {
+        .implementation = implementation,
+        .security_profile = security_profile,
+        .runtime_available = true,
+        .security_approved = true,
+        .contract_compatible = true,
+        .sample_count = 1000U,
+        .failure_count = 0U,
+        .parity_mismatch_count = 0U,
+        .p95_latency_us = latency,
+        .throughput_per_second = throughput,
+        .peak_memory_kib = memory,
+        .p95_startup_ms = startup};
+}
+
+std::vector<PolyglotRouteImpactMeasurement> representative_measurements() {
+    return {
+        measurement(
+            PolyglotRouteImplementation::direct_cpp,
+            PolyglotRouteSecurityProfile::trusted_native,
+            900U, 1100U, 50'000U, 10U),
+        measurement(
+            PolyglotRouteImplementation::cpp_dotnet_wrapper,
+            PolyglotRouteSecurityProfile::admitted_process,
+            300U, 2000U, 60'000U, 200U),
+        measurement(
+            PolyglotRouteImplementation::csharp_service,
+            PolyglotRouteSecurityProfile::admitted_process,
+            400U, 1800U, 70'000U, 300U)};
+}
+
+PolyglotRouteImpactRequest request() {
+    return {
+        .capability_id = "samples.dotnet.add-v1",
+        .policy = policy(),
+        .measurements = representative_measurements()};
+}
+
+void test_measured_route_and_fallback_order() {
+    const auto result =
+        copperfin::platform::evaluate_polyglot_route_impact(request());
+    expect(result.ok(), "representative evidence should be valid");
+    expect(result.recommendation_ready,
+           "representative evidence should produce a recommendation");
+    expect(result.preferred ==
+               PolyglotRouteImplementation::cpp_dotnet_wrapper,
+           "measured wrapper impact should win instead of a fixed route preference");
+    expect(result.fallback_chain == std::vector<PolyglotRouteImplementation>{
+               PolyglotRouteImplementation::csharp_service,
+               PolyglotRouteImplementation::direct_cpp},
+           "eligible fallbacks should be ordered by measured impact");
+    expect(result.assessments.size() == 3U &&
+               result.assessments[0].implementation ==
+                   PolyglotRouteImplementation::direct_cpp &&
+               result.assessments[1].implementation ==
+                   PolyglotRouteImplementation::cpp_dotnet_wrapper &&
+               result.assessments[2].implementation ==
+                   PolyglotRouteImplementation::csharp_service,
+           "assessment output should have canonical route order");
+    expect(result.assessments[0].impact_score == 579'750U &&
+               result.assessments[1].impact_score == 400'000U &&
+               result.assessments[2].impact_score == 488'875U,
+           "integer normalization and weighting should remain exact");
+}
+
+void test_input_order_does_not_change_decision() {
+    auto reversed = request();
+    std::reverse(reversed.measurements.begin(), reversed.measurements.end());
+    const auto result =
+        copperfin::platform::evaluate_polyglot_route_impact(reversed);
+    expect(result.ok() && result.recommendation_ready &&
+               result.preferred ==
+                   PolyglotRouteImplementation::cpp_dotnet_wrapper,
+           "input order should not change the preferred route");
+    expect(result.fallback_chain == std::vector<PolyglotRouteImplementation>{
+               PolyglotRouteImplementation::csharp_service,
+               PolyglotRouteImplementation::direct_cpp},
+           "input order should not change the fallback chain");
+}
+
+void test_hard_gates_precede_impact_score() {
+    auto gated = request();
+    gated.measurements[1].security_approved = false;
+    gated.measurements[2].parity_mismatch_count = 1U;
+    const auto result =
+        copperfin::platform::evaluate_polyglot_route_impact(gated);
+    expect(result.ok() && result.recommendation_ready &&
+               result.preferred == PolyglotRouteImplementation::direct_cpp,
+           "only a fully eligible route may be recommended");
+    expect(result.fallback_chain.empty(),
+           "ineligible routes should not appear in the fallback chain");
+    expect(result.assessments[1].reason_code ==
+               "polyglot.impact.security_not_approved" &&
+               result.assessments[2].reason_code ==
+               "polyglot.impact.parity_mismatch",
+           "hard-gate reasons should remain machine-readable");
+}
+
+void test_fail_closed_without_sufficient_evidence() {
+    auto insufficient = request();
+    for (auto& item : insufficient.measurements) {
+        item.sample_count = 10U;
+    }
+    const auto result =
+        copperfin::platform::evaluate_polyglot_route_impact(insufficient);
+    expect(!result.ok() && !result.recommendation_ready,
+           "insufficient evidence should not produce a recommendation");
+    expect(result.error_code == "polyglot.impact.no_eligible_route",
+           "no eligible route should have a stable error code");
+    expect(result.preferred == PolyglotRouteImplementation::direct_cpp &&
+               result.fallback_chain.empty(),
+           "failure should retain native/no-promotion defaults");
+}
+
+void test_security_profile_limit() {
+    auto limited = request();
+    limited.measurements[2].security_profile =
+        PolyglotRouteSecurityProfile::remote_service;
+    const auto result =
+        copperfin::platform::evaluate_polyglot_route_impact(limited);
+    expect(result.ok() && result.recommendation_ready,
+           "a disallowed service should not invalidate other evidence");
+    expect(result.assessments[2].reason_code ==
+               "polyglot.impact.security_profile_exceeds_policy",
+           "security exposure should be a hard eligibility gate");
+}
+
+void test_each_impact_gate_has_a_stable_reason() {
+    struct GateCase {
+        const char* expected;
+        void (*mutate)(PolyglotRouteImpactMeasurement&);
+    };
+    const std::vector<GateCase> cases{
+        {"polyglot.impact.runtime_unavailable", [](auto& value) {
+             value.runtime_available = false;
+         }},
+        {"polyglot.impact.contract_incompatible", [](auto& value) {
+             value.contract_compatible = false;
+         }},
+        {"polyglot.impact.insufficient_samples", [](auto& value) {
+             value.sample_count = 99U;
+         }},
+        {"polyglot.impact.execution_failures", [](auto& value) {
+             value.failure_count = 1U;
+         }},
+        {"polyglot.impact.parity_mismatch", [](auto& value) {
+             value.parity_mismatch_count = 1U;
+         }},
+        {"polyglot.impact.latency_budget_exceeded", [](auto& value) {
+             value.p95_latency_us = 1001U;
+         }},
+        {"polyglot.impact.throughput_budget_missed", [](auto& value) {
+             value.throughput_per_second = 999U;
+         }},
+        {"polyglot.impact.memory_budget_exceeded", [](auto& value) {
+             value.peak_memory_kib = 100'001U;
+         }},
+        {"polyglot.impact.startup_budget_exceeded", [](auto& value) {
+             value.p95_startup_ms = 1001U;
+         }}};
+
+    for (const GateCase& gate : cases) {
+        auto gated = request();
+        gate.mutate(gated.measurements[1]);
+        const auto result =
+            copperfin::platform::evaluate_polyglot_route_impact(gated);
+        expect(result.ok() && result.recommendation_ready,
+               std::string("other eligible routes should survive ") + gate.expected);
+        expect(result.assessments[1].reason_code == gate.expected,
+               std::string("unexpected reason for ") + gate.expected);
+        expect(std::find(result.fallback_chain.begin(),
+                         result.fallback_chain.end(),
+                         PolyglotRouteImplementation::cpp_dotnet_wrapper) ==
+                   result.fallback_chain.end() &&
+                   result.preferred !=
+                       PolyglotRouteImplementation::cpp_dotnet_wrapper,
+               std::string("gated route should not be recommended for ") +
+                   gate.expected);
+    }
+}
+
+void test_deterministic_tie_break() {
+    auto tied = request();
+    const auto common = measurement(
+        PolyglotRouteImplementation::direct_cpp,
+        PolyglotRouteSecurityProfile::trusted_native,
+        500U, 2000U, 50'000U, 500U);
+    tied.measurements = {common, common, common};
+    tied.measurements[0].implementation =
+        PolyglotRouteImplementation::csharp_service;
+    tied.measurements[0].security_profile =
+        PolyglotRouteSecurityProfile::admitted_process;
+    tied.measurements[1].implementation =
+        PolyglotRouteImplementation::cpp_dotnet_wrapper;
+    tied.measurements[1].security_profile =
+        PolyglotRouteSecurityProfile::admitted_process;
+    tied.measurements[2].implementation =
+        PolyglotRouteImplementation::direct_cpp;
+    const auto result =
+        copperfin::platform::evaluate_polyglot_route_impact(tied);
+    expect(result.ok() && result.preferred ==
+               PolyglotRouteImplementation::direct_cpp,
+           "exact ties should prefer the least exposed implementation class");
+    expect(result.fallback_chain == std::vector<PolyglotRouteImplementation>{
+               PolyglotRouteImplementation::cpp_dotnet_wrapper,
+               PolyglotRouteImplementation::csharp_service},
+           "exact tie fallback order should be stable");
+}
+
+void test_invalid_contract_inputs() {
+    auto invalid_capability = request();
+    invalid_capability.capability_id = "Not Canonical";
+    expect(copperfin::platform::evaluate_polyglot_route_impact(
+               invalid_capability).error_code ==
+               "polyglot.impact.invalid_capability_id",
+           "capability identity should reuse the route registry contract");
+
+    auto invalid_policy = request();
+    invalid_policy.policy.weights.startup = 24U;
+    expect(copperfin::platform::evaluate_polyglot_route_impact(
+               invalid_policy).error_code == "polyglot.impact.invalid_policy",
+           "weights that do not total 100 should be rejected");
+
+    auto duplicate = request();
+    duplicate.measurements[2].implementation =
+        PolyglotRouteImplementation::direct_cpp;
+    expect(copperfin::platform::evaluate_polyglot_route_impact(
+               duplicate).error_code == "polyglot.impact.duplicate_route",
+           "duplicate implementation evidence should be rejected");
+
+    auto missing = request();
+    missing.measurements.pop_back();
+    expect(copperfin::platform::evaluate_polyglot_route_impact(
+               missing).error_code == "polyglot.impact.wrong_route_count",
+           "all three route classes should be represented");
+
+    auto impossible_counts = request();
+    impossible_counts.measurements[0].failure_count = 1001U;
+    expect(copperfin::platform::evaluate_polyglot_route_impact(
+               impossible_counts).error_code ==
+               "polyglot.impact.invalid_measurement",
+           "failure counts above the sample count should be rejected");
+
+    auto excessive_metric = request();
+    excessive_metric.measurements[0].p95_latency_us =
+        1'000'000'000'001ULL;
+    expect(copperfin::platform::evaluate_polyglot_route_impact(
+               excessive_metric).error_code ==
+               "polyglot.impact.invalid_measurement",
+           "metrics above the fixed arithmetic ceiling should be rejected");
+}
+
+}  // namespace
+
+int main() {
+    test_measured_route_and_fallback_order();
+    test_input_order_does_not_change_decision();
+    test_hard_gates_precede_impact_score();
+    test_fail_closed_without_sufficient_evidence();
+    test_security_profile_limit();
+    test_each_impact_gate_has_a_stable_reason();
+    test_deterministic_tie_break();
+    test_invalid_contract_inputs();
+    std::cout << "polyglot route impact tests passed\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- adds a deterministic advisory impact evaluator for direct C++, C++/.NET-wrapper, and C#-service route evidence
- hard-gates availability, security approval/profile, contract compatibility, samples, failures, parity, latency, throughput, memory, and startup
- emits a stable integer-scored preferred route and ordered fallback chain without invoking or promoting anything
- updates the v1 roadmap, handoff, specification-gap analysis, overview, README, and changelog

## Why

Issue #277 requires route selection to depend on measured user impact while preserving a stable API and a defined fallback chain. The existing registry, executor, telemetry, and admitted Native AOT leaf did not provide a deterministic measurement-to-recommendation contract.

## Behavior and boundaries

Invalid or wholly ineligible evidence fails closed to no recommendation, an empty fallback chain, and the native/no-promotion default. The evaluator cannot run workloads, invoke artifacts, mutate the route registry, or change lifecycle state.

This advances but does not close #277. A representative workload runner and checked-in benchmark-result documents remain open, as does broader route-parity evidence.

## Validation

Exact signed product/test head `2f21378eb`:

- fresh GCC 15 Release focused and adjacent/isolation set: 5/5
- focused repeat: 20/20
- Clang 21 ASan/UBSan with leak detection: pass
- focused static analysis: clean
- Linux Native `31477286106`: 338/338, including route-impact and isolation
- macOS Native `31477287811`: 338/338 plus four locale pairs (8/8)
- Windows Native `31477289323`: 337/337, including route-impact and isolation
- all eleven PR-triggered checks: pass

Evidence-only signed head `9f727a493` records those direct results in durable documentation and is running its final protected checks.

## Contribution Licensing And Provenance

- [x] I have the right to submit this contribution and every included file.
- [x] I license my contribution under GPL-3.0-only with the Copperfin Application, Runtime, and Toolchain Exception 1.0; I retain my copyright and make no copyright assignment.
- [x] Every commit has the contributor's `Signed-off-by` trailer.
- [x] Third-party material is identified with its source, copyright, and compatible license, or this change contains none.
- [x] This change contains no secrets, signing material, personal/customer data, restricted source, or decompiled proprietary code.
