### PR TITLE
Differentiate launcher trust fixture payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 2026-08-12: Made the protected Windows launcher-trust fixture's dependency
+  and runtime-configuration JSON payloads distinct. The signed inventory
+  already binds path, role, and digest, so product trust behavior is unchanged;
+  the fixture evidence is now more representative and its provisioning
+  contract prevents the duplicate marker payload from returning.
+
 - 2026-08-12: Completed the protected Windows launcher-inventory trust gate.
   Corrected workflow run `31630819119` passed at exact merge commit
   `111fb67d09df1413221beeebce9b684f47097053` with the dedicated external signer

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,20 @@
 # Agent Handoff
 
+## Launcher-trust fixture review follow-up
+
+Independent inspection of protected run `31630819119` confirmed the archive
+and report hashes, all eight guard outcomes, and the absence of secret
+material. It also observed that the fixture's dependency and runtime-config
+paths used the same empty JSON payload and therefore had the same digest.
+
+The signed trust contract was not bypassed: each inventory record binds its
+package-relative path, role, and SHA-256 digest, and identical file content is
+valid. The fixture now uses distinct valid JSON markers for those two roles,
+with a source-contract regression preventing accidental reintroduction. Rerun
+the protected Windows launcher-trust workflow after this correction is merged
+to supersede the earlier fixture evidence before assembling the next immutable
+release candidate.
+
 ## Windows launcher-trust protected execution complete
 
 The first live protected `Windows Launcher Trust Validation` run

--- a/tests/run_launcher_trust_provisioning_contract_check.cmake
+++ b/tests/run_launcher_trust_provisioning_contract_check.cmake
@@ -9,9 +9,45 @@ endif()
 set(SCRIPT "${SOURCE_DIR}/scripts/prepare-windows-launcher-trust.ps1")
 set(VALIDATION_SCRIPT "${SOURCE_DIR}/scripts/run-windows-launcher-trust-validation.ps1")
 set(WORKFLOW "${SOURCE_DIR}/.github/workflows/windows-launcher-trust-validation.yml")
+set(FIXTURE "${SOURCE_DIR}/tests/test_windows_launcher_trust_fixture.cpp")
 foreach(REQUIRED_FILE IN ITEMS "${SCRIPT}" "${VALIDATION_SCRIPT}" "${WORKFLOW}")
     if(NOT EXISTS "${REQUIRED_FILE}")
         message(FATAL_ERROR "launcher trust provisioning file is missing: ${REQUIRED_FILE}")
+    endif()
+endforeach()
+
+if(NOT EXISTS "${FIXTURE}")
+    message(FATAL_ERROR "launcher trust fixture source is missing: ${FIXTURE}")
+endif()
+
+file(READ "${FIXTURE}" FIXTURE_CONTENT)
+foreach(REQUIRED_TEXT IN ITEMS
+    "constexpr char kDependenciesFixturePayload[] ="
+    "{\\\"fixture\\\":\\\"dependencies\\\"}\\n"
+    "constexpr char kRuntimeConfigurationFixturePayload[] ="
+    "{\\\"fixture\\\":\\\"runtime-configuration\\\"}\\n"
+    "kDependenciesFixturePayload);"
+    "kRuntimeConfigurationFixturePayload);"
+)
+    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_TEXT}" POSITION)
+    if(POSITION EQUAL -1)
+        message(FATAL_ERROR
+            "launcher trust fixture must retain distinct dependency and runtime-configuration payloads: ${REQUIRED_TEXT}")
+    endif()
+endforeach()
+
+set(DEPENDENCIES_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.deps.json",
+               kDependenciesFixturePayload);]=])
+set(RUNTIME_CONFIGURATION_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json",
+               kRuntimeConfigurationFixturePayload);]=])
+foreach(REQUIRED_BINDING IN ITEMS
+    "${DEPENDENCIES_FIXTURE_BINDING}"
+    "${RUNTIME_CONFIGURATION_FIXTURE_BINDING}"
+)
+    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_BINDING}" POSITION)
+    if(POSITION EQUAL -1)
+        message(FATAL_ERROR
+            "launcher trust fixture payload is not bound to its intended sidecar")
     endif()
 endforeach()
 

--- a/tests/test_windows_launcher_trust_fixture.cpp
+++ b/tests/test_windows_launcher_trust_fixture.cpp
@@ -21,6 +21,11 @@
 
 namespace {
 
+constexpr char kDependenciesFixturePayload[] =
+    "{\"fixture\":\"dependencies\"}\n";
+constexpr char kRuntimeConfigurationFixturePayload[] =
+    "{\"fixture\":\"runtime-configuration\"}\n";
+
 #if !defined(_WIN32)
 constexpr const char* kMarkerEnvironment = "COPPERFIN_TEST_LAUNCHER_TRUST_MARKER";
 #endif
@@ -108,8 +113,10 @@ int prepare_fixture(
         return 2;
     }
     write_text(package_root / "Copperfin.GeneratedLauncher.dll", "launcher dll fixture\n");
-    write_text(package_root / "Copperfin.GeneratedLauncher.deps.json", "{}\n");
-    write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json", "{}\n");
+    write_text(package_root / "Copperfin.GeneratedLauncher.deps.json",
+               kDependenciesFixturePayload);
+    write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json",
+               kRuntimeConfigurationFixturePayload);
 
     std::vector<copperfin::package_trust::LauncherInventoryArtifact> artifacts{
         {"public_apphost", public_name, file_digest(package_root / public_name)},


### PR DESCRIPTION
## Summary

- give the protected Windows launcher-trust dependency and runtime-configuration fixture files distinct valid JSON payloads
- bind each role-specific payload to its intended sidecar in the provisioning contract
- document why the prior duplicate content did not bypass path/role/digest authentication and require a superseding protected run

## Validation

- GCC build of test_windows_launcher_trust_fixture
- test_launcher_trust_provisioning_contract passed
- mutation proof: swapping the role-specific bindings fails the contract
- git diff --check

## Follow-up

After merge, rerun the protected Windows launcher-trust workflow on the exact main commit and record the superseding non-secret artifact evidence before assembling the next immutable RC.