### PR TITLE
Cover APRINTERS resolver invalid-CWD guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7548,6 +7548,16 @@ passes `1/1`.
   declaration. GCC Release focused regressions pass `4/4`; Clang ASan/UBSan
   coverage of the affected runtime and boundary/isolation contracts passes
   `3/3` with no findings.
+- 2026-08-12: Added the missing second invalid-working-directory APRINTERS
+  regression identified by independent review. The POSIX test now uses a
+  leading empty `PATH` segment while its current directory is deleted, directly
+  proving that executable resolution's throwing current-directory lookup is
+  caught and returns no queues. The source contract separately requires that
+  resolver guard and the non-throwing later working-directory query. GCC
+  Release and Clang ASan/UBSan each pass the focused runtime/boundary/workflow
+  set `4/4`; removing only the resolver guard makes the runtime regression
+  abort at the expected uncaught `filesystem_error`, then restoration returns
+  the suite to green.
 - 2026-08-12: Continued v1 portability lane J1 by replacing APRINTERS' `_popen`/
   `popen` command-shell discovery with a portable printer API. Windows now uses
   private Unicode spooler enumeration; POSIX resolves `lpstat` and invokes it

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -2,6 +2,16 @@
 
 ## V1 APRINTERS shell/printing boundary
 
+Independent post-merge review of #4963 found no product defect but identified
+that its invalid-CWD regression covered only the later non-throwing
+working-directory query. The follow-up regression now also uses a leading empty
+POSIX `PATH` segment with a deleted CWD, directly exercising the earlier
+executable-resolver exception guard; the source contract requires both guards.
+GCC Release and Clang ASan/UBSan each pass the focused runtime, printer-boundary,
+and two workflow-contract tests `4/4`. A direct mutation removing only the
+resolver guard makes the runtime test abort at the expected uncaught
+`filesystem_error`; restoration returns the worktree and suite to clean/green.
+
 Review follow-up keeps UTF-8 printer-name bytes stable by limiting
 case-insensitive deduplication to ASCII, fails closed when POSIX discovery
 cannot obtain a valid process working directory, and removes duplicate

--- a/docs/57-portable-printer-shell-boundary.md
+++ b/docs/57-portable-printer-shell-boundary.md
@@ -15,8 +15,10 @@ is used. An unavailable printer service produces the established deterministic
 
 Queue deduplication folds ASCII letters only, preserving every non-ASCII UTF-8
 byte and avoiding locale-sensitive keys. POSIX discovery also uses a
-non-throwing working-directory query and returns no queues when the process has
-an invalid working directory, preserving APRINTERS' fail-closed behavior.
+non-throwing working-directory query and catches filesystem failures from
+executable resolution. It returns no queues when the process has an invalid
+working directory, including when an empty `PATH` segment requires resolving
+the current directory, preserving APRINTERS' fail-closed behavior.
 
 `RuntimeSessionOptions::printer_enumeration_callback` lets an embedding host
 provide printer names without exposing platform mechanics and makes the PRG

--- a/tests/run_printer_shell_boundary_contract_check.cmake
+++ b/tests/run_printer_shell_boundary_contract_check.cmake
@@ -37,6 +37,7 @@ foreach(token IN ITEMS "popen(" "_popen(" "pclose(" "_pclose(" "std::system(" " 
 endforeach()
 forbid_text("${platform_source}" "std::tolower(" "locale-sensitive printer-name folding")
 require_text("${platform_source}" "character >= 'A' && character <= 'Z'" "locale-independent ASCII printer-name fold")
+require_text("${platform_source}" "catch (const fs::filesystem_error&)" "fail-closed executable resolution")
 require_text("${platform_source}" "fs::current_path(working_directory_error)" "non-throwing printer working-directory query")
 require_text("${runtime_source}" "copperfin::platform::enumerate_printer_names();" "runtime portable printer use")
 require_text("${root_build}" "src/platform/printer.cpp" "printer build source")

--- a/tests/test_prg_engine_arrays.cpp
+++ b/tests/test_prg_engine_arrays.cpp
@@ -1453,6 +1453,16 @@ void test_platform_printer_enumeration_uses_direct_host_boundary() {
     fs::current_path(original_directory);
     expect(missing_working_directory_names.empty(),
         "POSIX printer discovery should fail closed when the process working directory is invalid");
+
+    scoped_path.set(std::string(":") + fake_bin.string());
+    fs::create_directories(removed_directory);
+    fs::current_path(removed_directory);
+    fs::remove(removed_directory, ignored);
+    const std::vector<std::string> missing_resolver_working_directory_names =
+        copperfin::platform::enumerate_printer_names();
+    fs::current_path(original_directory);
+    expect(missing_resolver_working_directory_names.empty(),
+        "POSIX printer discovery should fail closed when an empty PATH segment requires an invalid working directory");
     fs::remove_all(temp_root, ignored);
 #else
     expect(std::all_of(names.begin(), names.end(), [](const std::string& name) { return !name.empty(); }),


### PR DESCRIPTION
Post-merge regression follow-up to #4963 based on independent review evidence.

What changed:
- exercise the distinct executable-resolution failure path with a leading empty POSIX `PATH` segment and a deleted current directory
- require the resolver exception guard separately from the later non-throwing working-directory query
- document both fail-closed paths and record the evidence

Impact:
- no product or machine-contract bytes change
- the already-shipped fail-closed behavior gains direct permanent regression coverage

Validation:
- clean GCC Release focused runtime/boundary/workflow set: 4/4
- Clang ASan/UBSan focused set: 4/4, no findings
- mutation removing only the resolver guard: runtime test aborts at the expected uncaught `filesystem_error`; restoration returns 4/4 green

Issue #35 remains open for broader J1/J2/J3 scope.

Signed-off-by: Rich Hamilton <51587867+rhamenator@users.noreply.github.com>