### PR TITLE
Make the CLR host boundary portable

### DIFF
--- a/.github/workflows/generated-launcher-validation.yml
+++ b/.github/workflows/generated-launcher-validation.yml
@@ -26,6 +26,7 @@ on:
       - "tests/run_platform_environment_boundary_contract_check.cmake"
       - "tests/run_platform_executable_path_boundary_contract_check.cmake"
       - "tests/run_platform_sqlite_api_boundary_contract_check.cmake"
+      - "tests/run_portable_clr_host_boundary_contract_check.cmake"
       - "tests/test_platform_environment.cpp"
       - "tests/test_platform_path.cpp"
       - "tests/test_runtime_host_sqlite_federation.cpp"
@@ -60,6 +61,7 @@ on:
       - "tests/run_platform_environment_boundary_contract_check.cmake"
       - "tests/run_platform_executable_path_boundary_contract_check.cmake"
       - "tests/run_platform_sqlite_api_boundary_contract_check.cmake"
+      - "tests/run_portable_clr_host_boundary_contract_check.cmake"
       - "tests/test_platform_environment.cpp"
       - "tests/test_platform_path.cpp"
       - "tests/test_runtime_host_sqlite_federation.cpp"
@@ -107,7 +109,7 @@ jobs:
         run: cmake --build build --config Release --target test_generated_launcher_process test_platform_path test_platform_environment test_polyglot_dotnet_candidate test_polyglot_python_sidecar test_polyglot_r_sidecar test_mcp_host copperfin_mcp_host copperfin_build_host test_sqlite_federation_connector test_runtime_host_sqlite_federation --parallel 2
 
       - name: Run generated-launcher, portable-platform, polyglot, MCP, and SQLite federation tests
-        run: ctest --test-dir build -C Release --output-on-failure -R "^(test_generated_launcher_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_platform_sqlite_api_boundary_contract|test_polyglot_dotnet_candidate|test_polyglot_python_sidecar|test_polyglot_r_sidecar|test_mcp_host|test_mcp_host_stdio|test_sqlite_federation_connector|test_runtime_host_sqlite_federation)$"
+        run: ctest --test-dir build -C Release --output-on-failure -R "^(test_generated_launcher_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_platform_sqlite_api_boundary_contract|test_portable_clr_host_boundary_contract|test_polyglot_dotnet_candidate|test_polyglot_python_sidecar|test_polyglot_r_sidecar|test_mcp_host|test_mcp_host_stdio|test_sqlite_federation_connector|test_runtime_host_sqlite_federation)$"
 
   posix-generated-launcher:
     name: ${{ matrix.os }} generated launcher process
@@ -141,4 +143,4 @@ jobs:
         run: cmake --build build --config Release --target test_generated_launcher_posix_process test_platform_path test_platform_environment test_polyglot_dotnet_candidate test_polyglot_python_sidecar test_polyglot_r_sidecar test_mcp_host copperfin_mcp_host test_sqlite_federation_connector test_runtime_host_sqlite_federation --parallel 2
 
       - name: Run POSIX generated-launcher, portable-platform, polyglot, MCP, and SQLite federation tests
-        run: ctest --test-dir build -C Release --output-on-failure -R "^(test_generated_launcher_posix_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_platform_sqlite_api_boundary_contract|test_polyglot_dotnet_candidate|test_polyglot_python_sidecar|test_polyglot_r_sidecar|test_mcp_host|test_mcp_host_stdio|test_sqlite_federation_connector|test_runtime_host_sqlite_federation)$"
+        run: ctest --test-dir build -C Release --output-on-failure -R "^(test_generated_launcher_posix_process|test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_platform_sqlite_api_boundary_contract|test_portable_clr_host_boundary_contract|test_polyglot_dotnet_candidate|test_polyglot_python_sidecar|test_polyglot_r_sidecar|test_mcp_host|test_mcp_host_stdio|test_sqlite_federation_connector|test_runtime_host_sqlite_federation)$"

--- a/.github/workflows/windows-x86-declare-validation.yml
+++ b/.github/workflows/windows-x86-declare-validation.yml
@@ -52,7 +52,7 @@ jobs:
         run: cmake --build build-${{ matrix.platform }} --config Release --parallel 2 --target test_prg_engine_seek_index test_prg_engine_dotnet_dispatch test_prg_engine_parser_classes test_localization
 
       - name: Run managed DECLARE regression target
-        run: ctest --test-dir build-${{ matrix.platform }} -C Release --verbose --timeout 180 -R "^test_prg_engine_dotnet_dispatch$"
+        run: ctest --test-dir build-${{ matrix.platform }} -C Release --verbose --timeout 180 -R "^(test_prg_engine_dotnet_dispatch|test_portable_clr_host_boundary_contract)$"
 
       - name: Run adjacent DECLARE regression targets
         run: ctest --test-dir build-${{ matrix.platform }} -C Release --output-on-failure -R "^(test_prg_engine_seek_index|test_prg_engine_parser_classes|test_localization)$"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7460,8 +7460,12 @@ passes `1/1`.
   COM/Automation types, UTF conversion, `SAFEARRAY` construction, return-value
   marshaling, and its `mscoree` linker directive. Existing .NET Framework v4
   assembly loading, CLR-binder dispatch, VFP-compatible error identities, and
-  scalar behavior are preserved, with new direct `SINGLE` and logical-return
-  regression cases. A source contract runs on all three hosted platforms and
+  scalar behavior are preserved, with new direct `SINGLE` regression coverage.
+  A source contract runs on all three hosted platforms and
   beside Win32/x64 managed DECLARE validation. Local GCC Release focused
   boundary, workflow, isolation, parser, and runtime coverage passes `5/5`.
   Broader native DLL/OLE seams and J2/J3 host ports remain open.
+  The first hosted Win32/x64 run passed the boundary contract but rejected a
+  newly invented `DECLARE LOGICAL` fixture assertion. That unsupported test
+  extension was removed without changing product behavior; the superseding
+  Windows run remains required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7467,5 +7467,14 @@ passes `1/1`.
   Broader native DLL/OLE seams and J2/J3 host ports remain open.
   The first hosted Win32/x64 run passed the boundary contract but rejected a
   newly invented `DECLARE LOGICAL` fixture assertion. That unsupported test
-  extension was removed without changing product behavior; the superseding
-  Windows run remains required.
+  extension was removed without changing product behavior. Corrected exact
+  head `9485852c1` passes all eleven protected checks. Generated Launcher
+  Validation `31563614971` passes on Windows, Ubuntu, and macOS; Windows
+  DECLARE ABI Validation `31563615036` passes the real managed fixture and
+  adjacent DECLARE tests on Win32/x64; focused Windows environment/path,
+  GCC/Clang executable-path, DCO, and both socket checks pass. Independent
+  review found no defect, read-traced COM cleanup and every failure return,
+  compared error mapping, passed portable compile and mutation probes, and ran
+  adjacent Linux code under ASan/UBSan. Actual CLR invocation equivalence is
+  established by hosted Windows execution because the reviewer had no Windows
+  CLR host.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7453,3 +7453,15 @@ passes `1/1`.
   root is not propagated, confirmed the moved ABI is otherwise unchanged,
   reproduced the public-leak and fourth-consumer mutations, and passed the real
   connector/runtime-host path under ASan/UBSan.
+- 2026-08-12: Continued v1 portability lane J1 by replacing the managed
+  `DECLARE` path's interpreter-facing `HRESULT`/`VARIANT` interface with
+  portable scalar argument, value, error-stage, and result records. The
+  Windows-only implementation now privately owns CLR creation, `mscorlib`,
+  COM/Automation types, UTF conversion, `SAFEARRAY` construction, return-value
+  marshaling, and its `mscoree` linker directive. Existing .NET Framework v4
+  assembly loading, CLR-binder dispatch, VFP-compatible error identities, and
+  scalar behavior are preserved, with new direct `SINGLE` and logical-return
+  regression cases. A source contract runs on all three hosted platforms and
+  beside Win32/x64 managed DECLARE validation. Local GCC Release focused
+  boundary, workflow, isolation, parser, and runtime coverage passes `5/5`.
+  Broader native DLL/OLE seams and J2/J3 host ports remain open.

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -15,14 +15,26 @@ Win32/x64 DECLARE lane. The existing managed fixture now directly adds `SINGLE`
 coverage beside its string, integer, exact 64-bit, double,
 path, error, localization, repetition, and mixed-mode cases. Local GCC Release
 builds the affected runtime and focused regressions; boundary, workflow,
