### PR TITLE
Add representative polyglot benchmark evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7244,3 +7244,9 @@ passes `1/1`.
   Syft release `v1.50.0`; the checked workflow no longer depends on the
   action's stale implicit `v1.42.3` selection. The single CycloneDX artifact
   owner, read-only permissions, and Trivy gate remain unchanged.
+- 2026-08-11: Added the representative polyglot benchmark runner and versioned
+  evidence schema. Bounded warmup/measurement loops now aggregate nearest-rank
+  p95 latency/startup, throughput, peak process memory, failures, and exact
+  payload parity across direct C++, the admitted C++/.NET wrapper, and the local
+  Native AOT endpoint boundary. Recommendations remain advisory and cannot
+  modify the route registry or promote traffic.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7258,4 +7258,8 @@ passes `1/1`.
   the maximum observed value; Windows retains its reliable Job Object peak.
   Review also found that valid observations were rejected after cumulative
   latency crossed the per-observation ceiling; accumulation now guards the
-  actual `uint64_t` boundary, with a 100-observation regression.
+  actual `uint64_t` boundary, with a 100-observation regression. Final review
+  found that the direct-C++ fixture had been an empty timing callback and that
+  the evidence schema left policy unconstrained. The direct route now strictly
+  parses, executes, serializes, and parity-checks the same signed-add workload,
+  while the schema and contract check require a closed policy and weights shape.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7249,4 +7249,12 @@ passes `1/1`.
   p95 latency/startup, throughput, peak process memory, failures, and exact
   payload parity across direct C++, the admitted C++/.NET wrapper, and the local
   Native AOT endpoint boundary. Recommendations remain advisory and cannot
-  modify the route registry or promote traffic.
+  modify the route registry or promote traffic. Independent review reproduced
+  that POSIX `wait4()` can seed a post-fork child's high-water mark with the
+  launcher's own pre-`exec` resident set, so generic POSIX process results now
+  mark peak memory unavailable instead of publishing a misleading value. The
+  controlled benchmark candidate self-reports its own peak working set through
+  a strict opt-in metric channel; Windows retains its reliable Job Object peak.
+  Review also found that valid observations were rejected after cumulative
+  latency crossed the per-observation ceiling; accumulation now guards the
+  actual `uint64_t` boundary, with a 100-observation regression.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7253,8 +7253,9 @@ passes `1/1`.
   that POSIX `wait4()` can seed a post-fork child's high-water mark with the
   launcher's own pre-`exec` resident set, so generic POSIX process results now
   mark peak memory unavailable instead of publishing a misleading value. The
