### PR TITLE
Preserve Windows path comparison rationale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 - 2026-08-11: Restored the review-identified rationale for the layered Windows
   Unicode path-component comparison APIs after their move behind the portable
   public boundary. The original comments explain the invariant-locale
-  fallbacks and `CharLowerBuffW`'s ambiguous zero result; a source contract now
-  prevents those load-bearing explanations from being silently discarded.
-  Executable behavior is unchanged. Final pre-follow-up evidence head
+  fallbacks and accurately identifies `CharLowerBuffW`'s zero return as
+  failure; a source contract now prevents those load-bearing explanations from
+  being silently discarded. Review also found unchecked narrowing into Win32
+  signed length parameters, so unrepresentable component lengths now fail
+  closed. Representable path behavior is unchanged. Final pre-follow-up evidence head
   `e0fbdd11c` passed all eleven protected checks, including Generated Launcher
   Validation `31542720317` on Windows, Ubuntu, and macOS and Windows
   Environment and Executable Path Validation `31542720276`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@
   closed. Representable path behavior is unchanged. Final pre-follow-up evidence head
   `e0fbdd11c` passed all eleven protected checks, including Generated Launcher
   Validation `31542720317` on Windows, Ubuntu, and macOS and Windows
-  Environment and Executable Path Validation `31542720276`.
+  Environment and Executable Path Validation `31542720276`. Corrected
+  implementation head `e35830c30` passes all eleven protected checks;
+  Generated Launcher Validation `31545471149` runs the path contracts on all
+  three hosts, and Windows Environment and Executable Path Validation
+  `31545471092` repeats them. Independent review passes and independently
+  mutation-proves the length guard, with direct Win32 execution supplied by
+  the hosted Windows jobs.
 
 - 2026-08-11: Seeded v1 portability lane J1 with an explicit public path
   boundary. The widely consumed `copperfin/platform/path.h` interface now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+- 2026-08-11: Restored the review-identified rationale for the layered Windows
+  Unicode path-component comparison APIs after their move behind the portable
+  public boundary. The original comments explain the invariant-locale
+  fallbacks and `CharLowerBuffW`'s ambiguous zero result; a source contract now
+  prevents those load-bearing explanations from being silently discarded.
+  Executable behavior is unchanged. Final pre-follow-up evidence head
+  `e0fbdd11c` passed all eleven protected checks, including Generated Launcher
+  Validation `31542720317` on Windows, Ubuntu, and macOS and Windows
+  Environment and Executable Path Validation `31542720276`.
+
 - 2026-08-11: Seeded v1 portability lane J1 with an explicit public path
   boundary. The widely consumed `copperfin/platform/path.h` interface now
   contains only standard C++ declarations; Windows SDK inclusion and all

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -27,8 +27,11 @@ native-boundary inventory and the J2/J3 ports remain open. See
 Independent review found no functional defect and mechanically confirmed the
 moved implementations, then identified one maintainability gap: the move had
 dropped the rationale for the layered Windows Unicode comparison fallbacks.
-That original rationale is restored without a behavior change, and the source
-contract now protects its key explanations. Final pre-follow-up evidence head
+That original rationale is restored, with its inherited `CharLowerBuffW`
+statement corrected to identify zero as failure. Review also found unchecked
+narrowing into Win32 signed length parameters; unrepresentable component
+lengths now fail closed, while representable behavior is unchanged. The source
+contract protects the length guard and key explanations. Final pre-follow-up evidence head
 `e0fbdd11c` passed all eleven protected checks; Generated Launcher Validation
 `31542720317` ran both path tests on Windows, Ubuntu, and macOS, while Windows
 Environment and Executable Path Validation `31542720276` repeated them in its

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -24,6 +24,16 @@ is corrected and contract-protected. This seeds J1 only; broader
 native-boundary inventory and the J2/J3 ports remain open. See
 `docs/50-portable-public-path-boundary.md`.
 
+Independent review found no functional defect and mechanically confirmed the
+moved implementations, then identified one maintainability gap: the move had
+dropped the rationale for the layered Windows Unicode comparison fallbacks.
+That original rationale is restored without a behavior change, and the source
+contract now protects its key explanations. Final pre-follow-up evidence head
+`e0fbdd11c` passed all eleven protected checks; Generated Launcher Validation
+`31542720317` ran both path tests on Windows, Ubuntu, and macOS, while Windows
+Environment and Executable Path Validation `31542720276` repeated them in its
+focused set.
+
 ## V1 read-only SQLite federation execution
 
 The current H1 increment connects the deterministic SQLite translator/planner

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -37,6 +37,14 @@ contract protects the length guard and key explanations. Final pre-follow-up evi
 Environment and Executable Path Validation `31542720276` repeated them in its
 focused set.
 