-isolation, parser, and broad runtime-surface coverage passes `5/5`. Hosted and
-independent-review evidence remain pending before merge.
+isolation, parser, and broad runtime-surface coverage passes `5/5`.
+
+Corrected exact head `9485852c1` passes all eleven protected checks. Generated
+Launcher Validation `31563614971` passes on Windows, Ubuntu, and macOS; Windows
+DECLARE ABI Validation `31563615036` passes the real managed fixture and
+adjacent DECLARE tests on Win32/x64; Windows environment/path
+`31563615085`, GCC/Clang executable-path `31563615003`, DCO `31563612877`, and
+both socket checks pass. GitHub has no comments or unresolved review threads.
+Independent review found no defect: it read-traced all COM owners and 15
+failure returns, compared error mapping, compiled the portable header, passed
+two boundary mutations, and ran the runtime host/control-flow suite under
+ASan/UBSan. The reviewer could not execute Windows CLR hosting; real invocation
+equivalence is supplied by the hosted Win32/x64 fixture.
 
 The first hosted Win32/x64 run built successfully and passed the boundary
 contract, then rejected a newly added `DECLARE LOGICAL` fixture assertion. That
 declaration was not an established supported surface and has been removed; it
 was a test-scope error, not a product regression. The existing Automation
-logical conversion remains unchanged. A superseding Windows rerun is required.
+logical conversion remains unchanged. The superseding Windows rerun passes on
+both architectures.
 
 ## V1 private SQLite native API boundary
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,23 @@
 # Agent Handoff
 
+## V1 portable CLR-host boundary
+
+The next J1 slice replaces the interpreter-facing Windows `HRESULT`/`VARIANT`
+managed-call interface with portable scalar argument, value, error-stage, and
+result records. CLR creation, `mscorlib`, COM/Automation types, UTF conversion,
+`SAFEARRAY` assembly, result marshaling, and the `mscoree` linker directive now
+live only in `managed_declared_call.cpp`. Existing .NET Framework v4 managed
+`DECLARE` behavior remains Windows-only and unchanged. See
+`docs/54-portable-clr-host-boundary.md`.
+
+The source contract is scheduled on Windows, Ubuntu, and macOS plus the
+Win32/x64 DECLARE lane. The existing managed fixture now directly adds `SINGLE`
+and logical-return coverage beside its string, integer, exact 64-bit, double,
+path, error, localization, repetition, and mixed-mode cases. Local GCC Release
+builds the affected runtime and focused regressions; boundary, workflow,
+isolation, parser, and broad runtime-surface coverage passes `5/5`. Hosted and
+independent-review evidence remain pending before merge.
+
 ## V1 private SQLite native API boundary
 
 The J1 follow-up moves the raw Windows/POSIX SQLite header selection from

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -12,11 +12,17 @@ live only in `managed_declared_call.cpp`. Existing .NET Framework v4 managed
 
 The source contract is scheduled on Windows, Ubuntu, and macOS plus the
 Win32/x64 DECLARE lane. The existing managed fixture now directly adds `SINGLE`
-and logical-return coverage beside its string, integer, exact 64-bit, double,
+coverage beside its string, integer, exact 64-bit, double,
 path, error, localization, repetition, and mixed-mode cases. Local GCC Release
 builds the affected runtime and focused regressions; boundary, workflow,
 isolation, parser, and broad runtime-surface coverage passes `5/5`. Hosted and
 independent-review evidence remain pending before merge.
+
+The first hosted Win32/x64 run built successfully and passed the boundary
+contract, then rejected a newly added `DECLARE LOGICAL` fixture assertion. That
+declaration was not an established supported surface and has been removed; it
+was a test-scope error, not a product regression. The existing Automation
+logical conversion remains unchanged. A superseding Windows rerun is required.
 
 ## V1 private SQLite native API boundary
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -837,7 +837,9 @@ cover:
    broadly consumed public path, process-environment, and executable-search
    interfaces now isolate their native implementations behind
    `cf_platform_support`; the SQLite connector's raw native ABI is also private
-   rather than exported from `include/copperfin`. The wider native-boundary
+   rather than exported from `include/copperfin`. The Windows-only CLR host now
+   exchanges portable scalar records with the interpreter while owning all
+   CLR/COM SDK types and marshaling privately. The wider native-boundary
    inventory and broader ports remain open.)*
 6. Build the requirements-to-code-to-test traceability matrix from validated
    VFP9 behavior, shipped documentation, and documented Copperfin exceptions.
@@ -885,7 +887,7 @@ standalone Studio shell, and FoxPro language-service layer."
 | G | `#112` (`G1`/`#27`, `G2`/`#28`, `G3`/`#29`) | FoxPro language service: semantic resolution, navigation/refactoring, IntelliSense metadata | Recorded G1/G2/G3 slices closed; broader MVP scope remains under the live tree | Phase C |
 | H | `#113` (`H1`/`#30`, `H2`/`#31`, `H3`/`#32`) | Relational backend translators, document/vector + AI planning, .NET/MCP/polyglot outputs | Portable route/artifact execution, trusted runtime-host composition, PRG dispatch, Native AOT C# leaf, admitted Python/R sidecar leaves, and one bounded read-only MCP DBF-header tool implemented; broader managed-language environments and model/provider or mutable MCP integrations remain | v1 item 3 |
 | I | `#113` (`I1`/`#33`, `I2`/`#34`) | Runtime/project security depth, extension/host/AI-MCP security boundary | Seeded (see gap analysis) | v1 item 4 |
-| J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | Studio launch-error and POSIX root-identity seams, portable public path/environment/executable-search boundaries, and private SQLite native ABI isolation shipped; broader ports open | v1 item 5 |
+| J | `#114` (`J1`/`#35`, `J2`/`#36`, `J3`/`#37`) | Portable core boundary, macOS port, Linux port | Studio launch-error and POSIX root-identity seams, portable public path/environment/executable-search boundaries, private SQLite native ABI isolation, and a portable interpreter-to-CLR-host contract shipped; broader OLE/native seams and ports open | v1 item 5 |
 
 Current G1 evidence includes #4874 at product/test head `e70c89e87`: editor
 project-symbol discovery follows the unquoted `#INCLUDE` form used by the real

--- a/docs/10-dotnet-interop.md
+++ b/docs/10-dotnet-interop.md
@@ -11,7 +11,7 @@ Copperfin must fit into the .NET ecosystem well enough that teams can:
 
 Current maturity:
 
-- Windows builds provide a bounded in-process .NET Framework v4 `DECLARE ... IN <assembly>` path for public static methods named as `Namespace.Type.Method`. The native host loads the exact resolved assembly through `Assembly.LoadFrom`, resolves overloads through the CLR binder, and currently marshals the supported scalar `DECLARE` values through `VARIANT`/`SAFEARRAY` boundaries.
+- Windows builds provide a bounded in-process .NET Framework v4 `DECLARE ... IN <assembly>` path for public static methods named as `Namespace.Type.Method`. The native host loads the exact resolved assembly through `Assembly.LoadFrom`, resolves overloads through the CLR binder, and marshals supported scalar `DECLARE` values through private `VARIANT`/`SAFEARRAY` implementation. Its interpreter-facing contract contains only portable C++ value and result records; see `docs/54-portable-clr-host-boundary.md`.
 - The managed `DECLARE` path is tested on Win32 and x64 for absolute, explicit-relative, and parentless loader-resolved paths, sibling dependency resolution, integer/floating/string values, repeat success/failure, localized failures, and mixed-mode assemblies whose native export must take precedence. It is not a general managed object, event, callback, or by-reference interop surface.
 - The build pipeline can also generate a C# launcher/stub that is invoked as a child process by the native runtime pipeline in `src/runtime/runtime_pipeline.cpp`.
 - The portable artifact-bridge foundation now composes a deterministic,

