### PR TITLE
Audit file-version boundary test isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+- 2026-08-12: Corrected the v1 native isolation inventory after independent
+  review found that `test_platform_file_version_boundary_contract` fell
+  through to the fail-closed `audit=pending` default. A fresh configure
+  reproduced the resulting `test_native_test_isolation_contract` failure.
+  The file-version source contract is now explicitly classified as portable,
+  read-only, child-process-free, resource-free, and parallel-safe, matching
+  the adjacent platform-boundary checks. No product, VFP9, package, debug,
+  localization, or machine contract changes.
+
 - 2026-08-12: Continued v1 portability lane J1 by moving
   `AGETFILEVERSION()` metadata extraction out of the PRG interpreter and behind
   a standard-C++ platform record. Windows version-resource APIs, native

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,21 @@
 # Agent Handoff
 
+## V1 file-version isolation audit correction
+
+Independent review of the merged portable `AGETFILEVERSION()` boundary found
+that its new source-contract test was not explicitly classified in
+`tests/CopperfinTestIsolation.cmake`. A fresh configure at the merged v1 head
+reproduced the consequence: `test_native_test_isolation_contract` failed only
+because `test_platform_file_version_boundary_contract` retained the
+fail-closed `audit=pending` and unverified default axes.
+
+The correction classifies that source-only CMake test as portable, read-only,
+free of environment changes, child processes, network, samples, and shared
+resources, and parallel-safe with `audit=complete`, matching the neighboring
+platform-boundary contracts. No product or test behavior changes. Reconfigure
+before validation because the generated isolation inventory records both the
+classification-source digest and resolved labels.
+
 ## V1 portable AGETFILEVERSION boundary
 
 The current J1 slice moves `AGETFILEVERSION()` host metadata extraction behind

--- a/docs/58-portable-file-version-boundary.md
+++ b/docs/58-portable-file-version-boundary.md
@@ -31,7 +31,9 @@ behavior. `test_platform_file_version_boundary_contract` rejects native
 version-resource ownership in the public header or interpreter, requires the
 private Windows and POSIX implementations, preserves private `version` library
 linkage, and requires all three generated-launcher hosts to schedule the
-contract.
+contract. Its source-only CMake read is explicitly classified as portable,
+read-only, child-process-free, resource-free, and parallel-safe in the native
+test-isolation inventory.
 
 The focused GCC Release selection passes `5/5`: the new boundary, existing path
 boundary, AGETFILEVERSION behavior, GitHub Actions workflow contract, and native
@@ -39,8 +41,14 @@ platform workflow contract. Deliberately restoring a `GetFileVersionInfo`
 token to the interpreter and separately breaking the exact portable delegation
 both fail at their intended assertions; restoration returns the selection to
 green. Clang ASan/UBSan passes the affected behavior, boundary, and workflow
-selection `4/4` with no sanitizer findings. Exact-head Windows, macOS, and
-Ubuntu hosted validation remains required before merge.
+selection `4/4` with no sanitizer findings. Exact-head PR #4966 validation
+passed the generated-launcher contract on Windows, Ubuntu, and macOS, the
+Win32/x64 DECLARE lanes, Windows environment/path, GCC/Clang executable-path,
+DCO, and both package-safety checks before merge. Independent post-merge
+review then found the missing explicit isolation classification: a fresh
+configure reproduced the native isolation contract failure, and the
+classification correction removes that sole `audit=pending` row without
+changing runtime or platform-boundary behavior.
 
 ## Scope
 

--- a/tests/CopperfinTestIsolation.cmake
+++ b/tests/CopperfinTestIsolation.cmake
@@ -320,6 +320,17 @@ function(copperfin_configure_native_test_isolation)
         PLATFORM portable
         AUDIT complete
     )
+    copperfin_set_test_isolation(test_platform_file_version_boundary_contract
+        PARALLEL_SAFE
+        FILESYSTEM read-only
+        ENVIRONMENT none
+        CHILD_PROCESSES none
+        NETWORK none
+        RESOURCES none
+        SAMPLES none
+        PLATFORM portable
+        AUDIT complete
+    )
     copperfin_set_test_isolation(test_platform_sqlite_api_boundary_contract
         PARALLEL_SAFE
         FILESYSTEM read-only


### PR DESCRIPTION
## What changed

- explicitly classify `test_platform_file_version_boundary_contract` as a portable, read-only, resource-free, parallel-safe native test
- update the file-version boundary, changelog, and handoff evidence

## Why

Independent post-merge review found that the new test fell through to the deliberately fail-closed `audit=pending` isolation default. A fresh configure of current `v1-development` reproduced `test_native_test_isolation_contract` failing solely for that unclassified test.

## Impact

This changes test scheduling metadata only. It does not change product, VFP9, package, debug, localization, installer, or machine behavior.

## Validation

- pre-fix fresh configure: `test_native_test_isolation_contract` fails and names only `test_platform_file_version_boundary_contract`
- corrected fresh configure: native isolation, file-version boundary, GitHub Actions, and native-platform workflow contracts pass 4/4
- generated inventory row contains only resolved axes, `audit=complete`, and `schedule=parallel-safe`
- `git diff --check` passes

Signed-off-by: rhamenator <rhamenator@gmail.com>