-  controlled benchmark candidate self-reports its own peak working set through
-  a strict opt-in metric channel; Windows retains its reliable Job Object peak.
+  controlled benchmark candidate self-reports its current cross-platform
+  working set through a strict opt-in metric channel, and aggregation retains
+  the maximum observed value; Windows retains its reliable Job Object peak.
   Review also found that valid observations were rejected after cumulative
   latency crossed the per-observation ceiling; accumulation now guards the
   actual `uint64_t` boundary, with a 100-observation regression.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ target_link_libraries(cf_package_trust PRIVATE cf_licensing)
 
 add_library(cf_platform_profile
     src/platform/bounded_process.cpp
+    src/platform/polyglot_benchmark.cpp
     src/platform/database_model.cpp
     src/platform/extensibility_model.cpp
     src/platform/federation_execution.cpp

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ License documents:
 - [`docs/42-prg-polyglot-dispatch.md`](docs/42-prg-polyglot-dispatch.md)
 - [`docs/43-dotnet-polyglot-candidate.md`](docs/43-dotnet-polyglot-candidate.md)
 - [`docs/44-polyglot-route-impact.md`](docs/44-polyglot-route-impact.md)
+- [`docs/45-polyglot-benchmark-evidence.md`](docs/45-polyglot-benchmark-evidence.md)
 - [`assets/copperfin-logo.png`](assets/copperfin-logo.png)
 
 Current implementation focus:

--- a/docs/44-polyglot-route-impact.md
+++ b/docs/44-polyglot-route-impact.md
@@ -64,12 +64,12 @@ ineligible, the result is `polyglot.impact.no_eligible_route`,
 field retains its direct-C++/native default. Operators must keep the live route
 unchanged; insufficient evidence is not permission to promote.
 
-## Nonclaims And Remaining Work
+## Related Evidence
 
-This slice defines the decision contract and regression fixtures. It does not
-yet provide the representative workload runner or checked-in benchmark result
-documents required to close the broader routing-strategy acceptance criterion.
-It also does not replace artifact admission, parity comparison, route execution,
+The representative workload runner, result schema, capture procedure, and
+measurement limitations are defined in
+[`45-polyglot-benchmark-evidence.md`](45-polyglot-benchmark-evidence.md). Neither
+component replaces artifact admission, parity comparison, route execution,
 telemetry, signing, or human review. Those remain separate reviewed boundaries.
 
 ## Verification

--- a/docs/45-polyglot-benchmark-evidence.md
+++ b/docs/45-polyglot-benchmark-evidence.md
@@ -47,13 +47,16 @@ forked child's high-water mark can already contain the launcher's copy-on-write
 resident set.
 
 For this controlled cross-platform benchmark, the Native AOT candidate receives
-an explicit opt-in environment flag and reports its own `PeakWorkingSet64` in
-KiB on the otherwise-unused diagnostic channel. The harness accepts only the
+an explicit opt-in environment flag and reports its own cross-platform
+`Environment.WorkingSet` in KiB on the otherwise-unused diagnostic channel.
+The harness accepts only the
 exact metric prefix, a positive base-10 integer, and one terminating newline;
 a missing or malformed metric fails that observation. Normal candidate calls
 do not emit the metric. The current direct C++ sample performs no route-specific
-allocation and therefore records zero additional KiB. These are route-impact
-figures, not total host memory or a universal language comparison.
+allocation and therefore records zero additional KiB. Aggregation records the
+maximum observed working set in the existing peak-memory policy field; it does
+not claim an OS lifetime high-water mark. These are route-impact figures, not
+total host memory or a universal language comparison.
 
 ## Representative Workload
 
@@ -72,7 +75,7 @@ versioned schema in `docs/contracts/polyglot-benchmark-result-v1.schema.json`.
 Timing values are host-specific observations and must not be generalized.
 
 The checked-in corrected result was captured from exact signed source commit
-`deaa815ef1ccf74836676654d4108689d6422c8a` on Linux x86_64. All 27 measured
+`2ca80ab39135185b67f81b470ab500cf2c4d6a58` on Linux x86_64. All 27 measured
 executions completed with exact parity and no failures. The host-specific
 advisory order was direct C++, local C# endpoint boundary, then the full
 C++/.NET wrapper. Each measurement records its memory source so a consumer

--- a/docs/45-polyglot-benchmark-evidence.md
+++ b/docs/45-polyglot-benchmark-evidence.md
@@ -71,9 +71,12 @@ host/toolchain metadata, UTC capture time, policy, and limitations under the
 versioned schema in `docs/contracts/polyglot-benchmark-result-v1.schema.json`.
 Timing values are host-specific observations and must not be generalized.
 
-The first checked-in result was captured from exact signed source commit
-`cf4cd9573103096d915a211c9cd95aae413cb68c` on Linux x86_64. All 27 measured
+The checked-in corrected result was captured from exact signed source commit
+`deaa815ef1ccf74836676654d4108689d6422c8a` on Linux x86_64. All 27 measured
 executions completed with exact parity and no failures. The host-specific
 advisory order was direct C++, local C# endpoint boundary, then the full
-C++/.NET wrapper. The result and its explicit limitations are stored in
+C++/.NET wrapper. Each measurement records its memory source so a consumer
+cannot confuse the direct route-specific value, controlled candidate
+self-report, or a possible Windows owned-job observation. The result and its
+explicit limitations are stored in
 `docs/contracts/polyglot-benchmark-result-v1.json`; no route was changed.

--- a/docs/45-polyglot-benchmark-evidence.md
+++ b/docs/45-polyglot-benchmark-evidence.md
@@ -68,6 +68,15 @@ different call layers, so their timing series are independently observed. Every
 sample must execute successfully and exactly match the expected payload before
 the advisory result is accepted.
 
+The direct C++ route is also an executed workload, not an empty timing control:
+it strictly reads the canonical signed-integer arguments, performs checked
+64-bit addition, serializes the resulting payload, and compares that payload
+with the same expected value used by the external routes. The integration test
+requires all three direct warmups and all nine direct measurements to run.
+The result schema closes the complete policy object and its nested weights, so
+a schema-valid evidence document cannot omit or invent the thresholds and
+security ceiling that produced its recommendation.
+
 The test prints a single `COPPERFIN_POLYGLOT_BENCHMARK_V1=` JSON payload for
 evidence capture. A checked-in evidence document adds the exact source commit,
 host/toolchain metadata, UTC capture time, policy, and limitations under the

--- a/docs/45-polyglot-benchmark-evidence.md
+++ b/docs/45-polyglot-benchmark-evidence.md
@@ -1,0 +1,64 @@
+# Representative Polyglot Benchmark Evidence
+
+## Purpose
+
+`run_polyglot_benchmark()` supplies the repeatable evidence boundary that feeds
+the advisory route-impact evaluator. It executes caller-owned representative
+workloads through exactly three named implementation layers:
+
+- `direct-cpp`: the in-process C++ implementation
+- `cpp-dotnet-wrapper`: Copperfin artifact admission, request serialization,
+  bounded process execution, response validation, and parity comparison
+- `csharp-service`: direct invocation of the same local Native AOT endpoint
+  boundary, bypassing the Copperfin wrapper
+
+The third layer is a local one-request endpoint boundary. It is not evidence of
+a persistent or remote service, which Copperfin does not currently ship.
+
+## Runner Contract
+
+The request fixes warmup and measured iteration counts, one or more named
+workloads with expected payloads, route availability/security/compatibility
+facts, and the existing route-impact policy. Hard ceilings allow at most 100
+warmup iterations, 10,000 measured iterations, and 100 workloads. Duplicate or
+missing route classes, empty workload fields, overflow, invalid measurements,
+and callback exceptions fail before any recommendation is usable.
+
+Warmups exercise readiness but are excluded from metrics; any warmup execution
+or parity failure invalidates the run. Measured observations
+record invocation success, exact payload parity, wall-clock latency, startup
+time, and peak resident memory. Aggregation uses nearest-rank p95, integer
+throughput over total measured latency, maximum observed memory, and exact
+failure/parity counts. Unavailable routes are retained with zero samples and
+are never invoked or populated with synthetic timings.
+
+`run_polyglot_benchmark()` owns no route registry, artifact, network client, or
+promotion function. It passes measurements to `evaluate_polyglot_route_impact()`;
+operators must separately review any recommendation and change routing through
+the existing migration workflow.
+
+## Memory Semantics
+
+The bounded-process result reports peak resident memory for the owned root
+process on POSIX and the owned job, including descendants, on Windows. macOS
+byte units are normalized to KiB; Linux `ru_maxrss` is already KiB. The current
+direct C++ sample performs no route-specific allocation and therefore records
+zero additional KiB. External routes report their measured process footprint.
+This is a route-impact measure, not total host memory or a universal language
+comparison.
+
+## Representative Workload
+
+`test_polyglot_dotnet_candidate` runs positive, negative, and zero signed
+64-bit additions. After one warmup iteration per workload and route, it records
+three measured iterations per workload (nine samples per route). The C++/.NET
+wrapper and direct endpoint paths use the same admitted Native AOT artifact but
+different call layers, so their timing series are independently observed. Every
+sample must execute successfully and exactly match the expected payload before
+the advisory result is accepted.
+
+The test prints a single `COPPERFIN_POLYGLOT_BENCHMARK_V1=` JSON payload for
+evidence capture. A checked-in evidence document adds the exact source commit,
+host/toolchain metadata, UTC capture time, policy, and limitations under the
+versioned schema in `docs/contracts/polyglot-benchmark-result-v1.schema.json`.
+Timing values are host-specific observations and must not be generalized.

--- a/docs/45-polyglot-benchmark-evidence.md
+++ b/docs/45-polyglot-benchmark-evidence.md
@@ -84,7 +84,7 @@ versioned schema in `docs/contracts/polyglot-benchmark-result-v1.schema.json`.
 Timing values are host-specific observations and must not be generalized.
 
 The checked-in corrected result was captured from exact signed source commit
-`2ca80ab39135185b67f81b470ab500cf2c4d6a58` on Linux x86_64. All 27 measured
+`48930b970b14164308aee8fd035148925b2ae74b` on Linux x86_64. All 27 measured
 executions completed with exact parity and no failures. The host-specific
 advisory order was direct C++, local C# endpoint boundary, then the full
 C++/.NET wrapper. Each measurement records its memory source so a consumer

--- a/docs/45-polyglot-benchmark-evidence.md
+++ b/docs/45-polyglot-benchmark-evidence.md
@@ -39,13 +39,21 @@ the existing migration workflow.
 
 ## Memory Semantics
 
-The bounded-process result reports peak resident memory for the owned root
-process on POSIX and the owned job, including descendants, on Windows. macOS
-byte units are normalized to KiB; Linux `ru_maxrss` is already KiB. The current
-direct C++ sample performs no route-specific allocation and therefore records
-zero additional KiB. External routes report their measured process footprint.
-This is a route-impact measure, not total host memory or a universal language
-comparison.
+Windows bounded-process results expose a peak only when the owned Job Object
+query succeeds; that value includes descendants. Generic POSIX bounded-process
+results deliberately mark peak memory unavailable and leave the value zero.
+`wait4()` cannot supply a trustworthy post-`exec` child peak because the
+forked child's high-water mark can already contain the launcher's copy-on-write
+resident set.
+
+For this controlled cross-platform benchmark, the Native AOT candidate receives
+an explicit opt-in environment flag and reports its own `PeakWorkingSet64` in
+KiB on the otherwise-unused diagnostic channel. The harness accepts only the
+exact metric prefix, a positive base-10 integer, and one terminating newline;
+a missing or malformed metric fails that observation. Normal candidate calls
+do not emit the metric. The current direct C++ sample performs no route-specific
+allocation and therefore records zero additional KiB. These are route-impact
+figures, not total host memory or a universal language comparison.
 
 ## Representative Workload
 

--- a/docs/45-polyglot-benchmark-evidence.md
+++ b/docs/45-polyglot-benchmark-evidence.md
@@ -62,3 +62,10 @@ evidence capture. A checked-in evidence document adds the exact source commit,
 host/toolchain metadata, UTC capture time, policy, and limitations under the
 versioned schema in `docs/contracts/polyglot-benchmark-result-v1.schema.json`.
 Timing values are host-specific observations and must not be generalized.
+
+The first checked-in result was captured from exact signed source commit
+`cf4cd9573103096d915a211c9cd95aae413cb68c` on Linux x86_64. All 27 measured
+executions completed with exact parity and no failures. The host-specific
+advisory order was direct C++, local C# endpoint boundary, then the full
+C++/.NET wrapper. The result and its explicit limitations are stored in
+`docs/contracts/polyglot-benchmark-result-v1.json`; no route was changed.

--- a/docs/contracts/polyglot-benchmark-result-v1.json
+++ b/docs/contracts/polyglot-benchmark-result-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "kind": "copperfin-polyglot-benchmark-result",
-  "captured_at_utc": "2026-08-11T12:19:10Z",
-  "source_commit": "2ca80ab39135185b67f81b470ab500cf2c4d6a58",
+  "captured_at_utc": "2026-08-11T13:20:23Z",
+  "source_commit": "48930b970b14164308aee8fd035148925b2ae74b",
   "host": {
     "os": "Linux 7.0.0-29-generic",
     "architecture": "x86_64",
@@ -44,11 +44,11 @@
       "sample_count": 9,
       "failure_count": 0,
       "parity_mismatch_count": 0,
-      "p95_latency_us": 20557,
-      "throughput_per_second": 67,
-      "peak_memory_kib": 4416,
+      "p95_latency_us": 13789,
+      "throughput_per_second": 79,
+      "peak_memory_kib": 4408,
       "peak_memory_source": "candidate-self-reported-working-set",
-      "p95_startup_ms": 10
+      "p95_startup_ms": 4
     },
     {
       "implementation": "csharp-service",
@@ -56,11 +56,11 @@
       "sample_count": 9,
       "failure_count": 0,
       "parity_mismatch_count": 0,
-      "p95_latency_us": 9419,
-      "throughput_per_second": 162,
+      "p95_latency_us": 10381,
+      "throughput_per_second": 166,
       "peak_memory_kib": 4408,
       "peak_memory_source": "candidate-self-reported-working-set",
-      "p95_startup_ms": 9
+      "p95_startup_ms": 10
     }
   ],
   "recommendation": {

--- a/docs/contracts/polyglot-benchmark-result-v1.json
+++ b/docs/contracts/polyglot-benchmark-result-v1.json
@@ -1,0 +1,75 @@
+{
+  "schema_version": 1,
+  "kind": "copperfin-polyglot-benchmark-result",
+  "captured_at_utc": "2026-08-11T11:14:13Z",
+  "source_commit": "cf4cd9573103096d915a211c9cd95aae413cb68c",
+  "host": {
+    "os": "Linux 7.0.0-29-generic",
+    "architecture": "x86_64",
+    "compiler": "GCC 15.2.0",
+    "configuration": "Release",
+    "dotnet_sdk": "10.0.104"
+  },
+  "capability_id": "samples.dotnet.add-v1",
+  "runner": {
+    "warmup_iterations": 1,
+    "measured_iterations": 3,
+    "workloads": ["positive", "negative", "zero"]
+  },
+  "policy": {
+    "minimum_sample_count": 9,
+    "maximum_p95_latency_us": 5000000,
+    "minimum_throughput_per_second": 1,
+    "maximum_peak_memory_kib": 1048576,
+    "maximum_p95_startup_ms": 5000,
+    "maximum_security_profile": "admitted-process",
+    "weights": {"latency": 25, "throughput": 25, "memory": 25, "startup": 25}
+  },
+  "measurements": [
+    {
+      "implementation": "direct-cpp",
+      "security_profile": "trusted-native",
+      "sample_count": 9,
+      "failure_count": 0,
+      "parity_mismatch_count": 0,
+      "p95_latency_us": 1,
+      "throughput_per_second": 1000000,
+      "peak_memory_kib": 0,
+      "p95_startup_ms": 0
+    },
+    {
+      "implementation": "cpp-dotnet-wrapper",
+      "security_profile": "admitted-process",
+      "sample_count": 9,
+      "failure_count": 0,
+      "parity_mismatch_count": 0,
+      "p95_latency_us": 18167,
+      "throughput_per_second": 71,
+      "peak_memory_kib": 3828,
+      "p95_startup_ms": 6
+    },
+    {
+      "implementation": "csharp-service",
+      "security_profile": "admitted-process",
+      "sample_count": 9,
+      "failure_count": 0,
+      "parity_mismatch_count": 0,
+      "p95_latency_us": 9916,
+      "throughput_per_second": 161,
+      "peak_memory_kib": 3820,
+      "p95_startup_ms": 9
+    }
+  ],
+  "recommendation": {
+    "ready": true,
+    "preferred": "direct-cpp",
+    "fallback_chain": ["csharp-service", "cpp-dotnet-wrapper"],
+    "automatic_promotion": false
+  },
+  "limitations": [
+    "This is one Linux x86_64 host observation, not a cross-platform performance claim.",
+    "The csharp-service class is a local one-request Native AOT endpoint boundary, not a persistent or remote service.",
+    "Direct C++ reports zero route-specific additional KiB for this allocation-free operation, not total host-process RSS.",
+    "Timing and route ordering must be remeasured for each target host and representative production workload."
+  ]
+}

--- a/docs/contracts/polyglot-benchmark-result-v1.json
+++ b/docs/contracts/polyglot-benchmark-result-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "kind": "copperfin-polyglot-benchmark-result",
-  "captured_at_utc": "2026-08-11T11:14:13Z",
-  "source_commit": "cf4cd9573103096d915a211c9cd95aae413cb68c",
+  "captured_at_utc": "2026-08-11T12:13:25Z",
+  "source_commit": "deaa815ef1ccf74836676654d4108689d6422c8a",
   "host": {
     "os": "Linux 7.0.0-29-generic",
     "architecture": "x86_64",
@@ -35,6 +35,7 @@
       "p95_latency_us": 1,
       "throughput_per_second": 1000000,
       "peak_memory_kib": 0,
+      "peak_memory_source": "route-specific-additional",
       "p95_startup_ms": 0
     },
     {
@@ -43,10 +44,11 @@
       "sample_count": 9,
       "failure_count": 0,
       "parity_mismatch_count": 0,
-      "p95_latency_us": 18167,
-      "throughput_per_second": 71,
-      "peak_memory_kib": 3828,
-      "p95_startup_ms": 6
+      "p95_latency_us": 19366,
+      "throughput_per_second": 63,
+      "peak_memory_kib": 4720,
+      "peak_memory_source": "candidate-self-reported-peak-working-set",
+      "p95_startup_ms": 10
     },
     {
       "implementation": "csharp-service",
@@ -54,10 +56,11 @@
       "sample_count": 9,
       "failure_count": 0,
       "parity_mismatch_count": 0,
-      "p95_latency_us": 9916,
-      "throughput_per_second": 161,
-      "peak_memory_kib": 3820,
-      "p95_startup_ms": 9
+      "p95_latency_us": 8312,
+      "throughput_per_second": 190,
+      "peak_memory_kib": 4720,
+      "peak_memory_source": "candidate-self-reported-peak-working-set",
+      "p95_startup_ms": 8
     }
   ],
   "recommendation": {
@@ -69,6 +72,7 @@
   "limitations": [
     "This is one Linux x86_64 host observation, not a cross-platform performance claim.",
     "The csharp-service class is a local one-request Native AOT endpoint boundary, not a persistent or remote service.",
+    "External-route memory is the candidate's opt-in self-reported PeakWorkingSet64, not POSIX wait4 rusage.",
     "Direct C++ reports zero route-specific additional KiB for this allocation-free operation, not total host-process RSS.",
     "Timing and route ordering must be remeasured for each target host and representative production workload."
   ]

--- a/docs/contracts/polyglot-benchmark-result-v1.json
+++ b/docs/contracts/polyglot-benchmark-result-v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": 1,
   "kind": "copperfin-polyglot-benchmark-result",
-  "captured_at_utc": "2026-08-11T12:13:25Z",
-  "source_commit": "deaa815ef1ccf74836676654d4108689d6422c8a",
+  "captured_at_utc": "2026-08-11T12:19:10Z",
+  "source_commit": "2ca80ab39135185b67f81b470ab500cf2c4d6a58",
   "host": {
     "os": "Linux 7.0.0-29-generic",
     "architecture": "x86_64",
@@ -44,10 +44,10 @@
       "sample_count": 9,
       "failure_count": 0,
       "parity_mismatch_count": 0,
-      "p95_latency_us": 19366,
-      "throughput_per_second": 63,
-      "peak_memory_kib": 4720,
-      "peak_memory_source": "candidate-self-reported-peak-working-set",
+      "p95_latency_us": 20557,
+      "throughput_per_second": 67,
+      "peak_memory_kib": 4416,
+      "peak_memory_source": "candidate-self-reported-working-set",
       "p95_startup_ms": 10
     },
     {
@@ -56,11 +56,11 @@
       "sample_count": 9,
       "failure_count": 0,
       "parity_mismatch_count": 0,
-      "p95_latency_us": 8312,
-      "throughput_per_second": 190,
-      "peak_memory_kib": 4720,
-      "peak_memory_source": "candidate-self-reported-peak-working-set",
-      "p95_startup_ms": 8
+      "p95_latency_us": 9419,
+      "throughput_per_second": 162,
+      "peak_memory_kib": 4408,
+      "peak_memory_source": "candidate-self-reported-working-set",
+      "p95_startup_ms": 9
     }
   ],
   "recommendation": {
@@ -72,7 +72,7 @@
   "limitations": [
     "This is one Linux x86_64 host observation, not a cross-platform performance claim.",
     "The csharp-service class is a local one-request Native AOT endpoint boundary, not a persistent or remote service.",
-    "External-route memory is the candidate's opt-in self-reported PeakWorkingSet64, not POSIX wait4 rusage.",
+    "External-route memory is the maximum observed candidate self-reported Environment.WorkingSet, not an OS lifetime peak or POSIX wait4 rusage.",
     "Direct C++ reports zero route-specific additional KiB for this allocation-free operation, not total host-process RSS.",
     "Timing and route ordering must be remeasured for each target host and representative production workload."
   ]

--- a/docs/contracts/polyglot-benchmark-result-v1.schema.json
+++ b/docs/contracts/polyglot-benchmark-result-v1.schema.json
@@ -57,7 +57,7 @@
           "peak_memory_source": {
             "enum": [
               "route-specific-additional",
-              "candidate-self-reported-peak-working-set",
+              "candidate-self-reported-working-set",
               "windows-owned-job"
             ]
           },

--- a/docs/contracts/polyglot-benchmark-result-v1.schema.json
+++ b/docs/contracts/polyglot-benchmark-result-v1.schema.json
@@ -43,7 +43,7 @@
         "required": [
           "implementation", "security_profile", "sample_count", "failure_count",
           "parity_mismatch_count", "p95_latency_us", "throughput_per_second",
-          "peak_memory_kib", "p95_startup_ms"
+          "peak_memory_kib", "peak_memory_source", "p95_startup_ms"
         ],
         "properties": {
           "implementation": {"enum": ["direct-cpp", "cpp-dotnet-wrapper", "csharp-service"]},
@@ -54,6 +54,13 @@
           "p95_latency_us": {"type": "integer", "minimum": 0},
           "throughput_per_second": {"type": "integer", "minimum": 0},
           "peak_memory_kib": {"type": "integer", "minimum": 0},
+          "peak_memory_source": {
+            "enum": [
+              "route-specific-additional",
+              "candidate-self-reported-peak-working-set",
+              "windows-owned-job"
+            ]
+          },
           "p95_startup_ms": {"type": "integer", "minimum": 0}
         }
       }