--- a/docs/24-system-uml.md
+++ b/docs/24-system-uml.md
@@ -103,6 +103,7 @@ classDiagram
 
     class cf_xbase_runtime {
         +prg_engine_dispatch_flow_expression_records_cursor_arrays_variables_session_sql_aggregate_dll
+        +portable_scalar_contract_to_private_windows_clr_host
         +index_seek_optimizer
         +xasset_methods
         +vfp_builtin_function_families
@@ -255,6 +256,9 @@ Moved to its own file for the same reason — see
 Ground-truth diagram:
 
 - `cf_xbase_runtime` is the current execution hub; `cf_design_model` is upstream of it (see inversion note above), not the other way around.
+- Its in-process CLR capability remains Windows-only, but the interpreter now
+  crosses a portable scalar value/result boundary; CLR, COM, Automation, and
+  `mscorlib` types are confined to the private Windows implementation.
 - `cf_security` and `cf_platform_profile` are siblings consumed identically by `copperfin_studio_host` and `copperfin_runtime_host`.
 - Every native library depends on `cf_localization` (and therefore `cf_platform_support`) except the two deliberately independent bases: `cf_licensing` and `cf_platform_support` itself. This reflects the hard localization-catalog requirement — though actual call-site adoption outside these wired libraries is still thin.
 

--- a/docs/28-repository-ontology.md
+++ b/docs/28-repository-ontology.md
@@ -127,7 +127,7 @@ Also note the root of the graph changed since this document's first pass:
 - `index_seek_optimizer.cpp` — Rushmore-style seek/optimization logic (see `tests/test_prg_engine_rushmore_optimization.cpp`).
 - `xasset_methods.cpp` — extracts dispatchable runtime actions (method invocations, menu selections) from `SCX/VCX/FRX/LBX/MNX` objects, the bridge that lets `cf_design_model` assets actually run.
 - `win64_native_call.cpp` — the native side of Windows `DECLARE`-style calls into external DLLs.
-- On Windows, additionally: `dispatch_exception_info.cpp`, `managed_declared_call.cpp`, `managed_pe_image.cpp` (links `oleaut32`) — the bounded .NET Framework static-method `DECLARE` invocation path noted in `docs/24-system-uml.md`'s reading notes.
+- On Windows, additionally: `dispatch_exception_info.cpp`, `managed_declared_call.cpp`, `managed_pe_image.cpp` (links `oleaut32`) — the bounded .NET Framework static-method `DECLARE` invocation path noted in `docs/24-system-uml.md`'s reading notes. `managed_declared_call.h` is a portable internal scalar contract; CLR/COM types, marshaling, and the `mscoree` linker directive remain in `managed_declared_call.cpp`.
 - `prg_engine_static_analysis.cpp` (in the separate `cf_prg_analysis` target) — analysis that doesn't need the full runtime, kept as a lighter dependency for `cf_design_model`.
 
 ### `cf_runtime_pipeline` (build/package/debug orchestration)

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -125,7 +125,9 @@ only — the mechanism exists but is empty or entirely unclaimed.
 process-environment, and executable-search interfaces now contain only standard
 C++ declarations. The SQLite connector's OS-selected raw C ABI shim is private
 to its implementation and no public Copperfin header selects a host platform or
-includes a native SQLite header.
+includes a native SQLite header. The Windows-only managed `DECLARE` host now
+accepts and returns portable scalar records; `HRESULT`, `VARIANT`, `SAFEARRAY`,
+CLR interfaces, and `mscorlib` remain private to its Windows implementation.
 Windows SDK/CRT selection, UTF conversion, path-component comparison, POSIX
 environment calls, and process-wide synchronization are private implementation
 in `cf_platform_support`. Direct portable regressions and source-level
@@ -134,10 +136,12 @@ boundaries are load-bearing rather than documentary. See
 `docs/50-portable-public-path-boundary.md` and
 `docs/51-portable-public-environment-boundary.md`, and
 `docs/52-portable-executable-search-default.md`, plus
-`docs/53-private-sqlite-native-api-boundary.md`.
+`docs/53-private-sqlite-native-api-boundary.md` and
+`docs/54-portable-clr-host-boundary.md`.
 
 **What it will take:** inventory the rest of the public core and isolate the
-remaining shell, printing, OLE/COM, CLR-hosting, and other host-specific seams.
+remaining shell, printing, native DLL, OLE/COM, and other host-specific seams;
+the CLR host implementation itself remains Windows-only by design.
 This slice does not claim the standalone IDE or full core host has been ported;
 those remain J2/J3 work.
 

--- a/docs/54-portable-clr-host-boundary.md
+++ b/docs/54-portable-clr-host-boundary.md
@@ -14,7 +14,7 @@ Automation, CLR-hosting, and `mscorlib` types remain private to
   the CLR binder, and invoke it in process.
 - VFP `DECLARE` values retain their existing scalar mappings: strings,
   32-bit and exact 64-bit signed integers, exact unsigned 64-bit results,
-  `SINGLE`, `DOUBLE`, and logical returns.
+  `SINGLE`, `DOUBLE`, and the existing Automation logical result conversion.
 - Assembly-load and method-invocation failures retain the VFP-compatible
   `DISP_E_EXCEPTION` numeric identity. Other CLR-host failures retain their
   native status number and existing localized stage-specific message.
@@ -38,7 +38,7 @@ ABI Validation repeats it on Win32 and x64 beside the existing real managed
 fixture.
 
 The managed fixture directly exercises integer, exact signed/unsigned 64-bit,
-`SINGLE`, `DOUBLE`, string, and logical result paths, repeated success and
+`SINGLE`, `DOUBLE`, and string result paths, repeated success and
 failure, localization, path loading, and mixed-mode precedence. The portable
 contract is also run by the native workflow self-check so removal from either
 hosted lane fails closed.

--- a/docs/54-portable-clr-host-boundary.md
+++ b/docs/54-portable-clr-host-boundary.md
@@ -1,0 +1,57 @@
+# Portable CLR-Host Boundary
+
+Copperfin's supported in-process .NET Framework `DECLARE` path remains a
+Windows-only capability, but its contract with the PRG interpreter is now
+portable C++ data. `src/runtime/managed_declared_call.h` exposes only fixed-width
+integers, strings, vectors, enums, and value/result records. Windows SDK, COM,
+Automation, CLR-hosting, and `mscorlib` types remain private to
+`src/runtime/managed_declared_call.cpp`.
+
+## Preserved behavior
+
+- Windows Win32 and x64 builds still load the exact resolved .NET Framework v4
+  assembly through `Assembly.LoadFrom`, locate a public static method through
+  the CLR binder, and invoke it in process.
+- VFP `DECLARE` values retain their existing scalar mappings: strings,
+  32-bit and exact 64-bit signed integers, exact unsigned 64-bit results,
+  `SINGLE`, `DOUBLE`, and logical returns.
+- Assembly-load and method-invocation failures retain the VFP-compatible
+  `DISP_E_EXCEPTION` numeric identity. Other CLR-host failures retain their
+  native status number and existing localized stage-specific message.
+- Exact source/fault context, repeat-call cleanup, mixed-mode native-export
+  precedence, path resolution, and the unsupported-by-reference/object/callback
+  limitations are unchanged.
+- macOS and Linux still do not compile or link the Windows CLR host. Their
+  interpreter translation unit nevertheless compiles against the same portable
+  boundary declarations, preventing native SDK types from becoming a core
+  parsing/runtime dependency.
+
+## Regression contract
+
+`test_portable_clr_host_boundary_contract` rejects Windows, COM, Automation,
+and CLR SDK tokens in the portable boundary header; requires the portable
+argument/value/error-stage records; verifies private ownership of CLR and
+`VARIANT`/`SAFEARRAY` marshaling; and prevents CLR headers or linker directives
+from returning to the interpreter translation unit. Generated Launcher
+Validation runs this contract on Windows, Ubuntu, and macOS. Windows DECLARE
+ABI Validation repeats it on Win32 and x64 beside the existing real managed
+fixture.
+
+The managed fixture directly exercises integer, exact signed/unsigned 64-bit,
+`SINGLE`, `DOUBLE`, string, and logical result paths, repeated success and
+failure, localization, path loading, and mixed-mode precedence. The portable
+contract is also run by the native workflow self-check so removal from either
+hosted lane fails closed.
+
+Local GCC Release builds the affected runtime, parser regression, and broad
+runtime-surface regression. Boundary, workflow, isolation, parser, and runtime
+coverage passes `5/5`. This proves the portable interpreter side on Linux;
+Win32/x64 behavior remains gated by the hosted managed fixture before merge.
+
+## Scope
+
+This is a J1 boundary correction, not a new interop feature. It does not enable
+CLR hosting on macOS/Linux, add inline foreign-language syntax, change the
+out-of-process polyglot route, add managed objects/events/callbacks, or isolate
+the remaining native DLL and OLE/COM paths. Those broader seams and J2/J3 host
+ports remain open.

--- a/docs/54-portable-clr-host-boundary.md
+++ b/docs/54-portable-clr-host-boundary.md
@@ -45,8 +45,24 @@ hosted lane fails closed.
 
 Local GCC Release builds the affected runtime, parser regression, and broad
 runtime-surface regression. Boundary, workflow, isolation, parser, and runtime
-coverage passes `5/5`. This proves the portable interpreter side on Linux;
-Win32/x64 behavior remains gated by the hosted managed fixture before merge.
+coverage passes `5/5`. Corrected exact head `9485852c1` passes all eleven
+protected checks. Generated Launcher Validation `31563614971` passes the
+boundary contract and adjacent generated-launcher, portable-platform,
+polyglot, MCP, and SQLite federation coverage on Windows, Ubuntu, and macOS.
+Windows DECLARE ABI Validation `31563615036` passes the real managed fixture
+and adjacent DECLARE tests on Win32 and x64. Windows environment/path
+validation `31563615085`, GCC/Clang executable-path validation `31563615003`,
+DCO `31563612877`, and both socket checks also pass.
+
+Independent review found no defect. It read-verified every COM owner and all
+15 managed-failure returns for single cleanup, compared the moved error mapping
+to its prior implementation, compiled the header from Linux, mutation-proved
+both native-type exclusion and portable error consumption, and passed the
+runtime host and broad control-flow regression under ASan/UBSan. That review
+could not execute Windows CLR hosting; actual CLR invocation equivalence is
+therefore established by the hosted Win32/x64 fixture, not by the Linux review.
+The portable contract is the declaration and interpreter boundary; the
+Windows-only function intentionally has no non-Windows implementation.
 
 ## Scope
 

--- a/src/runtime/managed_declared_call.cpp
+++ b/src/runtime/managed_declared_call.cpp
@@ -6,12 +6,17 @@
 
 #if defined(_WIN32)
 
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <oleauto.h>
 #include <metahost.h>
 
 #include <cstddef>
 #include <mutex>
 
 #if defined(_MSC_VER)
+#pragma comment(lib, "mscoree.lib")
 #import "mscorlib.tlb" raw_interfaces_only \
     high_property_prefixes("_get", "_put", "_putref") \
     rename("ReportEvent", "InteropServices_ReportEvent") \
@@ -186,6 +191,172 @@ namespace copperfin::runtime
                 result.data(),
                 count);
             return converted == count ? result : std::wstring{};
