### PR TITLE
Make SQLite native API private

### DIFF
--- a/.github/workflows/generated-launcher-validation.yml
+++ b/.github/workflows/generated-launcher-validation.yml
@@ -25,6 +25,7 @@ on:
       - "tests/run_platform_path_boundary_contract_check.cmake"
       - "tests/run_platform_environment_boundary_contract_check.cmake"
       - "tests/run_platform_executable_path_boundary_contract_check.cmake"
+      - "tests/run_platform_sqlite_api_boundary_contract_check.cmake"
       - "tests/test_platform_environment.cpp"
       - "tests/test_platform_path.cpp"
       - "tests/test_runtime_host_sqlite_federation.cpp"
@@ -58,6 +59,7 @@ on:
       - "tests/run_platform_path_boundary_contract_check.cmake"
       - "tests/run_platform_environment_boundary_contract_check.cmake"
       - "tests/run_platform_executable_path_boundary_contract_check.cmake"
+      - "tests/run_platform_sqlite_api_boundary_contract_check.cmake"
       - "tests/test_platform_environment.cpp"
       - "tests/test_platform_path.cpp"
       - "tests/test_runtime_host_sqlite_federation.cpp"
@@ -105,7 +107,7 @@ jobs:
         run: cmake --build build --config Release --target test_generated_launcher_process test_platform_path test_platform_environment test_polyglot_dotnet_candidate test_polyglot_python_sidecar test_polyglot_r_sidecar test_mcp_host copperfin_mcp_host copperfin_build_host test_sqlite_federation_connector test_runtime_host_sqlite_federation --parallel 2
 
       - name: Run generated-launcher, portable-platform, polyglot, MCP, and SQLite federation tests
-        run: ctest --test-dir build -C Release --output-on-failure -R "^(test_generated_launcher_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_polyglot_dotnet_candidate|test_polyglot_python_sidecar|test_polyglot_r_sidecar|test_mcp_host|test_mcp_host_stdio|test_sqlite_federation_connector|test_runtime_host_sqlite_federation)$"
+        run: ctest --test-dir build -C Release --output-on-failure -R "^(test_generated_launcher_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_platform_sqlite_api_boundary_contract|test_polyglot_dotnet_candidate|test_polyglot_python_sidecar|test_polyglot_r_sidecar|test_mcp_host|test_mcp_host_stdio|test_sqlite_federation_connector|test_runtime_host_sqlite_federation)$"
 
   posix-generated-launcher:
     name: ${{ matrix.os }} generated launcher process
@@ -139,4 +141,4 @@ jobs:
         run: cmake --build build --config Release --target test_generated_launcher_posix_process test_platform_path test_platform_environment test_polyglot_dotnet_candidate test_polyglot_python_sidecar test_polyglot_r_sidecar test_mcp_host copperfin_mcp_host test_sqlite_federation_connector test_runtime_host_sqlite_federation --parallel 2
 
       - name: Run POSIX generated-launcher, portable-platform, polyglot, MCP, and SQLite federation tests
-        run: ctest --test-dir build -C Release --output-on-failure -R "^(test_generated_launcher_posix_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_polyglot_dotnet_candidate|test_polyglot_python_sidecar|test_polyglot_r_sidecar|test_mcp_host|test_mcp_host_stdio|test_sqlite_federation_connector|test_runtime_host_sqlite_federation)$"
+        run: ctest --test-dir build -C Release --output-on-failure -R "^(test_generated_launcher_posix_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_platform_sqlite_api_boundary_contract|test_polyglot_dotnet_candidate|test_polyglot_python_sidecar|test_polyglot_r_sidecar|test_mcp_host|test_mcp_host_stdio|test_sqlite_federation_connector|test_runtime_host_sqlite_federation)$"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7438,8 +7438,11 @@ passes `1/1`.
   Windows still uses system WinSQLite with the same SDK-header/fallback
   declarations; Linux and macOS still use system SQLite3. The connector and its
   two synthetic-fixture tests receive a non-propagated private include root.
-  A new source contract rejects OS/native SQLite tokens across every public
-  Copperfin header and protects exact private ABI, consumer, and build wiring.
+  A new source contract rejects OS/native SQLite tokens across the complete
+  public Copperfin include tree and protects exact private ABI, three-consumer,
+  and build wiring.
   Local GCC Release focused behavior/workflow/isolation coverage passes `6/6`;
   public-shim and private-Windows-selector mutations fail at exact requirements,
   and Clang 21 ASan/UBSan passes the connector and boundary tests `2/2`.
+  Alternate-suffix public leakage and a fourth private-shim consumer are also
+  rejected by the tree-wide scan and closed consumer count.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7446,3 +7446,6 @@ passes `1/1`.
   and Clang 21 ASan/UBSan passes the connector and boundary tests `2/2`.
   Alternate-suffix public leakage and a fourth private-shim consumer are also
   rejected by the tree-wide scan and closed consumer count.
+  Exact signed/DCO corrected head `52b9b5c65` passes all eleven protected
+  checks, including the real connector, runtime-host integration, and boundary
+  contract on Windows, Ubuntu, and macOS; GitHub has no unresolved PR threads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7433,3 +7433,13 @@ passes `1/1`.
   collision resistance, traced all current callers through their preserved
   platform guards, matched the Linux result to `getconf PATH`, and passed a
   fresh ASan/UBSan build and run of the affected regression and hosts.