+Corrected implementation head `e35830c30` passes all eleven protected checks.
+Generated Launcher Validation `31545471149` runs the path runtime and boundary
+contracts on Windows, Ubuntu, and macOS; Windows Environment and Executable
+Path Validation `31545471092` repeats them. Independent review passes and
+independently mutation-proves the length guard. The reviewer read-verified the
+Win32 API correction from Linux; the hosted Windows jobs provide direct
+build-and-execution evidence.
+
 ## V1 read-only SQLite federation execution
 
 The current H1 increment connects the deterministic SQLite translator/planner

--- a/docs/50-portable-public-path-boundary.md
+++ b/docs/50-portable-public-path-boundary.md
@@ -51,6 +51,16 @@ preserved `CharLowerBuffW` fallback's User32 dependency had remained implicit
 through CMake's default Windows libraries; the corrected head declares that
 dependency on `cf_platform_support`, and the source contract protects it.
 
+Final evidence head `e0fbdd11c` passes all eleven protected checks. Generated
+Launcher Validation run `31542720317` runs both path contracts on Windows,
+Ubuntu, and macOS, and Windows Environment and Executable Path Validation run
+`31542720276` repeats them inside its `9/9` focused set. Independent review
+found no functional defect, but did identify that the move had dropped the
+hard-won rationale for the layered Windows Unicode comparison fallbacks. The
+original rationale is restored without changing code behavior, and the source
+contract now protects the key explanations alongside the implementation and
+explicit User32 link dependency.
+
 ## Remaining J1 work
 
 This boundary is a seed, not a blanket portability claim. Later independently

--- a/docs/50-portable-public-path-boundary.md
+++ b/docs/50-portable-public-path-boundary.md
@@ -57,9 +57,12 @@ Ubuntu, and macOS, and Windows Environment and Executable Path Validation run
 `31542720276` repeats them inside its `9/9` focused set. Independent review
 found no functional defect, but did identify that the move had dropped the
 hard-won rationale for the layered Windows Unicode comparison fallbacks. The
-original rationale is restored without changing code behavior, and the source
-contract now protects the key explanations alongside the implementation and
-explicit User32 link dependency.
+original rationale is restored, with one inherited statement corrected to
+match the `CharLowerBuffW` failure contract. Review also identified unchecked
+narrowing into Win32's signed length type; unrepresentable component lengths
+now fail closed instead of reaching the comparison APIs. The source contract
+protects the length guard and key explanations alongside the implementation
+and explicit User32 link dependency. Representable path behavior is unchanged.
 
 ## Remaining J1 work
 

--- a/docs/50-portable-public-path-boundary.md
+++ b/docs/50-portable-public-path-boundary.md
@@ -64,6 +64,16 @@ now fail closed instead of reaching the comparison APIs. The source contract
 protects the length guard and key explanations alongside the implementation
 and explicit User32 link dependency. Representable path behavior is unchanged.
 
+Corrected implementation head `e35830c30` passes all eleven protected checks.
+Generated Launcher Validation run `31545471149` builds and runs the path
+runtime and boundary contracts on Windows, Ubuntu, and macOS; Windows
+Environment and Executable Path Validation run `31545471092` repeats them in
+its focused set. Independent review at that exact head passes, independently
+mutation-proves the length guard, and confirms the documentation scope. Its
+disclosed limitation is that the corrected Win32 branch was read-verified
+against the API contract rather than executed on the reviewer's Linux host;
+the hosted Windows jobs provide the direct build-and-execution evidence.
+
 ## Remaining J1 work
 
 This boundary is a seed, not a blanket portability claim. Later independently

--- a/src/platform/path.cpp
+++ b/src/platform/path.cpp
@@ -78,6 +78,11 @@ bool path_component_equal_for_platform(
 #if defined(_WIN32)
     const std::wstring left_value = left.native();
     const std::wstring right_value = right.native();
+    const auto maximum_api_length =
+        static_cast<std::size_t>((std::numeric_limits<int>::max)());
+    if (left_value.size() > maximum_api_length || right_value.size() > maximum_api_length) {
+        return false;
+    }
     if (::CompareStringOrdinal(
             left_value.c_str(), static_cast<int>(left_value.size()),
             right_value.c_str(), static_cast<int>(right_value.size()), TRUE) == CSTR_EQUAL) {
@@ -128,10 +133,12 @@ bool path_component_equal_for_platform(
         }
 
         std::wstring fallback = value;
-        // CharLowerBuffW returns zero when the buffer needs no changes as
-        // well as when the call cannot process the buffer. The unchanged
-        // value is still a valid case-folding result.
-        (void)::CharLowerBuffW(fallback.data(), static_cast<DWORD>(fallback.size()));
+        // CharLowerBuffW reports zero on failure. Returning the unchanged
+        // input makes a mapping failure conservative rather than treating
+        // unconverted text as a successful fold.
+        if (::CharLowerBuffW(fallback.data(), static_cast<DWORD>(fallback.size())) == 0) {
+            return value;
+        }
         return fallback;
     };
     return invariant_lowercase(left_value) == invariant_lowercase(right_value);

--- a/src/platform/path.cpp
+++ b/src/platform/path.cpp
@@ -83,12 +83,21 @@ bool path_component_equal_for_platform(
             right_value.c_str(), static_cast<int>(right_value.size()), TRUE) == CSTR_EQUAL) {
         return true;
     }