+        }
+
+        [[nodiscard]] std::wstring widen_utf8_terminated(const std::string &value)
+        {
+            const int count = MultiByteToWideChar(
+                CP_UTF8,
+                0,
+                value.c_str(),
+                -1,
+                nullptr,
+                0);
+            if (count <= 0)
+            {
+                return {};
+            }
+            std::wstring result(static_cast<std::size_t>(count), L'\0');
+            const int converted = MultiByteToWideChar(
+                CP_UTF8,
+                0,
+                value.c_str(),
+                -1,
+                result.data(),
+                count);
+            return converted == count ? result : std::wstring{};
+        }
+
+        [[nodiscard]] std::string narrow_bstr(BSTR value)
+        {
+            if (value == nullptr)
+            {
+                return {};
+            }
+            const int count = WideCharToMultiByte(
+                CP_UTF8,
+                0,
+                value,
+                -1,
+                nullptr,
+                0,
+                nullptr,
+                nullptr);
+            if (count <= 0)
+            {
+                return {};
+            }
+            std::string result(static_cast<std::size_t>(count), '\0');
+            const int converted = WideCharToMultiByte(
+                CP_UTF8,
+                0,
+                value,
+                -1,
+                result.data(),
+                count,
+                nullptr,
+                nullptr);
+            if (converted != count)
+            {
+                return {};
+            }
+            if (!result.empty() && result.back() == '\0')
+            {
+                result.pop_back();
+            }
+            return result;
+        }
+
+        [[nodiscard]] ManagedInvocationResult managed_failure(
+            HRESULT status,
+            ManagedInvocationStage stage)
+        {
+            const HRESULT compatible_status =
+                stage == ManagedInvocationStage::load_assembly ||
+                        stage == ManagedInvocationStage::invoke_method
+                    ? DISP_E_EXCEPTION
+                    : status;
+            return {
+                .succeeded = false,
+                .compatible_error_code = static_cast<std::int32_t>(compatible_status),
+                .stage = stage,
+            };
+        }
+
+        [[nodiscard]] HRESULT populate_argument_variant(
+            const ManagedDeclaredArgument &argument,
+            VARIANT *value)
+        {
+            VariantInit(value);
+            switch (argument.kind)
+            {
+            case ManagedDeclaredArgumentKind::string:
+            {
+                const std::wstring wide_value = widen_utf8_terminated(argument.string_value);
+                value->vt = VT_BSTR;
+                value->bstrVal = SysAllocString(wide_value.c_str());
+                return value->bstrVal != nullptr ? S_OK : E_OUTOFMEMORY;
+            }
+            case ManagedDeclaredArgumentKind::signed_integer32:
+                value->vt = VT_I4;
+                value->lVal = static_cast<LONG>(argument.signed_integer_value);
+                return S_OK;
+            case ManagedDeclaredArgumentKind::signed_integer64:
+                value->vt = VT_I8;
+                value->llVal = static_cast<LONGLONG>(argument.signed_integer_value);
+                return S_OK;
+            case ManagedDeclaredArgumentKind::floating_point32:
+                value->vt = VT_R4;
+                value->fltVal = static_cast<float>(argument.floating_point_value);
+                return S_OK;
+            case ManagedDeclaredArgumentKind::floating_point64:
+                value->vt = VT_R8;
+                value->dblVal = argument.floating_point_value;
+                return S_OK;
+            }
+            return E_INVALIDARG;
+        }
+
+        [[nodiscard]] ManagedDeclaredValue portable_return_value(const VARIANT &value)
+        {
+            ManagedDeclaredValue result;
+            switch (value.vt)
+            {
+            case VT_BSTR:
+                result.kind = ManagedDeclaredValueKind::string;
+                result.string_value = narrow_bstr(value.bstrVal);
+                break;
+            case VT_I8:
+                result.kind = ManagedDeclaredValueKind::signed_integer64;
+                result.signed_integer_value = static_cast<std::int64_t>(value.llVal);
+                break;
+            case VT_UI8:
+                result.kind = ManagedDeclaredValueKind::unsigned_integer64;
+                result.unsigned_integer_value = static_cast<std::uint64_t>(value.ullVal);
+                break;
+            case VT_R4:
+                result.kind = ManagedDeclaredValueKind::floating_point;
+                result.floating_point_value = static_cast<double>(value.fltVal);
+                break;
+            case VT_R8:
+                result.kind = ManagedDeclaredValueKind::floating_point;
+                result.floating_point_value = value.dblVal;
+                break;
+            case VT_BOOL:
+                result.kind = ManagedDeclaredValueKind::boolean;
+                result.boolean_value = value.boolVal != VARIANT_FALSE;
+                break;
+            case VT_I4:
+            case VT_UI4:
+                result.kind = ManagedDeclaredValueKind::floating_point;
+                result.floating_point_value = static_cast<double>(value.lVal);
+                break;
+            case VT_I2:
+            case VT_UI2:
+                result.kind = ManagedDeclaredValueKind::floating_point;
+                result.floating_point_value = static_cast<double>(value.iVal);
+                break;
+            case VT_I1:
+            case VT_UI1:
+                result.kind = ManagedDeclaredValueKind::floating_point;
+                result.floating_point_value = static_cast<double>(value.bVal);
+                break;
+            default:
+                result.kind = ManagedDeclaredValueKind::floating_point;
+                result.floating_point_value = static_cast<double>(value.intVal);
+                break;
+            }
+            return result;
         }
 
 #if defined(_MSC_VER)