--- a/docs/contracts/polyglot-benchmark-result-v1.schema.json
+++ b/docs/contracts/polyglot-benchmark-result-v1.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://project-copperfin.invalid/contracts/polyglot-benchmark-result-v1.schema.json",
+  "title": "Copperfin Polyglot Benchmark Result v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "kind", "captured_at_utc", "source_commit",
+    "host", "capability_id", "runner", "policy", "measurements",
+    "recommendation", "limitations"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "kind": {"const": "copperfin-polyglot-benchmark-result"},
+    "captured_at_utc": {"type": "string", "format": "date-time"},
+    "source_commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+    "host": {
+      "type": "object", "additionalProperties": false,
+      "required": ["os", "architecture", "compiler", "configuration", "dotnet_sdk"],
+      "properties": {
+        "os": {"type": "string", "minLength": 1},
+        "architecture": {"type": "string", "minLength": 1},
+        "compiler": {"type": "string", "minLength": 1},
+        "configuration": {"type": "string", "minLength": 1},
+        "dotnet_sdk": {"type": "string", "minLength": 1}
+      }
+    },
+    "capability_id": {"const": "samples.dotnet.add-v1"},
+    "runner": {
+      "type": "object", "additionalProperties": false,
+      "required": ["warmup_iterations", "measured_iterations", "workloads"],
+      "properties": {
+        "warmup_iterations": {"type": "integer", "minimum": 0},
+        "measured_iterations": {"type": "integer", "minimum": 1},
+        "workloads": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+      }
+    },
+    "policy": {"type": "object"},
+    "measurements": {
+      "type": "array", "minItems": 3, "maxItems": 3,
+      "items": {
+        "type": "object", "additionalProperties": false,
+        "required": [
+          "implementation", "security_profile", "sample_count", "failure_count",
+          "parity_mismatch_count", "p95_latency_us", "throughput_per_second",
+          "peak_memory_kib", "p95_startup_ms"
+        ],
+        "properties": {
+          "implementation": {"enum": ["direct-cpp", "cpp-dotnet-wrapper", "csharp-service"]},
+          "security_profile": {"enum": ["trusted-native", "admitted-process", "remote-service"]},
+          "sample_count": {"type": "integer", "minimum": 0},
+          "failure_count": {"type": "integer", "minimum": 0},
+          "parity_mismatch_count": {"type": "integer", "minimum": 0},
+          "p95_latency_us": {"type": "integer", "minimum": 0},
+          "throughput_per_second": {"type": "integer", "minimum": 0},
+          "peak_memory_kib": {"type": "integer", "minimum": 0},
+          "p95_startup_ms": {"type": "integer", "minimum": 0}
+        }
+      }
+    },
+    "recommendation": {
+      "type": "object", "additionalProperties": false,
+      "required": ["ready", "preferred", "fallback_chain", "automatic_promotion"],
+      "properties": {
+        "ready": {"type": "boolean"},
+        "preferred": {"enum": ["direct-cpp", "cpp-dotnet-wrapper", "csharp-service"]},
+        "fallback_chain": {"type": "array", "items": {"enum": ["direct-cpp", "cpp-dotnet-wrapper", "csharp-service"]}},
+        "automatic_promotion": {"const": false}
+      }
+    },
+    "limitations": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
+  }
+}

--- a/docs/contracts/polyglot-benchmark-result-v1.schema.json
+++ b/docs/contracts/polyglot-benchmark-result-v1.schema.json
@@ -35,7 +35,32 @@
         "workloads": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}}
       }
     },
