### PR TITLE
Synchronize polyglot roadmap evidence

### DIFF
--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -482,7 +482,7 @@ excluded from the compliance map above:
 | 12 | VFP Asset Editing And Execution | Partial | xAsset execution is first-pass, bounded by language-surface coverage |
 | 13 | Index Format Notes | Partial | No index write fidelity; collation hints are heuristic, not named |
 | 18 | Native Security And RBAC | Partial (real baseline) | Not yet verified against docs/04's fuller vision |
-| 19 | Polyglot And AI Subprojects | Partial (portable artifact boundary, route executor, trusted host composition, PRG seam, first Native AOT C# target, and advisory measured-route strategy) | No representative benchmark-result set or general CLR/Python/R runtime hook; AI/MCP policy has little to govern yet |
+| 19 | Polyglot And AI Subprojects | Partial (portable artifact boundary, route executor, trusted host composition, PRG seam, first Native AOT C# target, advisory measured-route strategy, and versioned representative benchmark evidence) | No general CLR/Python/R runtime hook; AI/MCP policy has little to govern yet |
 | 20 | Runtime Build And Debug Pipeline | Partial | Engine is PRG-first, not the full command surface |
 | 21 | Database Federation And Query Translation | Partial (real seed) | No live connector execution behind the translator/planner |
 | 22 | VFP Language Reference Coverage | Partial, measured | 1,411 documented items; official surface exceeds current runtime |

--- a/docs/diagrams/roadmap-v1-lanes-hij.md
+++ b/docs/diagrams/roadmap-v1-lanes-hij.md
@@ -25,7 +25,7 @@ flowchart TB
         direction LR
         H1["H1 Deterministic Relational<br/>Backend Translators<br/>root #30 - SEEDED:<br/>see docs/21, cf_platform_profile"]
         H2["H2 Document/Vector Backend<br/>+ AI-Assisted Planning<br/>root #31"]
-        H3["H3 .NET Outputs, MCP/AI<br/>Hooks, Python/R Sidecars<br/>root #32 - SEEDED:<br/>admitted Native AOT leaf<br/>+ advisory route impact"]
+        H3["H3 .NET Outputs, MCP/AI<br/>Hooks, Python/R Sidecars<br/>root #32 - SEEDED:<br/>admitted Native AOT leaf<br/>+ benchmarked route impact"]
         H1 --> H2 --> H3
       end
 
@@ -68,13 +68,14 @@ flowchart TB
     class V1,LANEH,LANEI,LANEJ lane;
 ```
 
-**What's done:** `H1`'s relational backend translators, `H3`'s admitted Native
-AOT leaf and advisory measured-route strategy, and `I1`'s security baseline
-have real seeds — `cf_platform_profile`'s deterministic Fox-SQL
+**What's done:** `H1` has relational backend translators; `H3` has an admitted
+Native AOT leaf, advisory measured-route strategy, and versioned representative
+benchmark evidence; and `I1` has a security baseline. These real seeds are
+`cf_platform_profile`'s deterministic Fox-SQL
 translator/execution-planning lane, the trusted polyglot host and route-impact
 boundary, and `cf_security`'s RBAC/audit/secrets/signing baseline, respectively.
-`H3` still lacks its representative benchmark-result evidence and broader
-language/AI adapters. **What's left, and what it takes:** this is
+`H3` still lacks its broader language/AI adapters. **What's left, and what it
+takes:** this is
 covered in full, document-by-document, in
 [31-specification-compliance-gap-analysis.md](../31-specification-compliance-gap-analysis.md) —
 in particular its interop/federation/trust/security and language/data-fidelity


### PR DESCRIPTION
## What changed

- record the merged versioned representative polyglot benchmark evidence in the specification gap table
- update the v1 H3 roadmap node from advisory-only route impact to benchmarked route impact
- remove the now-false statement that H3 lacks representative benchmark-result evidence
- retain the actual remaining gap: broader CLR/Python/R and AI/MCP adapters

## Validation

- `git diff --check`
- active Markdown search finds no remaining claim that representative benchmark evidence is missing
- signed, DCO-compliant commit `f6e5469a9`

Documentation-only status synchronization after merged PR #4947; no product or contract behavior changes.