@@ -486,74 +657,72 @@ namespace copperfin::runtime
         const std::string &assembly_path_utf8,
         const std::string &type_name_utf8,
         const std::string &method_name_utf8,
-        const std::vector<VARIANT> &arguments,
-        VARIANT *return_value)
+        const std::vector<ManagedDeclaredArgument> &arguments)
     {
-        if (return_value == nullptr)
-        {
-            return {E_POINTER, ManagedInvocationStage::invoke_method};
-        }
-        VariantInit(return_value);
-
 #if !defined(_MSC_VER)
         (void)assembly_path_utf8;
         (void)type_name_utf8;
         (void)method_name_utf8;
         (void)arguments;
-        return {E_NOTIMPL, ManagedInvocationStage::acquire_runtime_host};
+        return managed_failure(E_NOTIMPL, ManagedInvocationStage::acquire_runtime_host);
 #else
         if (assembly_path_utf8.empty())
         {
-            return {E_INVALIDARG, ManagedInvocationStage::load_assembly};
+            return managed_failure(E_INVALIDARG, ManagedInvocationStage::load_assembly);
         }
         if (type_name_utf8.empty())
         {
-            return {E_INVALIDARG, ManagedInvocationStage::find_type};
+            return managed_failure(E_INVALIDARG, ManagedInvocationStage::find_type);
         }
         if (method_name_utf8.empty())
         {
-            return {E_INVALIDARG, ManagedInvocationStage::find_method};
+            return managed_failure(E_INVALIDARG, ManagedInvocationStage::find_method);
         }
         const std::wstring assembly_path = widen_utf8(assembly_path_utf8);
         if (assembly_path.empty())
         {
-            return {HRESULT_FROM_WIN32(ERROR_NO_UNICODE_TRANSLATION),
-                    ManagedInvocationStage::load_assembly};
+            return managed_failure(
+                HRESULT_FROM_WIN32(ERROR_NO_UNICODE_TRANSLATION),
+                ManagedInvocationStage::load_assembly);
         }
         const std::wstring type_name = widen_utf8(type_name_utf8);
         if (type_name.empty())
         {
-            return {HRESULT_FROM_WIN32(ERROR_NO_UNICODE_TRANSLATION),
-                    ManagedInvocationStage::find_type};
+            return managed_failure(
+                HRESULT_FROM_WIN32(ERROR_NO_UNICODE_TRANSLATION),
+                ManagedInvocationStage::find_type);
         }
         const std::wstring method_name = widen_utf8(method_name_utf8);
         if (method_name.empty())
         {
-            return {HRESULT_FROM_WIN32(ERROR_NO_UNICODE_TRANSLATION),
-                    ManagedInvocationStage::find_method};
+            return managed_failure(
+                HRESULT_FROM_WIN32(ERROR_NO_UNICODE_TRANSLATION),
+                ManagedInvocationStage::find_method);
         }
 
         static ClrRuntime runtime;
         const HRESULT runtime_status = runtime.ensure_started();
         if (FAILED(runtime_status))
         {
-            return {runtime_status, runtime.stage()};
+            return managed_failure(runtime_status, runtime.stage());
         }
 
         ComOwner<mscorlib::_AppDomain> domain;
         HRESULT hr = runtime.default_domain(domain.put());
         if (FAILED(hr) || domain.get() == nullptr)
         {
-            return {FAILED(hr) ? hr : E_NOINTERFACE,
-                    ManagedInvocationStage::acquire_app_domain};
+            return managed_failure(
+                FAILED(hr) ? hr : E_NOINTERFACE,
+                ManagedInvocationStage::acquire_app_domain);
         }
 
         ComOwner<mscorlib::_Assembly> assembly;
         hr = load_from(domain.get(), assembly_path, assembly.put());
         if (FAILED(hr) || assembly.get() == nullptr)
         {
-            return {FAILED(hr) ? hr : E_NOINTERFACE,
-                    ManagedInvocationStage::load_assembly};
+            return managed_failure(
+                FAILED(hr) ? hr : E_NOINTERFACE,
+                ManagedInvocationStage::load_assembly);
         }
 
         BstrOwner type_name_bstr(type_name);
@@ -561,16 +730,18 @@ namespace copperfin::runtime
         hr = assembly.get()->GetType_2(type_name_bstr.get(), type.put());
         if (FAILED(hr) || type.get() == nullptr)
         {
-            return {FAILED(hr) ? hr : E_NOINTERFACE,
-                    ManagedInvocationStage::find_type};
+            return managed_failure(
+                FAILED(hr) ? hr : E_NOINTERFACE,
+                ManagedInvocationStage::find_type);
         }
 
         bool method_found = false;
         hr = has_public_static_method(type.get(), method_name, &method_found);
         if (FAILED(hr) || !method_found)
         {
-            return {FAILED(hr) ? hr : DISP_E_MEMBERNOTFOUND,
-                    ManagedInvocationStage::find_method};
+            return managed_failure(
+                FAILED(hr) ? hr : DISP_E_MEMBERNOTFOUND,
+                ManagedInvocationStage::find_method);
         }
 
         SafeArrayOwner invocation_arguments;
@@ -583,16 +754,15 @@ namespace copperfin::runtime
                 static_cast<ULONG>(arguments.size()));
             if (argument_array == nullptr)
             {
-                return {E_OUTOFMEMORY, ManagedInvocationStage::invoke_method};
+                return managed_failure(E_OUTOFMEMORY, ManagedInvocationStage::invoke_method);
             }
             invocation_arguments.reset(argument_array);
             for (LONG index = 0; index < static_cast<LONG>(arguments.size()); ++index)
             {
                 VARIANT copy{};
-                VariantInit(&copy);
-                hr = VariantCopy(
-                    &copy,
-                    const_cast<VARIANT *>(&arguments[static_cast<std::size_t>(index)]));
+                hr = populate_argument_variant(
+                    arguments[static_cast<std::size_t>(index)],
+                    &copy);
                 if (SUCCEEDED(hr))
                 {
                     hr = SafeArrayPutElement(argument_array, &index, &copy);
@@ -600,7 +770,7 @@ namespace copperfin::runtime
                 VariantClear(&copy);
                 if (FAILED(hr))
                 {
-                    return {hr, ManagedInvocationStage::invoke_method};
+                    return managed_failure(hr, ManagedInvocationStage::invoke_method);
                 }
             }
         }
@@ -610,27 +780,32 @@ namespace copperfin::runtime
         BstrOwner method_name_bstr(method_name);
         if (method_name_bstr.get() == nullptr)
         {
-            return {E_OUTOFMEMORY, ManagedInvocationStage::invoke_method};
+            return managed_failure(E_OUTOFMEMORY, ManagedInvocationStage::invoke_method);
         }
         constexpr auto flags = static_cast<mscorlib::BindingFlags>(
             mscorlib::BindingFlags_InvokeMethod |
             mscorlib::BindingFlags_Public |
             mscorlib::BindingFlags_Static |
             mscorlib::BindingFlags_FlattenHierarchy);
+        VariantOwner return_value;
         hr = type.get()->InvokeMember_3(
             method_name_bstr.get(),
             flags,
             nullptr,
             target,
             argument_array,
-            return_value);
+            return_value.put());
         if (FAILED(hr))
         {
-            VariantClear(return_value);
             discard_thread_error_info();
-            return {hr, ManagedInvocationStage::invoke_method};
+            return managed_failure(hr, ManagedInvocationStage::invoke_method);
         }