-    "policy": {"type": "object"},
+    "policy": {
+      "type": "object", "additionalProperties": false,
+      "required": [
+        "minimum_sample_count", "maximum_p95_latency_us",
+        "minimum_throughput_per_second", "maximum_peak_memory_kib",
+        "maximum_p95_startup_ms", "maximum_security_profile", "weights"
+      ],
+      "properties": {
+        "minimum_sample_count": {"type": "integer", "minimum": 1, "maximum": 4294967295},
+        "maximum_p95_latency_us": {"type": "integer", "minimum": 1, "maximum": 1000000000000},
+        "minimum_throughput_per_second": {"type": "integer", "minimum": 1, "maximum": 1000000000000},
+        "maximum_peak_memory_kib": {"type": "integer", "minimum": 1, "maximum": 1000000000000},
+        "maximum_p95_startup_ms": {"type": "integer", "minimum": 1, "maximum": 1000000000000},
+        "maximum_security_profile": {"enum": ["trusted-native", "admitted-process", "remote-service"]},
+        "weights": {
+          "type": "object", "additionalProperties": false,
+          "required": ["latency", "throughput", "memory", "startup"],
+          "properties": {
+            "latency": {"type": "integer", "minimum": 0, "maximum": 100},
+            "throughput": {"type": "integer", "minimum": 0, "maximum": 100},
+            "memory": {"type": "integer", "minimum": 0, "maximum": 100},
+            "startup": {"type": "integer", "minimum": 0, "maximum": 100}
+          }
+        }
+      }
+    },
     "measurements": {
       "type": "array", "minItems": 3, "maxItems": 3,
       "items": {

--- a/include/copperfin/platform/bounded_process.h
+++ b/include/copperfin/platform/bounded_process.h
@@ -54,6 +54,9 @@ struct BoundedProcessResult {
     int exit_code = -1;
     int native_error = 0;
     std::uint64_t elapsed_ms = 0U;
+    // Peak resident memory attributed to the owned root process on POSIX and
+    // to the owned job (including descendants) on Windows.
+    std::uint64_t peak_memory_kib = 0U;
     std::string error_code = "polyglot.process.invalid_request";
     std::string standard_output;
     std::string standard_error;

--- a/include/copperfin/platform/bounded_process.h
+++ b/include/copperfin/platform/bounded_process.h
@@ -54,8 +54,10 @@ struct BoundedProcessResult {
     int exit_code = -1;
     int native_error = 0;
     std::uint64_t elapsed_ms = 0U;
-    // Peak resident memory attributed to the owned root process on POSIX and
-    // to the owned job (including descendants) on Windows.
+    // Windows Job Objects can report a reliable owned-job peak. Generic POSIX
+    // wait4() rusage is deliberately not exposed here because fork() can seed
+    // the child's high-water mark with the launcher's pre-exec resident set.
+    bool peak_memory_available = false;
     std::uint64_t peak_memory_kib = 0U;
     std::string error_code = "polyglot.process.invalid_request";
     std::string standard_output;

--- a/include/copperfin/platform/polyglot_benchmark.h
+++ b/include/copperfin/platform/polyglot_benchmark.h
@@ -1,0 +1,85 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#pragma once
+
+#include "copperfin/platform/polyglot_route_impact.h"
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace copperfin::platform {
+
+enum class PolyglotBenchmarkError : std::uint8_t {
+    none,
+    invalid_request,
+    invalid_observation,
+    invocation_failed
+};
+
+struct PolyglotBenchmarkWorkload {
+    std::string workload_id;
+    std::string arguments_json;
+    std::string expected_payload_json;
+};
+
+struct PolyglotBenchmarkRoute {
+    PolyglotRouteImplementation implementation =
+        PolyglotRouteImplementation::direct_cpp;
+    PolyglotRouteSecurityProfile security_profile =
+        PolyglotRouteSecurityProfile::trusted_native;
+    bool runtime_available = false;
+    bool security_approved = false;
+    bool contract_compatible = false;
+};
+
+struct PolyglotBenchmarkObservation {
+    bool invocation_succeeded = false;
+    bool parity_matched = false;
+    std::uint64_t latency_us = 0U;
+    std::uint64_t peak_memory_kib = 0U;
+    std::uint64_t startup_ms = 0U;
+};
+
+struct PolyglotBenchmarkInvocation {
+    PolyglotRouteImplementation implementation =
+        PolyglotRouteImplementation::direct_cpp;
+    const PolyglotBenchmarkWorkload* workload = nullptr;
+    std::uint32_t iteration = 0U;
+    bool warmup = false;
+};
+
+using PolyglotBenchmarkInvoke =
+    std::function<PolyglotBenchmarkObservation(const PolyglotBenchmarkInvocation&)>;
+
+struct PolyglotBenchmarkRequest {
+    std::string capability_id;
+    std::uint32_t warmup_iterations = 3U;
+    std::uint32_t measured_iterations = 10U;
+    PolyglotRouteImpactPolicy policy;
+    std::vector<PolyglotBenchmarkWorkload> workloads;
+    std::vector<PolyglotBenchmarkRoute> routes;
+    PolyglotBenchmarkInvoke invoke;
+};
+
+struct PolyglotBenchmarkResult {
+    PolyglotBenchmarkError error = PolyglotBenchmarkError::none;
+    std::string error_code;
+    std::vector<PolyglotRouteImpactMeasurement> measurements;
+    PolyglotRouteImpactResult impact;
+
+    [[nodiscard]] bool ok() const noexcept {
+        return error == PolyglotBenchmarkError::none && impact.ok();
+    }
+};
+
+// Runs a bounded, caller-supplied representative workload and aggregates its
+// observations for the advisory route-impact evaluator. This function owns no
+// registry, artifact, network, or promotion authority.
+[[nodiscard]] PolyglotBenchmarkResult run_polyglot_benchmark(
+    const PolyglotBenchmarkRequest& request);
+
+}  // namespace copperfin::platform

--- a/samples/polyglot-dotnet-candidate/Program.cs
+++ b/samples/polyglot-dotnet-candidate/Program.cs
@@ -48,6 +48,7 @@ internal static class Program
             try
             {
                 WriteSuccess(identity, checked(left + right));
+                WriteBenchmarkMetricsIfRequested();
             }
             catch (OverflowException)
             {
@@ -65,6 +66,18 @@ internal static class Program
             Console.Error.Write("polyglot candidate failed");
             return 3;
         }
+    }
+
+    private static void WriteBenchmarkMetricsIfRequested()
+    {
+        if (Environment.GetEnvironmentVariable(
+                "COPPERFIN_BENCHMARK_SELF_METRICS") != "1")
+        {
+            return;
+        }
+        using var process = System.Diagnostics.Process.GetCurrentProcess();
+        var peakMemoryKiB = checked((process.PeakWorkingSet64 + 1023L) / 1024L);
+        Console.Error.Write($"COPPERFIN_PEAK_MEMORY_KIB={peakMemoryKiB}\n");
     }
 
     private static byte[]? ReadBoundedStandardInput()

--- a/samples/polyglot-dotnet-candidate/Program.cs
+++ b/samples/polyglot-dotnet-candidate/Program.cs
@@ -75,9 +75,8 @@ internal static class Program
         {
             return;
         }
-        using var process = System.Diagnostics.Process.GetCurrentProcess();
-        var peakMemoryKiB = checked((process.PeakWorkingSet64 + 1023L) / 1024L);
-        Console.Error.Write($"COPPERFIN_PEAK_MEMORY_KIB={peakMemoryKiB}\n");
+        var workingSetKiB = checked((Environment.WorkingSet + 1023L) / 1024L);
+        Console.Error.Write($"COPPERFIN_WORKING_SET_KIB={workingSetKiB}\n");
     }
 
     private static byte[]? ReadBoundedStandardInput()

--- a/src/platform/bounded_process.cpp
+++ b/src/platform/bounded_process.cpp
@@ -31,6 +31,7 @@
 #include <csignal>
 #include <fcntl.h>
 #include <pthread.h>
+#include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -43,6 +44,18 @@ constexpr std::uint32_t kMaximumTransportBytes = 16U * 1024U * 1024U;
 
 #if defined(_WIN32)
 constexpr DWORD kTerminationWaitMilliseconds = 5000U;
+
+void capture_windows_peak_memory(
+    const HANDLE job,
+    BoundedProcessResult& result) noexcept {
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION information{};
+    if (::QueryInformationJobObject(
+            job, JobObjectExtendedLimitInformation, &information,
+            sizeof(information), nullptr) != FALSE) {
+        result.peak_memory_kib = static_cast<std::uint64_t>(
+            (information.PeakJobMemoryUsed + 1023U) / 1024U);
+    }
+}
 #endif
 
 using Clock = std::chrono::steady_clock;
@@ -792,6 +805,7 @@ BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
 
     // KILL_ON_JOB_CLOSE also removes descendants after an otherwise successful
     // root exit; artifact invocations never authorize persistent child jobs.
+    capture_windows_peak_memory(job, result);
     (void)::CloseHandle(job);
     result.process_tree_closed = true;
     (void)::CloseHandle(process_info.hProcess);
@@ -806,6 +820,19 @@ BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
 }
 
 #else
+
+void capture_posix_peak_memory(
+    const struct rusage& usage,
+    BoundedProcessResult& result) noexcept {
+#if defined(__APPLE__)
+    const std::uint64_t bytes = usage.ru_maxrss <= 0
+        ? 0U : static_cast<std::uint64_t>(usage.ru_maxrss);
+    result.peak_memory_kib = (bytes + 1023U) / 1024U;
+#else
+    result.peak_memory_kib = usage.ru_maxrss <= 0
+        ? 0U : static_cast<std::uint64_t>(usage.ru_maxrss);
+#endif
+}
 
 bool write_child_error(const int descriptor, const int child_error) {
     const auto* bytes = reinterpret_cast<const std::uint8_t*>(&child_error);
@@ -1282,8 +1309,10 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
 
     int status = 0;
     for (;;) {
-        const pid_t waited = ::waitpid(process_id, &status, WNOHANG);
+        struct rusage usage{};
+        const pid_t waited = ::wait4(process_id, &status, WNOHANG, &usage);
         if (waited == process_id) {
+            capture_posix_peak_memory(usage, result);
             result.status = BoundedProcessStatus::exited;
             result.error_code = "polyglot.process.exited";
             if (WIFEXITED(status)) {

--- a/src/platform/bounded_process.cpp
+++ b/src/platform/bounded_process.cpp
@@ -31,7 +31,6 @@
 #include <csignal>
 #include <fcntl.h>
 #include <pthread.h>
-#include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -52,6 +51,7 @@ void capture_windows_peak_memory(
     if (::QueryInformationJobObject(
             job, JobObjectExtendedLimitInformation, &information,
             sizeof(information), nullptr) != FALSE) {
+        result.peak_memory_available = true;
         result.peak_memory_kib = static_cast<std::uint64_t>(
             (information.PeakJobMemoryUsed + 1023U) / 1024U);
     }
@@ -821,19 +821,6 @@ BoundedProcessResult run_windows(const BoundedProcessRequest& request) {
 
 #else
 
-void capture_posix_peak_memory(
-    const struct rusage& usage,
-    BoundedProcessResult& result) noexcept {
-#if defined(__APPLE__)
-    const std::uint64_t bytes = usage.ru_maxrss <= 0
-        ? 0U : static_cast<std::uint64_t>(usage.ru_maxrss);
-    result.peak_memory_kib = (bytes + 1023U) / 1024U;
-#else
-    result.peak_memory_kib = usage.ru_maxrss <= 0
-        ? 0U : static_cast<std::uint64_t>(usage.ru_maxrss);
-#endif
-}
-
 bool write_child_error(const int descriptor, const int child_error) {
     const auto* bytes = reinterpret_cast<const std::uint8_t*>(&child_error);
     std::size_t written = 0U;
@@ -1309,10 +1296,8 @@ BoundedProcessResult run_posix(const BoundedProcessRequest& request) {
 
     int status = 0;
     for (;;) {
-        struct rusage usage{};
-        const pid_t waited = ::wait4(process_id, &status, WNOHANG, &usage);
+        const pid_t waited = ::waitpid(process_id, &status, WNOHANG);
         if (waited == process_id) {
-            capture_posix_peak_memory(usage, result);
             result.status = BoundedProcessStatus::exited;
             result.error_code = "polyglot.process.exited";
             if (WIFEXITED(status)) {

--- a/src/platform/polyglot_benchmark.cpp
+++ b/src/platform/polyglot_benchmark.cpp
@@ -1,0 +1,199 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/polyglot_benchmark.h"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <utility>
+
+namespace copperfin::platform {
+
+namespace {
+
+constexpr std::uint32_t kMaximumWarmupIterations = 100U;
+constexpr std::uint32_t kMaximumMeasuredIterations = 10'000U;
+constexpr std::size_t kMaximumWorkloads = 100U;
+constexpr std::uint64_t kMaximumMetricValue = 1'000'000'000'000ULL;
+
+std::size_t route_index(const PolyglotRouteImplementation implementation) noexcept {
+    switch (implementation) {
+    case PolyglotRouteImplementation::direct_cpp: return 0U;
+    case PolyglotRouteImplementation::cpp_dotnet_wrapper: return 1U;
+    case PolyglotRouteImplementation::csharp_service: return 2U;
+    }
+    return 3U;
+}
+
+PolyglotBenchmarkResult reject(
+    const PolyglotBenchmarkError error,
+    std::string error_code) {
+    PolyglotBenchmarkResult result;
+    result.error = error;
+    result.error_code = std::move(error_code);
+    return result;
+}
+
+bool valid_request(const PolyglotBenchmarkRequest& request) {
+    if (request.capability_id.empty() || request.warmup_iterations >
+            kMaximumWarmupIterations || request.measured_iterations == 0U ||
+        request.measured_iterations > kMaximumMeasuredIterations ||
+        request.workloads.empty() || request.workloads.size() > kMaximumWorkloads ||
+        request.routes.size() != 3U || !request.invoke) {
+        return false;
+    }
+    const std::uint64_t sample_count =
+        static_cast<std::uint64_t>(request.measured_iterations) *
+        static_cast<std::uint64_t>(request.workloads.size());
+    if (sample_count == 0U ||
+        sample_count > std::numeric_limits<std::uint32_t>::max()) {
+        return false;
+    }
+    for (const auto& workload : request.workloads) {
+        if (workload.workload_id.empty() || workload.arguments_json.empty() ||
+            workload.expected_payload_json.empty()) {
+            return false;
+        }
+    }
+    std::array<bool, 3U> seen{};
+    for (const auto& route : request.routes) {
+        const std::size_t index = route_index(route.implementation);
+        if (index >= seen.size() || seen[index]) {
+            return false;
+        }
+        seen[index] = true;
+    }
+    return true;
+}
+
+bool valid_observation(const PolyglotBenchmarkObservation& observation) noexcept {
+    return observation.latency_us > 0U &&
+        observation.latency_us <= kMaximumMetricValue &&
+        observation.peak_memory_kib <= kMaximumMetricValue &&
+        observation.startup_ms <= kMaximumMetricValue;
+}
+
+std::uint64_t percentile95(std::vector<std::uint64_t> values) {
+    std::sort(values.begin(), values.end());
+    const std::size_t rank =
+        (values.size() * 95U + 99U) / 100U;
+    return values[rank - 1U];
+}
+
+}  // namespace
+
+PolyglotBenchmarkResult run_polyglot_benchmark(
+    const PolyglotBenchmarkRequest& request) {
+    if (!valid_request(request)) {
+        return reject(
+            PolyglotBenchmarkError::invalid_request,
+            "polyglot.benchmark.invalid_request");
+    }
+
+    std::vector<PolyglotRouteImpactMeasurement> preflight_measurements;
+    preflight_measurements.reserve(request.routes.size());
+    for (const auto& route : request.routes) {
+        preflight_measurements.push_back({
+            .implementation = route.implementation,
+            .security_profile = route.security_profile,
+            .runtime_available = false,
+            .security_approved = route.security_approved,
+            .contract_compatible = route.contract_compatible});
+    }
+    const auto preflight = evaluate_polyglot_route_impact({
+        request.capability_id, request.policy, preflight_measurements});
+    if (preflight.error != PolyglotRouteImpactError::no_eligible_route) {
+        return reject(
+            PolyglotBenchmarkError::invalid_request,
+            "polyglot.benchmark.invalid_request");
+    }
+
+    PolyglotBenchmarkResult result;
+    result.error_code = "polyglot.benchmark.complete";
+    const std::uint32_t sample_count = static_cast<std::uint32_t>(
+        request.measured_iterations * request.workloads.size());
+    for (const auto& route : request.routes) {
+        PolyglotRouteImpactMeasurement measurement{
+            .implementation = route.implementation,
+            .security_profile = route.security_profile,
+            .runtime_available = route.runtime_available,
+            .security_approved = route.security_approved,
+            .contract_compatible = route.contract_compatible};
+        if (!route.runtime_available) {
+            result.measurements.push_back(measurement);
+            continue;
+        }
+
+        try {
+            for (std::uint32_t iteration = 0U;
+                 iteration < request.warmup_iterations; ++iteration) {
+                for (const auto& workload : request.workloads) {
+                    const auto observation = request.invoke({
+                        route.implementation, &workload, iteration, true});
+                    if (!valid_observation(observation)) {
+                        return reject(
+                            PolyglotBenchmarkError::invalid_observation,
+                            "polyglot.benchmark.invalid_observation");
+                    }
+                    if (!observation.invocation_succeeded ||
+                        !observation.parity_matched) {
+                        return reject(
+                            PolyglotBenchmarkError::invocation_failed,
+                            "polyglot.benchmark.warmup_failed");
+                    }
+                }
+            }
+
+            std::vector<std::uint64_t> latencies;
+            std::vector<std::uint64_t> startups;
+            latencies.reserve(sample_count);
+            startups.reserve(sample_count);
+            std::uint64_t total_latency = 0U;
+            for (std::uint32_t iteration = 0U;
+                 iteration < request.measured_iterations; ++iteration) {
+                for (const auto& workload : request.workloads) {
+                    const auto observation = request.invoke({
+                        route.implementation, &workload, iteration, false});
+                    if (!valid_observation(observation) ||
+                        total_latency > kMaximumMetricValue - observation.latency_us) {
+                        return reject(
+                            PolyglotBenchmarkError::invalid_observation,
+                            "polyglot.benchmark.invalid_observation");
+                    }
+                    latencies.push_back(observation.latency_us);
+                    startups.push_back(observation.startup_ms);
+                    total_latency += observation.latency_us;
+                    measurement.peak_memory_kib = std::max(
+                        measurement.peak_memory_kib,
+                        observation.peak_memory_kib);
+                    if (!observation.invocation_succeeded) {
+                        ++measurement.failure_count;
+                    }
+                    if (!observation.parity_matched) {
+                        ++measurement.parity_mismatch_count;
+                    }
+                }
+            }
+            measurement.sample_count = sample_count;
+            measurement.p95_latency_us = percentile95(std::move(latencies));
+            measurement.p95_startup_ms = percentile95(std::move(startups));
+            measurement.throughput_per_second = std::max<std::uint64_t>(
+                1U,
+                (static_cast<std::uint64_t>(sample_count) * 1'000'000U) /
+                    total_latency);
+        } catch (...) {
+            return reject(
+                PolyglotBenchmarkError::invocation_failed,
+                "polyglot.benchmark.invocation_failed");
+        }
+        result.measurements.push_back(measurement);
+    }
+
+    result.impact = evaluate_polyglot_route_impact({
+        request.capability_id, request.policy, result.measurements});
+    return result;
+}
+
+}  // namespace copperfin::platform

--- a/src/platform/polyglot_benchmark.cpp
+++ b/src/platform/polyglot_benchmark.cpp
@@ -157,7 +157,9 @@ PolyglotBenchmarkResult run_polyglot_benchmark(
                     const auto observation = request.invoke({
                         route.implementation, &workload, iteration, false});
                     if (!valid_observation(observation) ||
-                        total_latency > kMaximumMetricValue - observation.latency_us) {
+                        total_latency >
+                            std::numeric_limits<std::uint64_t>::max() -
+                                observation.latency_us) {
                         return reject(
                             PolyglotBenchmarkError::invalid_observation,
                             "polyglot.benchmark.invalid_observation");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4677,6 +4677,10 @@ copperfin_add_test(test_polyglot_route_impact cf_platform_profile
     test_polyglot_route_impact.cpp
 )
 
+copperfin_add_test(test_polyglot_benchmark cf_platform_profile
+    test_polyglot_benchmark.cpp
+)
+
 copperfin_add_test(test_polyglot_bridge_invocation cf_platform_profile
     test_polyglot_bridge_invocation.cpp
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4803,6 +4803,13 @@ add_test(
         -P ${CMAKE_CURRENT_SOURCE_DIR}/run_polyglot_route_contract_check.cmake
 )
 
+add_test(
+    NAME test_polyglot_benchmark_result_contract
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/run_polyglot_benchmark_result_contract_check.cmake
+)
+
 add_executable(test_platform_environment
     test_platform_environment.cpp
 )

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -113,6 +113,7 @@ function(copperfin_configure_native_test_isolation)
 
     foreach(test_name IN ITEMS
             test_polyglot_bridge_invocation
+            test_polyglot_benchmark
             test_polyglot_interop_envelope
             test_polyglot_migration_telemetry
             test_polyglot_parity_comparator

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -212,6 +212,16 @@ function(copperfin_configure_native_test_isolation)
         PLATFORM portable
         AUDIT complete
     )
+    copperfin_set_test_isolation(test_polyglot_benchmark_result_contract
+        PARALLEL_SAFE
+        FILESYSTEM read-only
+        ENVIRONMENT none
+        CHILD_PROCESSES none
+        NETWORK none
+        SAMPLES none
+        PLATFORM portable
+        AUDIT complete
+    )
 
     foreach(test_name IN ITEMS
             test_product_subsystems

--- a/tests/run_polyglot_benchmark_result_contract_check.cmake
+++ b/tests/run_polyglot_benchmark_result_contract_check.cmake
@@ -40,8 +40,8 @@ endif()
 set(expected_implementations direct-cpp cpp-dotnet-wrapper csharp-service)
 set(expected_memory_sources
     route-specific-additional
-    candidate-self-reported-peak-working-set
-    candidate-self-reported-peak-working-set)
+    candidate-self-reported-working-set
+    candidate-self-reported-working-set)
 foreach(index RANGE 0 2)
     list(GET expected_implementations ${index} expected)
     list(GET expected_memory_sources ${index} expected_memory_source)

--- a/tests/run_polyglot_benchmark_result_contract_check.cmake
+++ b/tests/run_polyglot_benchmark_result_contract_check.cmake
@@ -37,6 +37,33 @@ if(NOT schema_version EQUAL 1 OR
     message(FATAL_ERROR "Polyglot benchmark result identity or promotion contract is invalid")
 endif()
 
+string(JSON policy_additional GET "${schema_json}" properties policy additionalProperties)
+string(JSON policy_required_count LENGTH "${schema_json}" properties policy required)
+string(JSON weights_additional GET "${schema_json}" properties policy properties weights additionalProperties)
+string(JSON weights_required_count LENGTH "${schema_json}" properties policy properties weights required)
+if(policy_additional OR NOT policy_required_count EQUAL 7 OR
+   weights_additional OR NOT weights_required_count EQUAL 4)
+    message(FATAL_ERROR "Polyglot benchmark policy schema must be closed and complete")
+endif()
+
+set(expected_policy_fields
+    minimum_sample_count
+    maximum_p95_latency_us
+    minimum_throughput_per_second
+    maximum_peak_memory_kib
+    maximum_p95_startup_ms
+    maximum_security_profile
+    weights)
+foreach(field IN LISTS expected_policy_fields)
+    string(JSON field_index ERROR_VARIABLE field_error
+        GET "${schema_json}" properties policy properties "${field}")
+    string(JSON policy_value_error ERROR_VARIABLE value_error
+        GET "${result_json}" policy "${field}")
+    if(field_error OR value_error)
+        message(FATAL_ERROR "Polyglot benchmark policy field is missing: ${field}")
+    endif()
+endforeach()
+
 set(expected_implementations direct-cpp cpp-dotnet-wrapper csharp-service)
 set(expected_memory_sources
     route-specific-additional

--- a/tests/run_polyglot_benchmark_result_contract_check.cmake
+++ b/tests/run_polyglot_benchmark_result_contract_check.cmake
@@ -38,13 +38,20 @@ if(NOT schema_version EQUAL 1 OR
 endif()
 
 set(expected_implementations direct-cpp cpp-dotnet-wrapper csharp-service)
+set(expected_memory_sources
+    route-specific-additional
+    candidate-self-reported-peak-working-set
+    candidate-self-reported-peak-working-set)
 foreach(index RANGE 0 2)
     list(GET expected_implementations ${index} expected)
+    list(GET expected_memory_sources ${index} expected_memory_source)
     string(JSON implementation GET "${result_json}" measurements ${index} implementation)
+    string(JSON memory_source GET "${result_json}" measurements ${index} peak_memory_source)
     string(JSON samples GET "${result_json}" measurements ${index} sample_count)
     string(JSON failures GET "${result_json}" measurements ${index} failure_count)
     string(JSON mismatches GET "${result_json}" measurements ${index} parity_mismatch_count)
     if(NOT implementation STREQUAL expected OR
+       NOT memory_source STREQUAL expected_memory_source OR
        NOT samples EQUAL 9 OR NOT failures EQUAL 0 OR NOT mismatches EQUAL 0)
         message(FATAL_ERROR "Polyglot benchmark evidence is incomplete for ${expected}")
     endif()

--- a/tests/run_polyglot_benchmark_result_contract_check.cmake
+++ b/tests/run_polyglot_benchmark_result_contract_check.cmake
@@ -1,0 +1,53 @@
+# Copyright © 2026 Richard M. Hamilton.
+# SPDX-License-Identifier: GPL-3.0-only
+# Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+if(NOT DEFINED SOURCE_DIR OR "${SOURCE_DIR}" STREQUAL "")
+    message(FATAL_ERROR "SOURCE_DIR is required")
+endif()
+
+set(schema_path "${SOURCE_DIR}/docs/contracts/polyglot-benchmark-result-v1.schema.json")
+set(result_path "${SOURCE_DIR}/docs/contracts/polyglot-benchmark-result-v1.json")
+foreach(path IN ITEMS "${schema_path}" "${result_path}")
+    if(NOT EXISTS "${path}")
+        message(FATAL_ERROR "Polyglot benchmark contract fixture is missing: ${path}")
+    endif()
+endforeach()
+
+file(READ "${schema_path}" schema_json)
+file(READ "${result_path}" result_json)
+string(JSON schema_type ERROR_VARIABLE schema_error TYPE "${schema_json}")
+string(JSON result_type ERROR_VARIABLE result_error TYPE "${result_json}")
+if(schema_error OR NOT schema_type STREQUAL "OBJECT" OR
+   result_error OR NOT result_type STREQUAL "OBJECT")
+    message(FATAL_ERROR "Polyglot benchmark contract fixtures must be JSON objects")
+endif()
+
+string(JSON schema_version GET "${result_json}" schema_version)
+string(JSON result_kind GET "${result_json}" kind)
+string(JSON source_commit GET "${result_json}" source_commit)
+string(LENGTH "${source_commit}" source_commit_length)
+string(JSON measurement_count LENGTH "${result_json}" measurements)
+string(JSON promotion GET "${result_json}" recommendation automatic_promotion)
+if(NOT schema_version EQUAL 1 OR
+   NOT result_kind STREQUAL "copperfin-polyglot-benchmark-result" OR
+   NOT source_commit_length EQUAL 40 OR
+   NOT source_commit MATCHES "^[0-9a-f]+$" OR
+   NOT measurement_count EQUAL 3 OR promotion)
+    message(FATAL_ERROR "Polyglot benchmark result identity or promotion contract is invalid")
+endif()
+
+set(expected_implementations direct-cpp cpp-dotnet-wrapper csharp-service)
+foreach(index RANGE 0 2)
+    list(GET expected_implementations ${index} expected)
+    string(JSON implementation GET "${result_json}" measurements ${index} implementation)
+    string(JSON samples GET "${result_json}" measurements ${index} sample_count)
+    string(JSON failures GET "${result_json}" measurements ${index} failure_count)
+    string(JSON mismatches GET "${result_json}" measurements ${index} parity_mismatch_count)
+    if(NOT implementation STREQUAL expected OR
+       NOT samples EQUAL 9 OR NOT failures EQUAL 0 OR NOT mismatches EQUAL 0)
+        message(FATAL_ERROR "Polyglot benchmark evidence is incomplete for ${expected}")
+    endif()
+endforeach()
+
+message(STATUS "Polyglot benchmark result v1 schema and evidence passed")

--- a/tests/test_bounded_process.cpp
+++ b/tests/test_bounded_process.cpp
@@ -280,8 +280,13 @@ int run_tests(const std::filesystem::path& executable) {
         .cancellation_requested = {}});
     expect(exited.completed() && exited.started && exited.exit_code == 37,
            "#4700: direct invocation should preserve the candidate exit code");
-    expect(exited.peak_memory_kib > 0U,
-           "#4700: a completed child should report peak resident memory");
+#if defined(_WIN32)
+    expect(exited.peak_memory_available && exited.peak_memory_kib > 0U,
+           "#4700: a Windows owned job should report peak resident memory");
+#else
+    expect(!exited.peak_memory_available && exited.peak_memory_kib == 0U,
+           "#4700: POSIX must not expose fork-seeded wait4 memory as child memory");
+#endif
     expect(exited.process_tree_closed && exited.error_code == "polyglot.process.exited",
            "#4700: normal completion should close the owned process tree");
     expect(exited.standard_output.empty() && exited.standard_error.empty(),

--- a/tests/test_bounded_process.cpp
+++ b/tests/test_bounded_process.cpp
@@ -280,6 +280,8 @@ int run_tests(const std::filesystem::path& executable) {
         .cancellation_requested = {}});
     expect(exited.completed() && exited.started && exited.exit_code == 37,
            "#4700: direct invocation should preserve the candidate exit code");
+    expect(exited.peak_memory_kib > 0U,
+           "#4700: a completed child should report peak resident memory");
     expect(exited.process_tree_closed && exited.error_code == "polyglot.process.exited",
            "#4700: normal completion should close the owned process tree");
     expect(exited.standard_output.empty() && exited.standard_error.empty(),

--- a/tests/test_polyglot_benchmark.cpp
+++ b/tests/test_polyglot_benchmark.cpp
@@ -1,0 +1,160 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "copperfin/platform/polyglot_benchmark.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+using namespace copperfin::platform;
+
+void expect(const bool condition, const std::string& message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+PolyglotBenchmarkRequest request() {
+    return {
+        .capability_id = "samples.dotnet.add-v1",
+        .warmup_iterations = 2U,
+        .measured_iterations = 10U,
+        .policy = {
+            .minimum_sample_count = 20U,
+            .maximum_p95_latency_us = 10'000U,
+            .minimum_throughput_per_second = 100U,
+            .maximum_peak_memory_kib = 100'000U,
+            .maximum_p95_startup_ms = 1000U,
+            .maximum_security_profile =
+                PolyglotRouteSecurityProfile::admitted_process,
+            .weights = {25U, 25U, 25U, 25U}},
+        .workloads = {
+            {"positive", R"({"left":20,"right":22})", R"({"sum":42})"},
+            {"negative", R"({"left":-20,"right":-22})", R"({"sum":-42})"}},
+        .routes = {
+            {PolyglotRouteImplementation::direct_cpp,
+             PolyglotRouteSecurityProfile::trusted_native, true, true, true},
+            {PolyglotRouteImplementation::cpp_dotnet_wrapper,
+             PolyglotRouteSecurityProfile::admitted_process, true, true, true},
+            {PolyglotRouteImplementation::csharp_service,
+             PolyglotRouteSecurityProfile::admitted_process, false, true, true}},
+        .invoke = {}};
+}
+
+void test_bounded_aggregation_and_unavailable_route() {
+    auto input = request();
+    std::size_t calls = 0U;
+    input.invoke = [&](const PolyglotBenchmarkInvocation& invocation) {
+        ++calls;
+        const std::uint64_t base =
+            invocation.implementation == PolyglotRouteImplementation::direct_cpp
+            ? 100U : 200U;
+        return PolyglotBenchmarkObservation{
+            true, true, base + invocation.iteration,
+            base * 10U, base / 10U};
+    };
+    const auto result = run_polyglot_benchmark(input);
+    expect(result.ok() && result.impact.recommendation_ready,
+           "valid representative observations should produce an advisory result");
+    expect(calls == 48U,
+           "only available routes should receive fixed warmup and measured calls");
+    expect(result.measurements.size() == 3U &&
+               result.measurements[0].sample_count == 20U &&
+               result.measurements[0].p95_latency_us == 109U &&
+               result.measurements[0].throughput_per_second == 9569U &&
+               result.measurements[0].peak_memory_kib == 1000U &&
+               result.measurements[0].p95_startup_ms == 10U,
+           "aggregation should use nearest-rank p95 and integer throughput");
+    expect(result.measurements[2].runtime_available == false &&
+               result.measurements[2].sample_count == 0U,
+           "an unavailable route should be explicit and must not be fabricated");
+    expect(result.impact.assessments[2].reason_code ==
+               "polyglot.impact.runtime_unavailable",
+           "the evaluator should retain the unavailable-route reason");
+}
+
+void test_failures_and_parity_are_hard_gates() {
+    auto input = request();
+    input.routes[2].runtime_available = true;
+    input.invoke = [](const PolyglotBenchmarkInvocation& invocation) {
+        return PolyglotBenchmarkObservation{
+            invocation.warmup || invocation.implementation !=
+                PolyglotRouteImplementation::cpp_dotnet_wrapper,
+            invocation.warmup || invocation.implementation !=
+                PolyglotRouteImplementation::csharp_service,
+            100U, 1000U, 1U};
+    };
+    const auto result = run_polyglot_benchmark(input);
+    expect(result.ok() && result.impact.preferred ==
+               PolyglotRouteImplementation::direct_cpp,
+           "only a successful parity-matched route should be recommended");
+    expect(result.measurements[1].failure_count == 20U &&
+               result.measurements[2].parity_mismatch_count == 20U,
+           "each measured failed or mismatched observation should be counted");
+}
+
+void test_invalid_inputs_fail_before_callback() {
+    auto input = request();
+    std::size_t calls = 0U;
+    input.invoke = [&](const auto&) {
+        ++calls;
+        return PolyglotBenchmarkObservation{true, true, 1U, 0U, 0U};
+    };
+    input.routes[2].implementation =
+        PolyglotRouteImplementation::direct_cpp;
+    expect(run_polyglot_benchmark(input).error_code ==
+               "polyglot.benchmark.invalid_request" && calls == 0U,
+           "duplicate route classes should fail before invoking work");
+
+    input = request();
+    input.policy.weights.startup = 24U;
+    input.invoke = [&](const auto&) {
+        ++calls;
+        return PolyglotBenchmarkObservation{true, true, 1U, 0U, 0U};
+    };
+    expect(run_polyglot_benchmark(input).error_code ==
+               "polyglot.benchmark.invalid_request" && calls == 0U,
+           "an invalid impact policy should fail before invoking work");
+
+    input = request();
+    input.invoke = [&](const auto&) {
+        ++calls;
+        return PolyglotBenchmarkObservation{true, true, 0U, 0U, 0U};
+    };
+    expect(run_polyglot_benchmark(input).error_code ==
+               "polyglot.benchmark.invalid_observation",
+           "zero-latency or excessive observations should fail closed");
+
+    input = request();
+    input.invoke = [](const auto&) -> PolyglotBenchmarkObservation {
+        throw std::runtime_error("fixture");
+    };
+    expect(run_polyglot_benchmark(input).error_code ==
+               "polyglot.benchmark.invocation_failed",
+           "callback exceptions should not cross the benchmark boundary");
+
+    input = request();
+    input.invoke = [](const auto&) {
+        return PolyglotBenchmarkObservation{false, false, 1U, 0U, 0U};
+    };
+    expect(run_polyglot_benchmark(input).error_code ==
+               "polyglot.benchmark.warmup_failed",
+           "a failed warmup should invalidate the run instead of being hidden");
+}
+
+}  // namespace
+
+int main() {
+    test_bounded_aggregation_and_unavailable_route();
+    test_failures_and_parity_are_hard_gates();
+    test_invalid_inputs_fail_before_callback();
+    std::cout << "polyglot benchmark tests passed\n";
+    return 0;
+}

--- a/tests/test_polyglot_benchmark.cpp
+++ b/tests/test_polyglot_benchmark.cpp
@@ -100,6 +100,24 @@ void test_failures_and_parity_are_hard_gates() {
            "each measured failed or mismatched observation should be counted");
 }
 
+void test_cumulative_latency_uses_the_uint64_bound() {
+    auto input = request();
+    input.warmup_iterations = 0U;
+    input.measured_iterations = 100U;
+    input.workloads.resize(1U);
+    input.routes[1].runtime_available = false;
+    input.invoke = [](const PolyglotBenchmarkInvocation&) {
+        return PolyglotBenchmarkObservation{
+            true, true, 20'000'000'000ULL, 1000U, 1U};
+    };
+    const auto result = run_polyglot_benchmark(input);
+    expect(result.error == PolyglotBenchmarkError::none &&
+               result.measurements[0].sample_count == 100U &&
+               result.measurements[0].p95_latency_us == 20'000'000'000ULL &&
+               result.measurements[0].throughput_per_second == 1U,
+           "valid per-observation latencies may cumulatively exceed the metric ceiling");
+}
+
 void test_invalid_inputs_fail_before_callback() {
     auto input = request();
     std::size_t calls = 0U;
@@ -154,6 +172,7 @@ void test_invalid_inputs_fail_before_callback() {
 int main() {
     test_bounded_aggregation_and_unavailable_route();
     test_failures_and_parity_are_hard_gates();
+    test_cumulative_latency_uses_the_uint64_bound();
     test_invalid_inputs_fail_before_callback();
     std::cout << "polyglot benchmark tests passed\n";
     return 0;

--- a/tests/test_polyglot_dotnet_candidate.cpp
+++ b/tests/test_polyglot_dotnet_candidate.cpp
@@ -152,9 +152,9 @@ std::uint64_t elapsed_microseconds(
     return static_cast<std::uint64_t>(std::max<std::int64_t>(1, value));
 }
 
-std::optional<std::uint64_t> parse_self_reported_peak_memory(
+std::optional<std::uint64_t> parse_self_reported_working_set(
     const std::string_view document) {
-    constexpr std::string_view prefix = "COPPERFIN_PEAK_MEMORY_KIB=";
+    constexpr std::string_view prefix = "COPPERFIN_WORKING_SET_KIB=";
     if (!document.starts_with(prefix) || document.size() <= prefix.size() + 1U ||
         document.back() != '\n') {
         return std::nullopt;
@@ -214,15 +214,15 @@ void test_representative_benchmark(
         if (invocation.implementation ==
             PolyglotRouteImplementation::cpp_dotnet_wrapper) {
             const auto result = invoke_polyglot_artifact(admission, candidate);
-            const auto peak_memory = parse_self_reported_peak_memory(
+            const auto working_set = parse_self_reported_working_set(
                 result.process.standard_error);
             return PolyglotBenchmarkObservation{
-                result.ok() && peak_memory.has_value(),
-                result.ok() && peak_memory.has_value() &&
+                result.ok() && working_set.has_value(),
+                result.ok() && working_set.has_value() &&
                     result.response.envelope.payload_json ==
                     invocation.workload->expected_payload_json,
                 elapsed_microseconds(started),
-                peak_memory.value_or(0U),
+                working_set.value_or(0U),
                 result.process.elapsed_ms};
         }
 
@@ -250,15 +250,15 @@ void test_representative_benchmark(
              protocol_version, 64U * 1024U, 32U});
         const bool succeeded = process.completed() && process.exit_code == 0 &&
             process.process_tree_closed && parsed.ok();
-        const auto peak_memory = parse_self_reported_peak_memory(
+        const auto working_set = parse_self_reported_working_set(
             process.standard_error);
         return PolyglotBenchmarkObservation{
-            succeeded && peak_memory.has_value(),
-            succeeded && peak_memory.has_value() &&
+            succeeded && working_set.has_value(),
+            succeeded && working_set.has_value() &&
                 parsed.envelope.payload_json ==
                 invocation.workload->expected_payload_json,
             elapsed_microseconds(started),
-            peak_memory.value_or(0U),
+            working_set.value_or(0U),
             process.elapsed_ms};
     };
 

--- a/tests/test_polyglot_dotnet_candidate.cpp
+++ b/tests/test_polyglot_dotnet_candidate.cpp
@@ -16,6 +16,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -171,6 +172,39 @@ std::optional<std::uint64_t> parse_self_reported_working_set(
     return value;
 }
 
+std::optional<std::string> execute_direct_cpp_add(
+    const std::string_view arguments_json) {
+    constexpr std::string_view left_prefix = R"({"left":)";
+    constexpr std::string_view right_prefix = R"(,"right":)";
+    if (!arguments_json.starts_with(left_prefix)) {
+        return std::nullopt;
+    }
+
+    std::int64_t left = 0;
+    const char* const left_begin = arguments_json.data() + left_prefix.size();
+    const char* const end = arguments_json.data() + arguments_json.size();
+    const auto left_parsed = std::from_chars(left_begin, end, left);
+    if (left_parsed.ec != std::errc{} ||
+        static_cast<std::size_t>(end - left_parsed.ptr) <
+            right_prefix.size() + 2U ||
+        std::string_view(left_parsed.ptr, right_prefix.size()) != right_prefix) {
+        return std::nullopt;
+    }
+
+    std::int64_t right = 0;
+    const char* const right_begin = left_parsed.ptr + right_prefix.size();
+    const auto right_parsed = std::from_chars(right_begin, end, right);
+    if (right_parsed.ec != std::errc{} || right_parsed.ptr == end ||
+        right_parsed.ptr + 1 != end || *right_parsed.ptr != '}') {
+        return std::nullopt;
+    }
+    if ((right > 0 && left > std::numeric_limits<std::int64_t>::max() - right) ||
+        (right < 0 && left < std::numeric_limits<std::int64_t>::min() - right)) {
+        return std::nullopt;
+    }
+    return std::string(R"({"sum":)") + std::to_string(left + right) + '}';
+}
+
 void test_representative_benchmark(
     PolyglotArtifactAdmissionResult& admission,
     const PublishedCandidate& published) {
@@ -200,12 +234,19 @@ void test_representative_benchmark(
              PolyglotRouteSecurityProfile::admitted_process, true, true, true}},
         .invoke = {}};
 
+    std::size_t direct_cpp_invocations = 0U;
     request.invoke = [&](const PolyglotBenchmarkInvocation& invocation) {
         const auto started = std::chrono::steady_clock::now();
         if (invocation.implementation ==
             PolyglotRouteImplementation::direct_cpp) {
+            ++direct_cpp_invocations;
+            const auto payload = execute_direct_cpp_add(
+                invocation.workload->arguments_json);
             return PolyglotBenchmarkObservation{
-                true, true, elapsed_microseconds(started), 0U, 0U};
+                payload.has_value(),
+                payload.has_value() &&
+                    *payload == invocation.workload->expected_payload_json,
+                elapsed_microseconds(started), 0U, 0U};
         }
 
         auto candidate = candidate_request(invocation);
@@ -267,6 +308,8 @@ void test_representative_benchmark(
                  "representative native/.NET measurements should be advisory-ready");
     expect_local(result.measurements.size() == 3U,
                  "the representative benchmark should retain all route layers");
+    expect_local(direct_cpp_invocations == 12U,
+                 "direct C++ must execute all three warmups and nine measurements");
     for (const auto& measurement : result.measurements) {
         expect_local(
             measurement.sample_count == 9U &&

--- a/tests/test_polyglot_dotnet_candidate.cpp
+++ b/tests/test_polyglot_dotnet_candidate.cpp
@@ -4,11 +4,14 @@
 
 #include "copperfin/platform/bounded_process.h"
 #include "copperfin/platform/executable_path.h"
+#include "copperfin/platform/polyglot_benchmark.h"
 #include "copperfin/runtime/polyglot_runtime_host.h"
 #include "copperfin/security/sha256.h"
 #include "prg_engine_test_support.h"
 
+#include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -112,6 +115,185 @@ PolyglotRuntimeHostConfiguration configuration(
         .normalize_shadow_parity = {},
         .parity_policy = {}};
     return {std::move(routes.registry), {std::move(binding)}};
+}
+
+PolyglotArtifactInvocationRequest candidate_request(
+    const PolyglotBenchmarkInvocation& invocation) {
+    PolyglotArtifactInvocationRequest request;
+    request.invocation = {
+        .capability_id = capability_id,
+        .correlation_id = std::string("benchmark-") +
+            invocation.workload->workload_id + "-" +
+            polyglot_route_implementation_name(invocation.implementation) + "-" +
+            std::to_string(invocation.iteration) +
+            (invocation.warmup ? "-warmup" : "-measured"),
+        .protocol_version = protocol_version,
+        .arguments_json = invocation.workload->arguments_json};
+    request.policy = {
+        .timeout_ms = 5000U,
+        .latency_budget_ms = 5000U,
+        .cancellation = PolyglotCancellationPolicy::propagate,
+        .fallback = PolyglotFallbackPolicy::fail_fast,
+        .max_attempts = 1U};
+    request.poll_interval_ms = 1U;
+    request.stdin_limit_bytes = 64U * 1024U;
+    request.stdout_limit_bytes = 64U * 1024U;
+    request.stderr_limit_bytes = 4U * 1024U;
+    return request;
+}
+
+std::uint64_t elapsed_microseconds(
+    const std::chrono::steady_clock::time_point started) {
+    const auto value = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - started).count();
+    return static_cast<std::uint64_t>(std::max<std::int64_t>(1, value));
+}
+
+void test_representative_benchmark(
+    PolyglotArtifactAdmissionResult& admission,
+    const PublishedCandidate& published) {
+    PolyglotBenchmarkRequest request{
+        .capability_id = capability_id,
+        .warmup_iterations = 1U,
+        .measured_iterations = 3U,
+        .policy = {
+            .minimum_sample_count = 9U,
+            .maximum_p95_latency_us = 5'000'000U,
+            .minimum_throughput_per_second = 1U,
+            .maximum_peak_memory_kib = 1'048'576U,
+            .maximum_p95_startup_ms = 5000U,
+            .maximum_security_profile =
+                PolyglotRouteSecurityProfile::admitted_process,
+            .weights = {25U, 25U, 25U, 25U}},
+        .workloads = {
+            {"positive", R"({"left":20,"right":22})", R"({"sum":42})"},
+            {"negative", R"({"left":-20,"right":-22})", R"({"sum":-42})"},
+            {"zero", R"({"left":0,"right":0})", R"({"sum":0})"}},
+        .routes = {
+            {PolyglotRouteImplementation::direct_cpp,
+             PolyglotRouteSecurityProfile::trusted_native, true, true, true},
+            {PolyglotRouteImplementation::cpp_dotnet_wrapper,
+             PolyglotRouteSecurityProfile::admitted_process, true, true, true},
+            {PolyglotRouteImplementation::csharp_service,
+             PolyglotRouteSecurityProfile::admitted_process, true, true, true}},
+        .invoke = {}};
+
+    request.invoke = [&](const PolyglotBenchmarkInvocation& invocation) {
+        const auto started = std::chrono::steady_clock::now();
+        if (invocation.implementation ==
+            PolyglotRouteImplementation::direct_cpp) {
+            return PolyglotBenchmarkObservation{
+                true, true, elapsed_microseconds(started), 0U, 0U};
+        }
+
+        auto candidate = candidate_request(invocation);
+        candidate.working_directory = utf8_path(published.root);
+        if (invocation.implementation ==
+            PolyglotRouteImplementation::cpp_dotnet_wrapper) {
+            const auto result = invoke_polyglot_artifact(admission, candidate);
+            return PolyglotBenchmarkObservation{
+                result.ok(),
+                result.ok() && result.response.envelope.payload_json ==
+                    invocation.workload->expected_payload_json,
+                elapsed_microseconds(started),
+                result.process.peak_memory_kib,
+                result.process.elapsed_ms};
+        }
+
+        const auto serialized = serialize_polyglot_invocation_request(
+            candidate.invocation);
+        if (!serialized.ok()) {
+            return PolyglotBenchmarkObservation{
+                false, false, elapsed_microseconds(started), 0U, 0U};
+        }
+        const auto process = run_bounded_process({
+            .executable_path = utf8_path(published.executable),
+            .arguments = {},
+            .working_directory = utf8_path(published.root),
+            .environment = {},
+            .standard_input = serialized.document,
+            .timeout_ms = 5000U,
+            .poll_interval_ms = 1U,
+            .stdin_limit_bytes = 64U * 1024U,
+            .stdout_limit_bytes = 64U * 1024U,
+            .stderr_limit_bytes = 4U * 1024U,
+            .cancellation_requested = {}});
+        const auto parsed = parse_polyglot_interop_envelope(
+            process.standard_output,
+            {capability_id, candidate.invocation.correlation_id,
+             protocol_version, 64U * 1024U, 32U});
+        const bool succeeded = process.completed() && process.exit_code == 0 &&
+            process.process_tree_closed && parsed.ok();
+        return PolyglotBenchmarkObservation{
+            succeeded,
+            succeeded && parsed.envelope.payload_json ==
+                invocation.workload->expected_payload_json,
+            elapsed_microseconds(started),
+            process.peak_memory_kib,
+            process.elapsed_ms};
+    };
+
+    const auto result = run_polyglot_benchmark(request);
+    expect_local(result.ok() && result.impact.recommendation_ready,
+                 "representative native/.NET measurements should be advisory-ready");
+    expect_local(result.measurements.size() == 3U,
+                 "the representative benchmark should retain all route layers");
+    for (const auto& measurement : result.measurements) {
+        expect_local(
+            measurement.sample_count == 9U &&
+                measurement.failure_count == 0U &&
+                measurement.parity_mismatch_count == 0U &&
+                measurement.p95_latency_us > 0U &&
+                measurement.throughput_per_second > 0U,
+            std::string("representative evidence should be complete for ") +
+                polyglot_route_implementation_name(measurement.implementation));
+        if (measurement.implementation !=
+            PolyglotRouteImplementation::direct_cpp) {
+            expect_local(
+                measurement.peak_memory_kib > 0U,
+                "each external process layer should report peak resident memory");
+        }
+    }
+    std::cout << "COPPERFIN_POLYGLOT_BENCHMARK_V1={\"capability_id\":\""
+              << capability_id
+              << "\",\"warmup_iterations\":1,\"measured_iterations\":3,"
+                 "\"workload_count\":3,\"measurements\":[";
+    for (std::size_t index = 0U; index < result.measurements.size(); ++index) {
+        const auto& measurement = result.measurements[index];
+        if (index != 0U) {
+            std::cout << ',';
+        }
+        std::cout << "{\"implementation\":\""
+                  << polyglot_route_implementation_name(measurement.implementation)
+                  << "\",\"security_profile\":\""
+                  << polyglot_route_security_profile_name(measurement.security_profile)
+                  << "\",\"sample_count\":" << measurement.sample_count
+                  << ",\"failure_count\":" << measurement.failure_count
+                  << ",\"parity_mismatch_count\":"
+                  << measurement.parity_mismatch_count
+                  << ",\"p95_latency_us\":" << measurement.p95_latency_us
+                  << ",\"throughput_per_second\":"
+                  << measurement.throughput_per_second
+                  << ",\"peak_memory_kib\":" << measurement.peak_memory_kib
+                  << ",\"p95_startup_ms\":" << measurement.p95_startup_ms
+                  << '}';
+    }
+    std::cout << "],\"recommendation_ready\":"
+              << (result.impact.recommendation_ready ? "true" : "false")
+              << ",\"preferred\":\""
+              << polyglot_route_implementation_name(result.impact.preferred)
+              << "\",\"fallback_chain\":[";
+    for (std::size_t index = 0U;
+         index < result.impact.fallback_chain.size(); ++index) {
+        if (index != 0U) {
+            std::cout << ',';
+        }
+        std::cout << '\"'
+                  << polyglot_route_implementation_name(
+                         result.impact.fallback_chain[index])
+                  << '\"';
+    }
+    std::cout << "]}\n";
 }
 
 void test_publish_is_one_runtime_artifact(
@@ -249,9 +431,10 @@ int main() {
     if (!error) {
         test_publish_is_one_runtime_artifact(published);
         test_candidate_rejects_wrong_identity(published);
-        const auto admission = admit_candidate(published);
+        auto admission = admit_candidate(published);
         expect_local(admission.ok(), "the exact Native AOT candidate should be admitted");
         if (admission.ok()) {
+            test_representative_benchmark(admission, published);
             test_runtime_host_and_prg_dispatch(
                 admission, published, fixture_root);
         }

--- a/tests/test_polyglot_dotnet_candidate.cpp
+++ b/tests/test_polyglot_dotnet_candidate.cpp
@@ -10,12 +10,15 @@
 #include "prg_engine_test_support.h"
 
 #include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #if defined(_WIN32)
@@ -149,6 +152,25 @@ std::uint64_t elapsed_microseconds(
     return static_cast<std::uint64_t>(std::max<std::int64_t>(1, value));
 }
 
+std::optional<std::uint64_t> parse_self_reported_peak_memory(
+    const std::string_view document) {
+    constexpr std::string_view prefix = "COPPERFIN_PEAK_MEMORY_KIB=";
+    if (!document.starts_with(prefix) || document.size() <= prefix.size() + 1U ||
+        document.back() != '\n') {
+        return std::nullopt;
+    }
+    const std::string_view digits = document.substr(
+        prefix.size(), document.size() - prefix.size() - 1U);
+    std::uint64_t value = 0U;
+    const auto parsed = std::from_chars(
+        digits.data(), digits.data() + digits.size(), value);
+    if (parsed.ec != std::errc{} || parsed.ptr != digits.data() + digits.size() ||
+        value == 0U) {
+        return std::nullopt;
+    }
+    return value;
+}
+
 void test_representative_benchmark(
     PolyglotArtifactAdmissionResult& admission,
     const PublishedCandidate& published) {
@@ -188,15 +210,19 @@ void test_representative_benchmark(
 
         auto candidate = candidate_request(invocation);
         candidate.working_directory = utf8_path(published.root);
+        candidate.environment = {{"COPPERFIN_BENCHMARK_SELF_METRICS", "1"}};
         if (invocation.implementation ==
             PolyglotRouteImplementation::cpp_dotnet_wrapper) {
             const auto result = invoke_polyglot_artifact(admission, candidate);
+            const auto peak_memory = parse_self_reported_peak_memory(
+                result.process.standard_error);
             return PolyglotBenchmarkObservation{
-                result.ok(),
-                result.ok() && result.response.envelope.payload_json ==
+                result.ok() && peak_memory.has_value(),
+                result.ok() && peak_memory.has_value() &&
+                    result.response.envelope.payload_json ==
                     invocation.workload->expected_payload_json,
                 elapsed_microseconds(started),
-                result.process.peak_memory_kib,
+                peak_memory.value_or(0U),
                 result.process.elapsed_ms};
         }
 
@@ -210,7 +236,7 @@ void test_representative_benchmark(
             .executable_path = utf8_path(published.executable),
             .arguments = {},
             .working_directory = utf8_path(published.root),
-            .environment = {},
+            .environment = candidate.environment,
             .standard_input = serialized.document,
             .timeout_ms = 5000U,
             .poll_interval_ms = 1U,
@@ -224,12 +250,15 @@ void test_representative_benchmark(
              protocol_version, 64U * 1024U, 32U});
         const bool succeeded = process.completed() && process.exit_code == 0 &&
             process.process_tree_closed && parsed.ok();
+        const auto peak_memory = parse_self_reported_peak_memory(
+            process.standard_error);
         return PolyglotBenchmarkObservation{
-            succeeded,
-            succeeded && parsed.envelope.payload_json ==
+            succeeded && peak_memory.has_value(),
+            succeeded && peak_memory.has_value() &&
+                parsed.envelope.payload_json ==
                 invocation.workload->expected_payload_json,
             elapsed_microseconds(started),
-            process.peak_memory_kib,
+            peak_memory.value_or(0U),
             process.elapsed_ms};
     };
 


### PR DESCRIPTION
## What changed

- add a bounded callback-driven benchmark runner for direct C++, the admitted C++/.NET wrapper, and the local Native AOT endpoint boundary
- aggregate nearest-rank p95 latency/startup, integer throughput, maximum observed memory, failures, and exact payload parity
- expose reliable Windows owned-Job peak memory with an availability bit; generic POSIX bounded-process results explicitly report memory unavailable instead of publishing fork-seeded `wait4()` rusage
- let the controlled Native AOT benchmark candidate opt in to a strict self-reported cross-platform `Environment.WorkingSet` metric, with per-measurement provenance in the v1 JSON contract
- exercise positive, negative, and zero add workloads through all three real layers
- add a versioned result schema, exact-source Linux evidence document, contract check, isolation classification, and operator documentation
- correct cumulative-latency accumulation to guard the actual `uint64_t` boundary rather than applying the per-observation ceiling to the running total
- execute the direct C++ signed-add workload and compare its produced payload instead of timing an empty callback
- close and require the complete policy/weights shape in the versioned evidence schema

## Why

The advisory route-impact evaluator already ranked supplied measurements but lacked a repeatable representative workload runner and checked-in direct evidence. This closes that evidence gap without granting the benchmark any registry or traffic-promotion authority.

Independent review reproduced two validity defects in the first draft: POSIX child rusage could contain the launcher's pre-`exec` resident high-water mark, and valid observations could be rejected once cumulative latency exceeded the per-observation ceiling. Both now have load-bearing regressions. Final automated review then found that the direct-C++ fixture was an empty timing callback and that the schema left policy unconstrained; the direct route now strictly parses, executes, serializes, and parity-checks the workload, and the contract requires the closed policy/weights shape. A macOS PR run then proved `Process.PeakWorkingSet64` was not portable for this Native AOT target, so the controlled candidate now reports the cross-platform current working set and aggregation retains the maximum observed value without claiming an OS lifetime peak.

## Safety and limitations

- unavailable routes are recorded explicitly and never receive invented timings
- invalid policy, malformed observations, callback exceptions, warmup failures, measured failures, and parity mismatches fail closed or hard-gate the route
- the `csharp-service` sample is explicitly a local one-request endpoint boundary, not a claim that a persistent or remote service exists
- the checked-in timings are one Linux x86_64 observation and are not generalized across hosts
- external memory is the maximum observed candidate self-report; direct C++ records route-specific additional memory, and neither is described as total host RSS
- recommendations remain advisory; automatic promotion is fixed false

## Validation

- GCC 15 Release: focused benchmark, route-impact, bounded-process, Native AOT integration, result-contract, and native isolation tests pass
- Clang 21 ASan/UBSan with leak detection: benchmark, route-impact, bounded-process, and real Native AOT integration tests pass
- exact signed implementation commit `48930b970b14164308aee8fd035148925b2ae74b`: 27 measured route executions, zero failures, zero parity mismatches; all 12 direct C++ warmup/measured invocations executed
- signed evidence head `b97439cbc` is DCO compliant
- GCC integration plus evidence contract: 2/2 pass
- Clang 21 ASan/UBSan with leak detection: real Native AOT integration passes with no findings
- all eleven protected PR checks pass at signed head `b97439cbcf5315c629de0a1879483ff10a0edec6`
- exact-head Linux native: 340/340 pass
- exact-head macOS native: 340/340 pass, plus four locale runs × 2/2
- exact-head Windows native: 339/339 pass
- independent corrected-head review rebuilt the real candidate, proved the direct parity guard load-bearing with a deliberately wrong-result mutation, restored it, and reran Release plus Clang ASan/UBSan/leak checks clean