+- 2026-08-11: Continued J1 by moving the raw OS-selected SQLite C ABI shim out
+  of Copperfin's public include tree and beside the private read-only connector.
+  Windows still uses system WinSQLite with the same SDK-header/fallback
+  declarations; Linux and macOS still use system SQLite3. The connector and its
+  two synthetic-fixture tests receive a non-propagated private include root.
+  A new source contract rejects OS/native SQLite tokens across every public
+  Copperfin header and protects exact private ABI, consumer, and build wiring.
+  Local GCC Release focused behavior/workflow/isolation coverage passes `6/6`;
+  public-shim and private-Windows-selector mutations fail at exact requirements,
+  and Clang 21 ASan/UBSan passes the connector and boundary tests `2/2`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7449,3 +7449,7 @@ passes `1/1`.
   Exact signed/DCO corrected head `52b9b5c65` passes all eleven protected
   checks, including the real connector, runtime-host integration, and boundary
   contract on Windows, Ubuntu, and macOS; GitHub has no unresolved PR threads.
+  Independent review found no defect and directly proved the private include
+  root is not propagated, confirmed the moved ABI is otherwise unchanged,
+  reproduced the public-leak and fourth-consumer mutations, and passed the real
+  connector/runtime-host path under ASan/UBSan.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,6 +314,8 @@ add_library(cf_sqlite_connector
 target_include_directories(cf_sqlite_connector
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
 if(MSVC)

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -24,6 +24,12 @@ Validation `31559462461`, Windows Environment and Executable Path Validation
 or unresolved threads at that head.
 An alternate-suffix public header mutation and a fourth-consumer mutation also
 fail at the intended tree-wide and closed-consumer requirements.
+Independent review at corrected head `52b9b5c65` found no defect. A deliberate
+old-public-path include in the runtime host failed compilation, directly
+proving the private include root is not propagated. The review also confirmed
+the ABI content is unchanged, reproduced the public-leak and fourth-consumer
+mutations, passed real connector/runtime-host ASan/UBSan tests, and reran both
+workflow-text contracts.
 
 ## V1 portable executable-search default
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,23 @@
 # Agent Handoff
 
+## V1 private SQLite native API boundary
+
+The J1 follow-up moves the raw Windows/POSIX SQLite header selection from
+`include/copperfin/platform/` to the connector-private `src/platform/` surface.
+Windows WinSQLite header/fallback behavior, POSIX system SQLite, the real
+connector, runtime-host integration, security limits, and machine contracts are
+unchanged. The connector and two fixture-building tests receive a non-propagated
+private source include root. See `docs/53-private-sqlite-native-api-boundary.md`.
+
+The new source contract rejects OS/native SQLite tokens across every public
+Copperfin header, protects each private ABI branch, and verifies exact consumer
+and build wiring. Local GCC Release builds the connector tests and runtime host;
+focused behavior, workflow, boundary, and isolation coverage passes `6/6`.
+Restoring the public shim and changing only the private Windows fallback branch
+both fail at the intended exact requirement. Clang 21 ASan/UBSan with leak
+detection passes the connector and boundary tests `2/2`. Hosted
+Windows/macOS/Linux evidence and independent review remain required before merge.
+
 ## V1 portable executable-search default
 
 The J1 executable-path follow-up removes the last OS-selected declaration from

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -9,14 +9,16 @@ connector, runtime-host integration, security limits, and machine contracts are
 unchanged. The connector and two fixture-building tests receive a non-propagated
 private source include root. See `docs/53-private-sqlite-native-api-boundary.md`.
 
-The new source contract rejects OS/native SQLite tokens across every public
-Copperfin header, protects each private ABI branch, and verifies exact consumer
-and build wiring. Local GCC Release builds the connector tests and runtime host;
+The new source contract rejects OS/native SQLite tokens across the entire public
+Copperfin include tree, protects each private ABI branch, and verifies exactly
+three consumers plus exact build wiring. Local GCC Release builds the connector tests and runtime host;
 focused behavior, workflow, boundary, and isolation coverage passes `6/6`.
 Restoring the public shim and changing only the private Windows fallback branch
 both fail at the intended exact requirement. Clang 21 ASan/UBSan with leak
 detection passes the connector and boundary tests `2/2`. Hosted
 Windows/macOS/Linux evidence and independent review remain required before merge.
+An alternate-suffix public header mutation and a fourth-consumer mutation also
+fail at the intended tree-wide and closed-consumer requirements.
 
 ## V1 portable executable-search default
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -16,7 +16,12 @@ focused behavior, workflow, boundary, and isolation coverage passes `6/6`.
 Restoring the public shim and changing only the private Windows fallback branch
 both fail at the intended exact requirement. Clang 21 ASan/UBSan with leak
 detection passes the connector and boundary tests `2/2`. Hosted
-Windows/macOS/Linux evidence and independent review remain required before merge.
+Windows/macOS/Linux evidence passes at exact signed/DCO corrected head
+`52b9b5c65`: Generated Launcher Validation `31559462483`, Windows DECLARE ABI
+Validation `31559462461`, Windows Environment and Executable Path Validation
+`31559462418`, GCC/Clang Executable Path Validation `31559462383`, DCO
+`31559461132`, and both socket checks are green. GitHub has no review comments
+or unresolved threads at that head.
 An alternate-suffix public header mutation and a fourth-consumer mutation also
 fail at the intended tree-wide and closed-consumer requirements.
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -834,9 +834,11 @@ cover:
    portable native contracts. *(This is lane **J** — `J1`/`#35` portable core
    boundary, `J2`/`#36` macOS port, `J3`/`#37` Linux port. The first bounded
    Studio launch-error seam is shipped with three-platform evidence, and the
-   broadly consumed public path and process-environment interfaces now isolate
-   their native implementations behind `cf_platform_support`; the wider
-   native-boundary inventory and broader ports remain open.)*
+   broadly consumed public path, process-environment, and executable-search
+   interfaces now isolate their native implementations behind
+   `cf_platform_support`; the SQLite connector's raw native ABI is also private
+   rather than exported from `include/copperfin`. The wider native-boundary
+   inventory and broader ports remain open.)*
 6. Build the requirements-to-code-to-test traceability matrix from validated
    VFP9 behavior, shipped documentation, and documented Copperfin exceptions.
    *(No lane letter was ever assigned. The durable matrix has begun in
@@ -883,7 +885,7 @@ standalone Studio shell, and FoxPro language-service layer."
 | G | `#112` (`G1`/`#27`, `G2`/`#28`, `G3`/`#29`) | FoxPro language service: semantic resolution, navigation/refactoring, IntelliSense metadata | Recorded G1/G2/G3 slices closed; broader MVP scope remains under the live tree | Phase C |
 | H | `#113` (`H1`/`#30`, `H2`/`#31`, `H3`/`#32`) | Relational backend translators, document/vector + AI planning, .NET/MCP/polyglot outputs | Portable route/artifact execution, trusted runtime-host composition, PRG dispatch, Native AOT C# leaf, admitted Python/R sidecar leaves, and one bounded read-only MCP DBF-header tool implemented; broader managed-language environments and model/provider or mutable MCP integrations remain | v1 item 3 |
 | I | `#113` (`I1`/`#33`, `I2`/`#34`) | Runtime/project security depth, extension/host/AI-MCP security boundary | Seeded (see gap analysis) | v1 item 4 |
-| J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | Studio launch-error and POSIX root-identity seams plus portable public path/environment/executable-search boundaries shipped; broader ports open | v1 item 5 |
+| J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | Studio launch-error and POSIX root-identity seams, portable public path/environment/executable-search boundaries, and private SQLite native ABI isolation shipped; broader ports open | v1 item 5 |
 
 Current G1 evidence includes #4874 at product/test head `e70c89e87`: editor
 project-symbol discovery follows the unquoted `#INCLUDE` form used by the real

--- a/docs/24-system-uml.md
+++ b/docs/24-system-uml.md
@@ -66,6 +66,11 @@ classDiagram
         +extensibility_model
     }
 
+    class cf_sqlite_connector {
+        +read_only_plan_execution
+        -private_native_sqlite_api
+    }
+
     class cf_mcp_host {
         +dual_era_stdio_protocol
         +read_only_dbf_header_tool
@@ -157,6 +162,8 @@ classDiagram
 
     cf_security --> cf_localization
     cf_platform_profile --> cf_localization
+    cf_sqlite_connector --> cf_platform_profile
+    cf_sqlite_connector --> cf_security : private
     cf_vfp_assets --> cf_localization
     cf_mcp_host --> cf_platform_support
     cf_mcp_host --> cf_vfp_assets
@@ -194,6 +201,7 @@ classDiagram
     copperfin_runtime_host --> cf_xbase_runtime
     copperfin_runtime_host --> cf_security
     copperfin_runtime_host --> cf_platform_profile
+    copperfin_runtime_host --> cf_sqlite_connector
     copperfin_runtime_host --> cf_licensing
     copperfin_runtime_host --> cf_localization
 

--- a/docs/28-repository-ontology.md
+++ b/docs/28-repository-ontology.md
@@ -9,7 +9,7 @@ portable `cf_mcp_host` library and installed `copperfin_mcp_host` executable.
 
 | Class | Instances | Where |
 |---|---|---|
-| Native static libraries | `cf_platform_support`, `cf_localization`, `cf_security`, `cf_licensing`, `cf_package_trust`, `cf_platform_profile`, `cf_vfp_assets`, `cf_mcp_host`, `cf_design_model`, `cf_prg_analysis`, `cf_runtime_text`, `cf_xbase_runtime`, `cf_runtime_pipeline` | `CMakeLists.txt`, `src/*`, `include/copperfin/*` |
+| Native static libraries | `cf_platform_support`, `cf_localization`, `cf_security`, `cf_licensing`, `cf_package_trust`, `cf_platform_profile`, `cf_sqlite_connector`, `cf_vfp_assets`, `cf_mcp_host`, `cf_design_model`, `cf_prg_analysis`, `cf_runtime_text`, `cf_xbase_runtime`, `cf_runtime_pipeline` | `CMakeLists.txt`, `src/*`, `include/copperfin/*` |
 | Native executables ("hosts") | `copperfin_inspect`, `copperfin_mcp_host`, `copperfin_studio_host`, `copperfin_runtime_host`, `copperfin_build_host`, `copperfin_launcher_guard` (Windows-only) | `apps/*/main.cpp` |
 | Managed (.NET) projects | `Copperfin.VisualStudio` (VSIX), `Copperfin.Studio` (standalone shell), `Copperfin.DesignerSmokeTests`, `Copperfin.LanguageServiceTests`, `Copperfin.PolyglotCandidate` (Native AOT external leaf sample) | `vsix/*`, `samples/polyglot-dotnet-candidate/*` |
 | VFP-era asset formats (domain data) | `DBF/FPT`, `CDX/DCX/IDX/MDX`, `DBC`, `PJX/PJT`, `SCX/SCT`, `VCX/VCT`, `FRX/FRT`, `LBX/LBT`, `MNX/MNT`, `PRG/H/QPR/MPR/SPR` | parsed/edited across `cf_vfp_assets`, `cf_design_model`, `cf_xbase_runtime` |
@@ -36,6 +36,10 @@ cf_licensing                            (base64, canonical payload serializer, e
                                           envelope/key-registry/verification API; must not consume
                                           license parsing or license-status decisions)
 
+cf_sqlite_connector = cf_platform_profile(public) + cf_security(private)
+                      (read-only SQLite execution; raw Windows/POSIX SQLite ABI
+                       selection remains private under src/platform)
+
 cf_design_model  = cf_vfp_assets + cf_prg_analysis + cf_localization
                    (src/studio/*: designer_*, builder_*, toolbox_*, vs_launch_contract_*, report_layout, project_workspace, document_model)
 
@@ -55,7 +59,7 @@ Executables consume this graph at the top:
 copperfin_inspect        -> cf_vfp_assets, cf_security, cf_licensing, cf_localization
 copperfin_mcp_host       -> cf_mcp_host, cf_security
 copperfin_studio_host    -> cf_design_model, cf_security, cf_platform_profile, cf_licensing
-copperfin_runtime_host   -> cf_xbase_runtime, cf_security, cf_platform_profile, cf_licensing, cf_localization
+copperfin_runtime_host   -> cf_xbase_runtime, cf_security, cf_platform_profile, cf_sqlite_connector, cf_licensing, cf_localization
 copperfin_build_host     -> cf_runtime_pipeline, cf_localization
 copperfin_launcher_guard -> cf_security, cf_localization, cf_platform_support, cf_package_trust   (Windows-only)
 ```
@@ -88,6 +92,7 @@ Also note the root of the graph changed since this document's first pass:
 - **Localization**: catalog-driven string lookup (`resources/locales/{en-US,es-419,pt-BR,qps-ploc}/strings.json`); each higher subsystem has its own `localized_text.{h,cpp}` shim over this base.
 - **Security**: `authorization`, `audit_stream`, `external_process_policy`, `physical_path_containment`, `process_hardening`, `secret_provider`, `security_model`, `sha256` — an RBAC/audit/sandboxing layer (`docs/18-native-security-and-rbac.md`), independent of any one host. On Windows it links `bcrypt`, `crypt32`, `wintrust`, and `version`.
 - **Platform profile**: `database_model`, `query_translator`, `federation_execution`, `extensibility_model` — the "database federation" concept (`docs/21-database-federation-and-query-translation.md`): deterministic relational query translation plus AI-assisted document/vector planning metadata, surfaced into both Studio and the runtime host.
+- **SQLite connector**: bounded read-only execution of deterministic SQLite plans. Its public Copperfin header exposes only platform-neutral result/request types; the system SQLite/WinSQLite C ABI selection is a private implementation header.
 
 ### `cf_licensing` / `cf_package_trust` (new — crypto and package-trust layer)
 

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -123,7 +123,9 @@ only — the mechanism exists but is empty or entirely unclaimed.
 
 **Status: real seed, broad inventory still open.** The common public path,
 process-environment, and executable-search interfaces now contain only standard
-C++ declarations.
+C++ declarations. The SQLite connector's OS-selected raw C ABI shim is private
+to its implementation and no public Copperfin header selects a host platform or
+includes a native SQLite header.
 Windows SDK/CRT selection, UTF conversion, path-component comparison, POSIX
 environment calls, and process-wide synchronization are private implementation
 in `cf_platform_support`. Direct portable regressions and source-level
@@ -131,7 +133,8 @@ contracts run in the Windows, Linux, and macOS validation workflow, so the
 boundaries are load-bearing rather than documentary. See
 `docs/50-portable-public-path-boundary.md` and
 `docs/51-portable-public-environment-boundary.md`, and
-`docs/52-portable-executable-search-default.md`.
+`docs/52-portable-executable-search-default.md`, plus
+`docs/53-private-sqlite-native-api-boundary.md`.
 
 **What it will take:** inventory the rest of the public core and isolate the
 remaining shell, printing, OLE/COM, CLR-hosting, and other host-specific seams.

--- a/docs/49-read-only-sqlite-federation-execution.md
+++ b/docs/49-read-only-sqlite-federation-execution.md
@@ -31,13 +31,16 @@ and 1 MiB SQL text. Limits fail closed; results are never silently truncated.
 
 ## Build And Platform Contract
 
-Windows 10 and newer use the system `winsqlite3` library. Copperfin supplies a
-narrow compatibility declaration header when an SDK installation omits the
-optional header; it does not package or replace the OS library. Linux and macOS
-use a discoverable system SQLite3 development package. Ordinary builds provide
-a stable unavailable adapter when SQLite is absent. Validation and release
-builds set `COPPERFIN_REQUIRE_SQLITE_CONNECTOR=ON`, making absence a configure failure.
-Hosted Windows, Linux, and macOS validation builds and runs both new tests.
+Windows 10 and newer use the system `winsqlite3` library. Copperfin keeps a
+narrow private compatibility declaration header beside the connector when an
+SDK installation omits the optional header; it does not expose that native ABI
+through the Copperfin public include tree and does not package or replace the OS
+library. Linux and macOS use a discoverable system SQLite3 development package.
+Ordinary builds provide a stable unavailable adapter when SQLite is absent.
+Validation and release builds set `COPPERFIN_REQUIRE_SQLITE_CONNECTOR=ON`,
+making absence a configure failure. Hosted Windows, Linux, and macOS validation
+builds and runs both connector tests plus the private-boundary contract. See
+[53-private-sqlite-native-api-boundary.md](53-private-sqlite-native-api-boundary.md).
 
 ## Deliberate Limits
 

--- a/docs/53-private-sqlite-native-api-boundary.md
+++ b/docs/53-private-sqlite-native-api-boundary.md
@@ -42,6 +42,14 @@ An alternate-suffix `.hpp` public leak and a fourth private-shim consumer are
 also rejected, proving the tree-wide scan and closed consumer count are
 load-bearing rather than dependent on today's filenames.
 
+At exact signed/DCO corrected head `52b9b5c65`, all eleven protected PR
+checks pass. Generated Launcher Validation `31559462483` builds and runs the
+real connector, runtime-host integration, and boundary contract on Windows,
+Ubuntu, and macOS. Windows DECLARE ABI Validation `31559462461`, Windows
+Environment and Executable Path Validation `31559462418`, GCC/Clang Executable
+Path Validation `31559462383`, DCO `31559461132`, and both socket checks pass.
+GitHub reports no review comments or unresolved review threads at that head.
+
 ## Scope
 
 This is a pure J1 ownership/boundary correction. It does not change the SQLite

--- a/docs/53-private-sqlite-native-api-boundary.md
+++ b/docs/53-private-sqlite-native-api-boundary.md
@@ -50,6 +50,15 @@ Environment and Executable Path Validation `31559462418`, GCC/Clang Executable
 Path Validation `31559462383`, DCO `31559461132`, and both socket checks pass.
 GitHub reports no review comments or unresolved review threads at that head.
 
+Independent review at corrected head `52b9b5c65` found no defect. It proved
+the private include root is not propagated by deliberately including the old
+public path from the runtime host and observing the expected compiler failure;
+the host rebuilt cleanly after restoration. It confirmed the moved ABI content
+is unchanged except for its ownership comment, reproduced public-shim,
+unrelated-public-header, and fourth-consumer mutations, and passed the real
+connector and runtime-host tests under ASan/UBSan with the connector required.
+Both touched workflow-text contracts also pass independently.
+
 ## Scope
 
 This is a pure J1 ownership/boundary correction. It does not change the SQLite

--- a/docs/53-private-sqlite-native-api-boundary.md
+++ b/docs/53-private-sqlite-native-api-boundary.md
@@ -1,0 +1,47 @@
+# Private SQLite Native API Boundary
+
+The raw SQLite C ABI selection used by Copperfin's read-only relational
+connector is an implementation detail, not a Copperfin public interface.
+`src/platform/sqlite_api.h` now owns that detail beside the connector. No file
+under `include/copperfin/` includes SQLite headers, publishes Windows import
+syntax, or selects an operating system.
+
+## Preserved behavior
+
+- Windows 10 and newer still link the operating-system `winsqlite3` library.
+  SDKs with `winsqlite3.h` use it; SDK layouts without that optional header use
+  the same narrow public-domain ABI declarations as before.
+- Linux and macOS still use the discovered system SQLite3 development package.
+- `COPPERFIN_REQUIRE_SQLITE_CONNECTOR=ON` still fails configuration when the
+  required native library is unavailable.
+- The connector's read-only policy, resource ceilings, typed result JSON,
+  physical-file checks, audit events, runtime-host CLI, and unavailable adapter
+  are unchanged.
+- The two integration tests receive the private source include root only so
+  they can create local synthetic fixture databases through the same native
+  ABI. That include root is not propagated by `cf_sqlite_connector`.
+
+## Regression contract
+
+`test_platform_sqlite_api_boundary_contract` scans every Copperfin public
+header and rejects OS-selection macros, native SQLite headers, and Windows
+import syntax. It requires the exact private Windows-header, Windows-fallback,
+and POSIX-header branches, verifies the three intended consumers use the
+private path, and requires exact private include-root wiring for the connector
+and two tests.
+
+Generated Launcher Validation runs this source contract beside the real
+connector and runtime-host integration tests on Windows, Ubuntu, and macOS.
+Local GCC Release builds both tests and the runtime host, and focused behavior,
+workflow, boundary, and isolation coverage passes `6/6`. Deliberately restoring
+the public shim fails at the public-tree boundary; changing only the private
+Windows fallback selector fails at its exact required token.
+Clang 21 ASan/UBSan with leak detection also builds and passes the real
+connector regression plus the boundary contract `2/2`.
+
+## Scope
+
+This is a pure J1 ownership/boundary correction. It does not change the SQLite
+provider, add another database, alter VFP9 behavior or machine-readable output,
+or claim completion of the remaining shell, printing, OLE/COM, CLR-hosting,
+macOS-host, or Linux-host work.

--- a/docs/53-private-sqlite-native-api-boundary.md
+++ b/docs/53-private-sqlite-native-api-boundary.md
@@ -23,12 +23,12 @@ syntax, or selects an operating system.
 
 ## Regression contract
 
-`test_platform_sqlite_api_boundary_contract` scans every Copperfin public
-header and rejects OS-selection macros, native SQLite headers, and Windows
-import syntax. It requires the exact private Windows-header, Windows-fallback,
-and POSIX-header branches, verifies the three intended consumers use the
-private path, and requires exact private include-root wiring for the connector
-and two tests.
+`test_platform_sqlite_api_boundary_contract` scans every file in Copperfin's
+public include tree and rejects OS-selection macros, native SQLite headers, and
+Windows import syntax. It requires the exact private Windows-header,
+Windows-fallback, and POSIX-header branches, requires exactly the three intended
+source/test consumers, and checks exact private include-root wiring for the
+connector and two tests.
 
 Generated Launcher Validation runs this source contract beside the real
 connector and runtime-host integration tests on Windows, Ubuntu, and macOS.
@@ -38,6 +38,9 @@ the public shim fails at the public-tree boundary; changing only the private
 Windows fallback selector fails at its exact required token.
 Clang 21 ASan/UBSan with leak detection also builds and passes the real
 connector regression plus the boundary contract `2/2`.
+An alternate-suffix `.hpp` public leak and a fourth private-shim consumer are
+also rejected, proving the tree-wide scan and closed consumer count are
+load-bearing rather than dependent on today's filenames.
 
 ## Scope
 

--- a/docs/diagrams/roadmap-v1-lanes-hij.md
+++ b/docs/diagrams/roadmap-v1-lanes-hij.md
@@ -76,11 +76,13 @@ benchmark evidence; and `I1` has a security baseline. These real seeds are
 translator/execution-planning lane, the trusted polyglot host and route-impact
 boundary, and `cf_security`'s RBAC/audit/secrets/signing baseline, respectively.
 `J1` now has explicit portable public path, process-environment, and
-executable-search boundaries:
+executable-search boundaries plus a private SQLite native-ABI boundary:
 platform-neutral declarations remain in the broadly consumed headers while
 Windows/POSIX selection and native implementation stay private to
 `cf_platform_support`, with direct and source-contract tests scheduled on all
 three hosts.
+The read-only connector retains Windows/POSIX SQLite selection privately;
+public Copperfin headers reject host-selection and native SQLite API tokens.
 `H3` still lacks broader managed-language environments and model/provider or
 mutable MCP/AI adapters. **What's left, and what it
 takes:** this is

--- a/src/platform/sqlite_api.h
+++ b/src/platform/sqlite_api.h
@@ -9,8 +9,8 @@
 #elif defined(_WIN32)
 
 // Windows provides winsqlite3.dll and winsqlite3.lib even on SDK layouts that
-// omit the optional winsqlite3.h header. These are the public SQLite C ABI
-// declarations and constants used by Copperfin; SQLite's API is public domain.
+// omit the optional winsqlite3.h header. These private connector declarations
+// cover only the public-domain SQLite C ABI used by Copperfin.
 extern "C" {
 
 struct sqlite3;

--- a/src/platform/sqlite_federation_connector.cpp
+++ b/src/platform/sqlite_federation_connector.cpp
@@ -6,7 +6,7 @@
 
 #include "copperfin/platform/json.h"
 #include "copperfin/platform/path.h"
-#include "copperfin/platform/sqlite_api.h"
+#include "platform/sqlite_api.h"
 #include "copperfin/security/physical_path_containment.h"
 
 #include <algorithm>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4886,6 +4886,13 @@ add_test(
         -P ${CMAKE_CURRENT_SOURCE_DIR}/run_platform_executable_path_boundary_contract_check.cmake
 )
 
+add_test(
+    NAME test_platform_sqlite_api_boundary_contract
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/run_platform_sqlite_api_boundary_contract_check.cmake
+)
+
 add_executable(test_platform_environment
     test_platform_environment.cpp
 )
@@ -4914,6 +4921,8 @@ copperfin_add_test(test_federation_execution cf_platform_profile
 copperfin_add_test(test_sqlite_federation_connector cf_sqlite_connector
     test_sqlite_federation_connector.cpp
 )
+target_include_directories(test_sqlite_federation_connector PRIVATE
+    ${CMAKE_SOURCE_DIR}/src)
 
 add_executable(test_runtime_host_sqlite_federation
     test_runtime_host_sqlite_federation.cpp
@@ -4922,6 +4931,8 @@ target_link_libraries(test_runtime_host_sqlite_federation PRIVATE
     cf_sqlite_connector
     cf_platform_support
     cf_test_process_capture_support)
+target_include_directories(test_runtime_host_sqlite_federation PRIVATE
+    ${CMAKE_SOURCE_DIR}/src)
 add_dependencies(test_runtime_host_sqlite_federation copperfin_runtime_host)
 if(MSVC)
     target_compile_options(test_runtime_host_sqlite_federation PRIVATE /W4 /permissive-)

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -320,6 +320,17 @@ function(copperfin_configure_native_test_isolation)
         PLATFORM portable
         AUDIT complete
     )
+    copperfin_set_test_isolation(test_platform_sqlite_api_boundary_contract
+        PARALLEL_SAFE
+        FILESYSTEM read-only
+        ENVIRONMENT none
+        CHILD_PROCESSES none
+        NETWORK none
+        RESOURCES none
+        SAMPLES none
+        PLATFORM portable
+        AUDIT complete
+    )
 
     foreach(test_name IN ITEMS
             test_product_subsystems

--- a/tests/run_github_actions_contract_check.cmake
+++ b/tests/run_github_actions_contract_check.cmake
@@ -138,6 +138,7 @@ foreach(required_text IN ITEMS
         "tests/run_platform_path_boundary_contract_check.cmake"
         "tests/run_platform_environment_boundary_contract_check.cmake"
         "tests/run_platform_executable_path_boundary_contract_check.cmake"
+        "tests/run_platform_sqlite_api_boundary_contract_check.cmake"
         "tests/test_platform_environment.cpp"
         "tests/test_platform_path.cpp"
         "r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6"
@@ -148,8 +149,8 @@ foreach(required_text IN ITEMS
         "test_generated_launcher_posix_process test_platform_path test_platform_environment test_polyglot_dotnet_candidate"
         "test_polyglot_dotnet_candidate test_polyglot_python_sidecar"
         "test_polyglot_python_sidecar test_polyglot_r_sidecar"
-        "test_generated_launcher_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_polyglot_dotnet_candidate"
-        "test_generated_launcher_posix_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_polyglot_dotnet_candidate"
+        "test_generated_launcher_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_platform_sqlite_api_boundary_contract|test_polyglot_dotnet_candidate"
+        "test_generated_launcher_posix_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_platform_sqlite_api_boundary_contract|test_polyglot_dotnet_candidate"
         "test_polyglot_dotnet_candidate|test_polyglot_python_sidecar"
         "test_polyglot_python_sidecar|test_polyglot_r_sidecar")
     string(FIND "${generated_launcher_workflow}" "${required_text}" required_index)

--- a/tests/run_native_platform_workflow_contract_check.cmake
+++ b/tests/run_native_platform_workflow_contract_check.cmake
@@ -459,6 +459,10 @@ require_text_count(".github/workflows/generated-launcher-validation.yml"
     2
     "cross-platform SQLite connector test pairs")
 require_text_count(".github/workflows/generated-launcher-validation.yml"
+    "test_platform_sqlite_api_boundary_contract"
+    2
+    "cross-platform private SQLite API boundary tests")
+require_text_count(".github/workflows/generated-launcher-validation.yml"
     "apps/copperfin_runtime_host/**"
     2
     "runtime-host path triggers")

--- a/tests/run_platform_sqlite_api_boundary_contract_check.cmake
+++ b/tests/run_platform_sqlite_api_boundary_contract_check.cmake
@@ -1,0 +1,92 @@
+# Copyright © 2026 Richard M. Hamilton.
+# SPDX-License-Identifier: GPL-3.0-only
+# Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+if(NOT DEFINED SOURCE_DIR OR "${SOURCE_DIR}" STREQUAL "")
+    message(FATAL_ERROR "SOURCE_DIR is required")
+endif()
+
+set(public_api_path "${SOURCE_DIR}/include/copperfin/platform/sqlite_api.h")
+if(EXISTS "${public_api_path}")
+    message(FATAL_ERROR
+        "Raw SQLite native API shim must not exist in the public include tree")
+endif()
+
+file(GLOB_RECURSE public_headers
+    "${SOURCE_DIR}/include/copperfin/*.h")
+foreach(header_path IN LISTS public_headers)
+    file(READ "${header_path}" header_text)
+    foreach(forbidden IN ITEMS
+            "_WIN32"
+            "__APPLE__"
+            "__linux__"
+            "winsqlite3.h"
+            "sqlite3.h"
+            "__declspec(dllimport)")
+        string(FIND "${header_text}" "${forbidden}" offset)
+        if(NOT offset EQUAL -1)
+            message(FATAL_ERROR
+                "Public Copperfin header leaks native selection token ${forbidden}: ${header_path}")
+        endif()
+    endforeach()
+endforeach()
+
+set(private_api_path "${SOURCE_DIR}/src/platform/sqlite_api.h")
+if(NOT EXISTS "${private_api_path}")
+    message(FATAL_ERROR "Private SQLite connector API shim is missing")
+endif()
+file(READ "${private_api_path}" private_api_text)
+foreach(required IN ITEMS
+        "#if defined(_WIN32) && __has_include(<winsqlite3.h>)"
+        "#include <winsqlite3.h>"
+        "#elif defined(_WIN32)"
+        "__declspec(dllimport) int sqlite3_open_v2("
+        "#define SQLITE_OPEN_READONLY 0x00000001"
+        "#define SQLITE_DBCONFIG_DEFENSIVE 1010"
+        "#else\n#include <sqlite3.h>\n#endif")
+    string(FIND "${private_api_text}" "${required}" offset)
+    if(offset EQUAL -1)
+        message(FATAL_ERROR
+            "Private SQLite connector API shim is missing required token: ${required}")
+    endif()
+endforeach()
+
+foreach(consumer IN ITEMS
+        "src/platform/sqlite_federation_connector.cpp"
+        "tests/test_sqlite_federation_connector.cpp"
+        "tests/test_runtime_host_sqlite_federation.cpp")
+    file(READ "${SOURCE_DIR}/${consumer}" consumer_text)
+    string(FIND "${consumer_text}" "#include \"platform/sqlite_api.h\"" private_include_offset)
+    if(private_include_offset EQUAL -1)
+        message(FATAL_ERROR
+            "SQLite API consumer does not use the private connector shim: ${consumer}")
+    endif()
+    string(FIND "${consumer_text}" "copperfin/platform/sqlite_api.h" public_include_offset)
+    if(NOT public_include_offset EQUAL -1)
+        message(FATAL_ERROR
+            "SQLite API consumer still names the removed public shim: ${consumer}")
+    endif()
+endforeach()
+
+file(READ "${SOURCE_DIR}/CMakeLists.txt" root_cmake_text)
+string(FIND "${root_cmake_text}"
+    [=[${CMAKE_CURRENT_SOURCE_DIR}/src]=]
+    private_source_offset)
+if(private_source_offset EQUAL -1)
+    message(FATAL_ERROR "SQLite connector target lacks its private source include root")
+endif()
+
+file(READ "${SOURCE_DIR}/tests/CMakeLists.txt" tests_cmake_text)
+foreach(required IN ITEMS
+        [=[target_include_directories(test_sqlite_federation_connector PRIVATE
+    ${CMAKE_SOURCE_DIR}/src)]=]
+        [=[target_include_directories(test_runtime_host_sqlite_federation PRIVATE
+    ${CMAKE_SOURCE_DIR}/src)]=])
+    string(FIND "${tests_cmake_text}" "${required}" offset)
+    if(offset EQUAL -1)
+        message(FATAL_ERROR
+            "SQLite test target lacks its exact private source include root: ${required}")
+    endif()
+endforeach()
+
+message(STATUS "Private SQLite native API boundary contract passed")

--- a/tests/run_platform_sqlite_api_boundary_contract_check.cmake
+++ b/tests/run_platform_sqlite_api_boundary_contract_check.cmake
@@ -13,7 +13,8 @@ if(EXISTS "${public_api_path}")
 endif()
 
 file(GLOB_RECURSE public_headers
-    "${SOURCE_DIR}/include/copperfin/*.h")
+    LIST_DIRECTORIES false
+    "${SOURCE_DIR}/include/copperfin/*")
 foreach(header_path IN LISTS public_headers)
     file(READ "${header_path}" header_text)
     foreach(forbidden IN ITEMS
@@ -68,12 +69,32 @@ foreach(consumer IN ITEMS
     endif()
 endforeach()
 
+file(GLOB_RECURSE native_source_files
+    LIST_DIRECTORIES false
+    "${SOURCE_DIR}/src/*.cpp"
+    "${SOURCE_DIR}/tests/*.cpp")
+set(private_include_consumers 0)
+foreach(source_path IN LISTS native_source_files)
+    file(READ "${source_path}" source_text)
+    string(FIND "${source_text}" "#include \"platform/sqlite_api.h\"" include_offset)
+    if(NOT include_offset EQUAL -1)
+        math(EXPR private_include_consumers "${private_include_consumers} + 1")
+    endif()
+endforeach()
+if(NOT private_include_consumers EQUAL 3)
+    message(FATAL_ERROR
+        "Exactly three native source/test consumers may use the private SQLite API shim")
+endif()
+
 file(READ "${SOURCE_DIR}/CMakeLists.txt" root_cmake_text)
-string(FIND "${root_cmake_text}"
-    [=[${CMAKE_CURRENT_SOURCE_DIR}/src]=]
-    private_source_offset)
+string(FIND "${root_cmake_text}" [=[target_include_directories(cf_sqlite_connector
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)]=] private_source_offset)
 if(private_source_offset EQUAL -1)
-    message(FATAL_ERROR "SQLite connector target lacks its private source include root")
+    message(FATAL_ERROR "SQLite connector target lacks its exact private include block")
 endif()
 
 file(READ "${SOURCE_DIR}/tests/CMakeLists.txt" tests_cmake_text)

--- a/tests/test_runtime_host_sqlite_federation.cpp
+++ b/tests/test_runtime_host_sqlite_federation.cpp
@@ -7,7 +7,7 @@
 #include "test_process_capture_support.h"
 
 #if COPPERFIN_SQLITE_CONNECTOR_AVAILABLE
-#include "copperfin/platform/sqlite_api.h"
+#include "platform/sqlite_api.h"
 #endif
 
 #include <atomic>

--- a/tests/test_sqlite_federation_connector.cpp
+++ b/tests/test_sqlite_federation_connector.cpp
@@ -6,7 +6,7 @@
 #include "copperfin/platform/sqlite_federation_connector.h"
 
 #if COPPERFIN_SQLITE_CONNECTOR_AVAILABLE
-#include "copperfin/platform/sqlite_api.h"
+#include "platform/sqlite_api.h"
 #endif
 
 #include <chrono>


### PR DESCRIPTION
## What changed

- moved the raw OS-selected SQLite C ABI shim from `include/copperfin/platform/` to the connector-private `src/platform/` surface
- gave only `cf_sqlite_connector` and its two fixture-building tests a non-propagated private include root
- added a source contract that rejects host-selection/native SQLite tokens across every public Copperfin header and protects the exact private ABI branches and consumers
- scheduled the contract beside the real connector and runtime-host integration on Windows, Ubuntu, and macOS
- updated the J1 roadmap, architecture, ontology, gap analysis, handoff, changelog, and connector documentation

## Why

The shim is a native connector implementation detail, not a Copperfin public abstraction. Its public location leaked Windows import syntax and native SQLite headers through the portable include tree, weakening J1's cross-platform boundary.

## Impact

There is no connector or runtime behavior change. Windows continues to use system WinSQLite with the same optional-SDK-header fallback; Linux and macOS continue to use system SQLite3. Read-only enforcement, resource limits, audit events, typed JSON, CLI behavior, and unavailable-adapter behavior remain unchanged.

## Validation

- GCC Release built `test_sqlite_federation_connector`, `test_runtime_host_sqlite_federation`, and `copperfin_runtime_host`
- focused behavior, workflow, boundary, and isolation CTest coverage: 6/6 passed
- Clang 21 ASan/UBSan with leak detection: connector plus boundary contract 2/2 passed
- mutation: restoring the public shim fails at the public-tree boundary
- mutation: changing only the private Windows fallback selector fails at its exact required token
- `git diff --check` passed

Issue #35 remains open for the wider J1 native-seam inventory and J2/J3 port scope.