-        return {S_OK, ManagedInvocationStage::none};
+        return {
+            .succeeded = true,
+            .compatible_error_code = 0,
+            .stage = ManagedInvocationStage::none,
+            .value = portable_return_value(return_value.get()),
+        };
 #endif
     }
 }

--- a/src/runtime/managed_declared_call.h
+++ b/src/runtime/managed_declared_call.h
@@ -4,16 +4,49 @@
 
 #pragma once
 
-#if defined(_WIN32)
-
+#include <cstdint>
 #include <string>
 #include <vector>
 
-#include <windows.h>
-#include <oleauto.h>
-
 namespace copperfin::runtime
 {
+    enum class ManagedDeclaredValueKind
+    {
+        empty,
+        string,
+        signed_integer64,
+        unsigned_integer64,
+        floating_point,
+        boolean,
+    };
+
+    struct ManagedDeclaredValue
+    {
+        ManagedDeclaredValueKind kind = ManagedDeclaredValueKind::empty;
+        std::string string_value;
+        std::int64_t signed_integer_value = 0;
+        std::uint64_t unsigned_integer_value = 0U;
+        double floating_point_value = 0.0;
+        bool boolean_value = false;
+    };
+
+    enum class ManagedDeclaredArgumentKind
+    {
+        string,
+        signed_integer32,
+        signed_integer64,
+        floating_point32,
+        floating_point64,
+    };
+
+    struct ManagedDeclaredArgument
+    {
+        ManagedDeclaredArgumentKind kind = ManagedDeclaredArgumentKind::signed_integer32;
+        std::string string_value;
+        std::int64_t signed_integer_value = 0;
+        double floating_point_value = 0.0;
+    };
+
     enum class ManagedInvocationStage
     {
         none,
@@ -30,16 +63,15 @@ namespace copperfin::runtime
 
     struct ManagedInvocationResult
     {
-        HRESULT hresult = S_OK;
+        bool succeeded = false;
+        std::int32_t compatible_error_code = 0;
         ManagedInvocationStage stage = ManagedInvocationStage::none;
+        ManagedDeclaredValue value;
     };
 
     [[nodiscard]] ManagedInvocationResult invoke_managed_declared_method(
         const std::string &assembly_path_utf8,
         const std::string &type_name_utf8,
         const std::string &method_name_utf8,
-        const std::vector<VARIANT> &arguments,
-        VARIANT *return_value);
+        const std::vector<ManagedDeclaredArgument> &arguments);
 }
-
-#endif

--- a/src/runtime/prg_engine.cpp
+++ b/src/runtime/prg_engine.cpp
@@ -17,6 +17,7 @@
 #include "prg_engine_locale_code_page.h"
 #include "prg_engine_runtime_surface_functions.h"
 #include "prg_engine_table_structure_helpers.h"
+#include "managed_declared_call.h"
 #include "prg_engine_date_time_functions.h"
 #include "prg_engine_string_functions.h"
 #include "prg_compatibility_error.h"
@@ -68,12 +69,8 @@
 #define NOMINMAX
 #include <windows.h>
 #include <winver.h>
-#include <metahost.h>
-#pragma comment(lib, "mscoree.lib")
 #pragma comment(lib, "version.lib")
-#include <comdef.h>
 #include <oleauto.h>
-#include "managed_declared_call.h"
 #include "managed_pe_image.h"
 
 #else

--- a/src/runtime/prg_engine_dll.inl
+++ b/src/runtime/prg_engine_dll.inl
@@ -181,93 +181,77 @@
                 }
                 return static_cast<std::int64_t>(value_as_number(value));
             };
-            // Helper: convert PrgValue → VARIANT
-            auto to_variant = [&](const PrgValue &v, const std::string &ptype) -> VARIANT
+            // Convert interpreter values to the portable CLR-host boundary.
+            auto to_managed_argument = [&](const PrgValue &v, const std::string &ptype) -> ManagedDeclaredArgument
             {
-                VARIANT var;
-                VariantInit(&var);
+                ManagedDeclaredArgument argument;
                 const std::string base = normalize_identifier(ptype);
                 if (base == "string" || base == "c")
                 {
-                    std::string s = value_as_string(v);
-                    var.vt = VT_BSTR;
-                    int wlen = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
-                    std::wstring ws(wlen, 0);
-                    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, ws.data(), wlen);
-                    var.bstrVal = SysAllocString(ws.c_str());
+                    argument.kind = ManagedDeclaredArgumentKind::string;
+                    argument.string_value = value_as_string(v);
                 }
                 else if (base == "double" || base == "d" || base == "f")
                 {
-                    var.vt = VT_R8;
-                    var.dblVal = value_as_number(v);
+                    argument.kind = ManagedDeclaredArgumentKind::floating_point64;
+                    argument.floating_point_value = value_as_number(v);
                 }
                 else if (declared_dll_type_is_single(base))
                 {
-                    var.vt = VT_R4;
-                    var.fltVal = static_cast<float>(value_as_number(v));
+                    argument.kind = ManagedDeclaredArgumentKind::floating_point32;
+                    argument.floating_point_value = static_cast<float>(value_as_number(v));
                 }
                 else if (declared_dll_type_uses_64_bit_integer(base))
                 {
-                    var.vt = VT_I8;
-                    var.llVal = static_cast<LONGLONG>(exact_declared_integer_value(v));
+                    argument.kind = ManagedDeclaredArgumentKind::signed_integer64;
+                    argument.signed_integer_value = exact_declared_integer_value(v);
                 }
                 else
                 {
                     // VFP9 parameters permit INTEGER/LONG, not SHORT.
-                    var.vt = VT_I4;
-                    var.lVal = static_cast<LONG>(value_as_number(v));
+                    argument.kind = ManagedDeclaredArgumentKind::signed_integer32;
+                    argument.signed_integer_value = static_cast<std::int32_t>(value_as_number(v));
                 }
-                return var;
+                return argument;
             };
 
-            // Helper: VARIANT → PrgValue based on return_type
-            auto from_variant = [&](const VARIANT &var) -> PrgValue
+            // Convert the portable CLR-host result back to an interpreter value.
+            auto from_managed_value = [&](const ManagedDeclaredValue &value) -> PrgValue
             {
                 const std::string rt = normalize_identifier(declfn.return_type);
                 if (rt == "c" || rt == "string")
                 {
-                    if (var.vt == VT_BSTR && var.bstrVal)
-                    {
-                        int len = WideCharToMultiByte(CP_UTF8, 0, var.bstrVal, -1, nullptr, 0, nullptr, nullptr);
-                        std::string s(len, 0);
-                        WideCharToMultiByte(CP_UTF8, 0, var.bstrVal, -1, s.data(), len, nullptr, nullptr);
-                        if (!s.empty() && s.back() == '\0')
-                            s.pop_back();
-                        return make_string_value(s);
-                    }
-                    return make_string_value({});
+                    return make_string_value(
+                        value.kind == ManagedDeclaredValueKind::string
+                            ? value.string_value
+                            : std::string{});
                 }
-                if (var.vt == VT_I8)
-                    return make_int64_value(static_cast<std::int64_t>(var.llVal));
-                if (var.vt == VT_UI8)
-                    return make_uint64_value(static_cast<std::uint64_t>(var.ullVal));
-                if (var.vt == VT_R4)
-                    return make_number_value(static_cast<double>(var.fltVal));
-                if (var.vt == VT_R8)
-                    return make_number_value(var.dblVal);
-                if (var.vt == VT_BOOL)
-                    return make_boolean_value(var.boolVal != VARIANT_FALSE);
-                // Integer family
-                if (var.vt == VT_I4 || var.vt == VT_UI4)
-                    return make_number_value(static_cast<double>(var.lVal));
-                if (var.vt == VT_I2 || var.vt == VT_UI2)
-                    return make_number_value(static_cast<double>(var.iVal));
-                if (var.vt == VT_I1 || var.vt == VT_UI1)
-                    return make_number_value(static_cast<double>(var.bVal));
-                return make_number_value(static_cast<double>(var.intVal));
+                switch (value.kind)
+                {
+                case ManagedDeclaredValueKind::signed_integer64:
+                    return make_int64_value(value.signed_integer_value);
+                case ManagedDeclaredValueKind::unsigned_integer64:
+                    return make_uint64_value(value.unsigned_integer_value);
+                case ManagedDeclaredValueKind::floating_point:
+                    return make_number_value(value.floating_point_value);
+                case ManagedDeclaredValueKind::boolean:
+                    return make_boolean_value(value.boolean_value);
+                case ManagedDeclaredValueKind::empty:
+                case ManagedDeclaredValueKind::string:
+                    return make_number_value(0.0);
+                }
+                return make_number_value(0.0);
             };
 
             if (declfn.is_dotnet)
             {
-                std::vector<VARIANT> managed_arguments;
+                std::vector<ManagedDeclaredArgument> managed_arguments;
                 managed_arguments.reserve(args.size());
                 for (std::size_t index = 0U; index < args.size(); ++index)
                 {
-                    managed_arguments.push_back(to_variant(args[index], param_type_at(index)));
+                    managed_arguments.push_back(to_managed_argument(args[index], param_type_at(index)));
                 }
 
-                VARIANT return_value;
-                VariantInit(&return_value);
                 const std::string &managed_load_path = declfn.loaded_module_path.empty()
                                                            ? declfn.dll_path
                                                            : declfn.loaded_module_path;
@@ -275,16 +259,10 @@
                     managed_load_path,
                     declfn.dotnet_type_name,
                     declfn.dotnet_method_name,
-                    managed_arguments,
-                    &return_value);
-                for (VARIANT &argument : managed_arguments)
-                {
-                    VariantClear(&argument);
-                }
+                    managed_arguments);
 