+
+    // Retain the older invariant-locale entry point for Windows environments
+    // where the ordinal and extended comparison APIs do not share the same
+    // Unicode case table.
     if (::CompareStringW(
             LOCALE_INVARIANT, NORM_IGNORECASE,
             left_value.c_str(), static_cast<int>(left_value.size()),
             right_value.c_str(), static_cast<int>(right_value.size())) == CSTR_EQUAL) {
         return true;
     }
+
+    // Some Windows builds do not apply the complete Unicode simple-case
+    // table through CompareStringOrdinal. The invariant locale comparison
+    // supplies the Windows filesystem's case-insensitive behavior for those
+    // code points without consulting the user's active locale.
     if (::CompareStringEx(
             LOCALE_NAME_INVARIANT, NORM_IGNORECASE,
             left_value.c_str(), static_cast<int>(left_value.size()),
@@ -97,6 +106,9 @@ bool path_component_equal_for_platform(
         return true;
     }
 
+    // Some supported Windows environments do not provide complete Unicode
+    // simple-case behavior through CompareStringOrdinal alone. Prefer the
+    // invariant mapping API, with a native fallback when it is unavailable.
     const auto invariant_lowercase = [](const std::wstring& value) {
         if (value.empty()) {
             return std::wstring{};
@@ -116,6 +128,9 @@ bool path_component_equal_for_platform(
         }
 
         std::wstring fallback = value;
+        // CharLowerBuffW returns zero when the buffer needs no changes as
+        // well as when the call cannot process the buffer. The unchanged
+        // value is still a valid case-folding result.
         (void)::CharLowerBuffW(fallback.data(), static_cast<DWORD>(fallback.size()));
         return fallback;
     };

--- a/tests/run_platform_path_boundary_contract_check.cmake
+++ b/tests/run_platform_path_boundary_contract_check.cmake
@@ -39,7 +39,10 @@ foreach(required IN ITEMS
         "#include <windows.h>"
         "path_to_utf8_string"
         "path_from_utf8_string"
-        "path_component_equal_for_platform")
+        "path_component_equal_for_platform"
+        "Unicode case table"
+        "Windows filesystem's case-insensitive behavior"
+        "CharLowerBuffW returns zero")
     string(FIND "${source_text}" "${required}" offset)
     if(offset EQUAL -1)
         message(FATAL_ERROR

--- a/tests/run_platform_path_boundary_contract_check.cmake
+++ b/tests/run_platform_path_boundary_contract_check.cmake
@@ -40,9 +40,11 @@ foreach(required IN ITEMS
         "path_to_utf8_string"
         "path_from_utf8_string"
         "path_component_equal_for_platform"
+        "left_value.size() > maximum_api_length"
+        "right_value.size() > maximum_api_length"
         "Unicode case table"
         "Windows filesystem's case-insensitive behavior"
-        "CharLowerBuffW returns zero")
+        "CharLowerBuffW reports zero on failure")
     string(FIND "${source_text}" "${required}" offset)
     if(offset EQUAL -1)
         message(FATAL_ERROR


### PR DESCRIPTION
## What changed

- restored and contract-protected the layered Windows Unicode comparison rationale
- corrected the inherited `CharLowerBuffW` explanation and failure handling
- fail closed when a component length cannot be represented by Win32 signed length parameters
- recorded exact hosted and independent-review evidence

## Impact

Representable Windows and POSIX path behavior is unchanged. Unrepresentable Windows component lengths return `false` without narrowing, and a `CharLowerBuffW` failure returns the pristine input instead of inspecting a possibly modified buffer.

## Validation

- local Release path runtime and boundary contracts: `2/2`
- mutation probes prove the rationale and Win32 length guards are load-bearing
- corrected implementation head `e35830c30`: all eleven protected checks passed
- Generated Launcher Validation `31545471149`: Windows, Ubuntu, and macOS passed
- Windows Environment and Executable Path Validation `31545471092`: passed
- independent review: PASS at `e35830c30`, including independent guard mutation
- final signed/DCO documentation-only evidence head: `b0a74a6e2`