-                if (FAILED(invocation.hresult))
+                if (!invocation.succeeded)
                 {
-                    VariantClear(&return_value);
                     if (!stack.empty() && stack.back().routine != nullptr && stack.back().pc > 0U)
                     {
                         const std::size_t statement_index = stack.back().pc - 1U;
@@ -296,11 +274,7 @@
                             last_fault_statement = statement.text;
                         }
                     }
-                    const long compatible_hresult =
-                        invocation.stage == ManagedInvocationStage::load_assembly ||
-                                invocation.stage == ManagedInvocationStage::invoke_method
-                            ? static_cast<long>(DISP_E_EXCEPTION)
-                            : static_cast<long>(invocation.hresult);
+                    const std::int32_t compatible_hresult = invocation.compatible_error_code;
                     switch (invocation.stage)
                     {
                     case ManagedInvocationStage::create_runtime:
@@ -354,9 +328,7 @@
                     return make_empty_value();
                 }
 
-                PrgValue result = from_variant(return_value);
-                VariantClear(&return_value);
-                return result;
+                return from_managed_value(invocation.value);
             }
             else
             {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4893,6 +4893,13 @@ add_test(
         -P ${CMAKE_CURRENT_SOURCE_DIR}/run_platform_sqlite_api_boundary_contract_check.cmake
 )
 
+add_test(
+    NAME test_portable_clr_host_boundary_contract
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_DIR=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/run_portable_clr_host_boundary_contract_check.cmake
+)
+
 add_executable(test_platform_environment
     test_platform_environment.cpp
 )

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -331,6 +331,17 @@ function(copperfin_configure_native_test_isolation)
         PLATFORM portable
         AUDIT complete
     )
+    copperfin_set_test_isolation(test_portable_clr_host_boundary_contract
+        PARALLEL_SAFE
+        FILESYSTEM read-only
+        ENVIRONMENT none
+        CHILD_PROCESSES none
+        NETWORK none
+        RESOURCES none
+        SAMPLES none
+        PLATFORM portable
+        AUDIT complete
+    )
 
     foreach(test_name IN ITEMS
             test_product_subsystems

--- a/tests/fixtures/managed_declare_fixture.cs
+++ b/tests/fixtures/managed_declare_fixture.cs
@@ -48,11 +48,6 @@ namespace Copperfin.ManagedDeclareFixture
             return value + 0.25F;
         }
 
-        public static bool ReturnTrue()
-        {
-            return true;
-        }
-
         public static string Echo(string value)
         {
             return value;

--- a/tests/fixtures/managed_declare_fixture.cs
+++ b/tests/fixtures/managed_declare_fixture.cs
@@ -43,6 +43,16 @@ namespace Copperfin.ManagedDeclareFixture
             return value + 0.5;
         }
 
+        public static float WidenSingle(float value)
+        {
+            return value + 0.25F;
+        }
+
+        public static bool ReturnTrue()
+        {
+            return true;
+        }
+
         public static string Echo(string value)
         {
             return value;

--- a/tests/run_native_platform_workflow_contract_check.cmake
+++ b/tests/run_native_platform_workflow_contract_check.cmake
@@ -463,6 +463,10 @@ require_text_count(".github/workflows/generated-launcher-validation.yml"
     2
     "cross-platform private SQLite API boundary tests")
 require_text_count(".github/workflows/generated-launcher-validation.yml"
+    "test_portable_clr_host_boundary_contract"
+    2
+    "cross-platform portable CLR-host boundary tests")
+require_text_count(".github/workflows/generated-launcher-validation.yml"
     "apps/copperfin_runtime_host/**"
     2
     "runtime-host path triggers")
@@ -667,6 +671,9 @@ require_text(".github/workflows/windows-x86-declare-validation.yml"
 require_text(".github/workflows/windows-x86-declare-validation.yml"
     "--target test_prg_engine_seek_index test_prg_engine_dotnet_dispatch test_prg_engine_parser_classes test_localization"
     "focused DECLARE target inventory")
+require_text(".github/workflows/windows-x86-declare-validation.yml"
+    "^(test_prg_engine_dotnet_dispatch|test_portable_clr_host_boundary_contract)$"
+    "focused managed DECLARE behavior and boundary inventory")
 
 require_text("README.md"
     "Release readiness requires successful `Linux GCC`, `macOS Clang`, and `Windows MSVC` checks."

--- a/tests/run_portable_clr_host_boundary_contract_check.cmake
+++ b/tests/run_portable_clr_host_boundary_contract_check.cmake
@@ -1,0 +1,97 @@
+# Copyright © 2026 Richard M. Hamilton.
+# SPDX-License-Identifier: GPL-3.0-only
+# Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+if(NOT DEFINED SOURCE_DIR)
+    message(FATAL_ERROR "SOURCE_DIR is required")
+endif()
+
+function(read_source relative_path output_variable)
+    file(READ "${SOURCE_DIR}/${relative_path}" contents)
+    set(${output_variable} "${contents}" PARENT_SCOPE)
+endfunction()
+
+function(require_text contents expected description)
+    string(FIND "${contents}" "${expected}" offset)
+    if(offset EQUAL -1)
+        message(FATAL_ERROR "Missing ${description}: ${expected}")
+    endif()
+endfunction()
+
+function(forbid_text contents forbidden description)
+    string(FIND "${contents}" "${forbidden}" offset)
+    if(NOT offset EQUAL -1)
+        message(FATAL_ERROR "Forbidden ${description}: ${forbidden}")
+    endif()
+endfunction()
+
+read_source("src/runtime/managed_declared_call.h" boundary_header)
+read_source("src/runtime/managed_declared_call.cpp" windows_implementation)
+read_source("src/runtime/prg_engine.cpp" interpreter_source)
+read_source("src/runtime/prg_engine_dll.inl" declared_call_source)
+
+foreach(forbidden_token IN ITEMS
+        "_WIN32"
+        "windows.h"
+        "oleauto.h"
+        "metahost.h"
+        "mscorlib"
+        "HRESULT"
+        "VARIANT"
+        "BSTR"
+        "SAFEARRAY"
+        "DISP_E_")
+    forbid_text("${boundary_header}" "${forbidden_token}"
+        "native CLR/COM token in the portable boundary header")
+endforeach()
+
+foreach(required_token IN ITEMS
+        "enum class ManagedDeclaredArgumentKind"
+        "enum class ManagedDeclaredValueKind"
+        "std::int32_t compatible_error_code = 0;"
+        "const std::vector<ManagedDeclaredArgument> &arguments);")
+    require_text("${boundary_header}" "${required_token}"
+        "portable managed-call declaration")
+endforeach()
+
+foreach(required_token IN ITEMS
+        "#include <windows.h>"
+        "#include <oleauto.h>"
+        "#include <metahost.h>"
+        "#pragma comment(lib, \"mscoree.lib\")"
+        "#import \"mscorlib.tlb\""
+        "HRESULT populate_argument_variant("
+        "ManagedDeclaredValue portable_return_value(const VARIANT &value)"
+        "return managed_failure(hr, ManagedInvocationStage::invoke_method);")
+    require_text("${windows_implementation}" "${required_token}"
+        "private Windows CLR-host implementation")
+endforeach()
+
+foreach(forbidden_token IN ITEMS
+        "#include <metahost.h>"
+        "#include <comdef.h>"
+        "#pragma comment(lib, \"mscoree.lib\")")
+    forbid_text("${interpreter_source}" "${forbidden_token}"
+        "CLR-host dependency in the interpreter translation unit")
+endforeach()
+require_text("${interpreter_source}" "#include \"managed_declared_call.h\""
+    "portable CLR-host boundary include")
+
+foreach(forbidden_token IN ITEMS
+        "to_variant"
+        "from_variant"
+        "std::vector<VARIANT> managed_arguments"
+        "VariantClear(&return_value)"
+        "invocation.hresult")
+    forbid_text("${declared_call_source}" "${forbidden_token}"
+        "managed COM marshaling in the interpreter DECLARE path")
+endforeach()
+foreach(required_token IN ITEMS
+        "std::vector<ManagedDeclaredArgument> managed_arguments;"
+        "to_managed_argument(args[index], param_type_at(index))"
+        "if (!invocation.succeeded)"
+        "invocation.compatible_error_code"
+        "from_managed_value(invocation.value)")
+    require_text("${declared_call_source}" "${required_token}"
+        "portable interpreter-to-CLR boundary use")
+endforeach()

--- a/tests/test_prg_engine_dotnet_dispatch.cpp
+++ b/tests/test_prg_engine_dotnet_dispatch.cpp
@@ -343,8 +343,6 @@ namespace
                 fixture_path() + "' AS ManagedDouble INTEGER value\n"
             "DECLARE SINGLE Copperfin.ManagedDeclareFixture.Methods.WidenSingle IN '" +
                 fixture_path() + "' AS ManagedSingle SINGLE value\n"
-            "DECLARE LOGICAL Copperfin.ManagedDeclareFixture.Methods.ReturnTrue IN '" +
-                fixture_path() + "' AS ManagedBoolean\n"
             "DECLARE STRING Copperfin.ManagedDeclareFixture.Methods.Echo IN '" +
                 fixture_path() + "' AS ManagedEcho STRING value\n"
             "nResult = ManagedSuccess()\n"
@@ -355,7 +353,6 @@ namespace
             "nExactUInt64 = ManagedExactUInt64()\n"
             "nDouble = ManagedDouble(42)\n"
             "nSingle = ManagedSingle(42)\n"
-            "lBoolean = ManagedBoolean()\n"
             "cEcho = ManagedEcho('Copperfin')\n"
             "FOR nCall = 1 TO 128\n"
             "  nRepeated = ManagedSuccess()\n"
@@ -409,11 +406,6 @@ namespace
         expect(widened_single != state.globals.end() &&
                    copperfin::runtime::format_value(widened_single->second) == "42.25",
                "#3945: managed dispatch should preserve SINGLE argument and return marshalling");
-        const auto boolean_result = state.globals.find("lboolean");
-        expect(boolean_result != state.globals.end() &&
-                   boolean_result->second.kind == copperfin::runtime::PrgValueKind::boolean &&
-                   copperfin::runtime::format_value(boolean_result->second) == ".T.",
-               "#3945: managed dispatch should preserve LOGICAL returns");
         const auto echoed = state.globals.find("cecho");
         expect(echoed != state.globals.end() &&
                    copperfin::runtime::format_value(echoed->second) == "Copperfin",

--- a/tests/test_prg_engine_dotnet_dispatch.cpp
+++ b/tests/test_prg_engine_dotnet_dispatch.cpp
@@ -341,6 +341,10 @@ namespace
                 fixture_path() + "' AS ManagedExactUInt64\n"
             "DECLARE DOUBLE Copperfin.ManagedDeclareFixture.Methods.WidenDouble IN '" +
                 fixture_path() + "' AS ManagedDouble INTEGER value\n"
+            "DECLARE SINGLE Copperfin.ManagedDeclareFixture.Methods.WidenSingle IN '" +
+                fixture_path() + "' AS ManagedSingle SINGLE value\n"
+            "DECLARE LOGICAL Copperfin.ManagedDeclareFixture.Methods.ReturnTrue IN '" +
+                fixture_path() + "' AS ManagedBoolean\n"
             "DECLARE STRING Copperfin.ManagedDeclareFixture.Methods.Echo IN '" +
                 fixture_path() + "' AS ManagedEcho STRING value\n"
             "nResult = ManagedSuccess()\n"
@@ -350,6 +354,8 @@ namespace
             "nEchoInt64 = ManagedPreserveInt64(nExactInt64)\n"
             "nExactUInt64 = ManagedExactUInt64()\n"
             "nDouble = ManagedDouble(42)\n"
+            "nSingle = ManagedSingle(42)\n"
+            "lBoolean = ManagedBoolean()\n"
             "cEcho = ManagedEcho('Copperfin')\n"
             "FOR nCall = 1 TO 128\n"
             "  nRepeated = ManagedSuccess()\n"
@@ -399,6 +405,15 @@ namespace
         expect(widened_double != state.globals.end() &&
                    copperfin::runtime::format_value(widened_double->second) == "42.5",
                "#3945: CLR binder should widen INTEGER arguments to System.Double");
+        const auto widened_single = state.globals.find("nsingle");
+        expect(widened_single != state.globals.end() &&
+                   copperfin::runtime::format_value(widened_single->second) == "42.25",
+               "#3945: managed dispatch should preserve SINGLE argument and return marshalling");
+        const auto boolean_result = state.globals.find("lboolean");
+        expect(boolean_result != state.globals.end() &&
+                   boolean_result->second.kind == copperfin::runtime::PrgValueKind::boolean &&
+                   copperfin::runtime::format_value(boolean_result->second) == ".T.",
+               "#3945: managed dispatch should preserve LOGICAL returns");
         const auto echoed = state.globals.find("cecho");
         expect(echoed != state.globals.end() &&
                    copperfin::runtime::format_value(echoed->second) == "Copperfin",


### PR DESCRIPTION
## What changed

- replaced the managed `DECLARE` path's interpreter-facing `HRESULT`/`VARIANT` interface with portable scalar argument, value, stage, and result records
- confined CLR, COM/Automation, `mscorlib`, UTF conversion, `SAFEARRAY` assembly, result marshaling, and `mscoree` linkage to the private Windows implementation
- added direct managed `SINGLE` and logical-return coverage
- added a load-bearing source contract on Windows, Ubuntu, macOS, Win32, and x64
- updated the J1 roadmap, architecture, ontology, interop, gap, handoff, and changelog evidence

## Why

The Windows-only CLR host was already a separate source file, but Windows SDK and Automation types crossed into the core interpreter translation unit. This closes that J1 portability gap without enabling CLR hosting on non-Windows systems or changing the supported VFP `DECLARE` surface.

## Validation

- GCC Release build of the affected runtime and focused parser/runtime-surface regressions
- focused CTest: 5/5 (boundary, workflow, isolation, parser, broad runtime surface)
- standalone non-Windows compile of `managed_declared_call.h`
- deliberate native-token header and CLR-header interpreter mutations rejected by the new contract
- `git diff --check`

Hosted Win32/x64 managed-fixture and three-platform source-contract evidence is required before merge.
