### PR TITLE
Forward-port terminal callback teardown to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7623,3 +7623,13 @@ passes `1/1`.
   self-checks, direct parsing-equivalence review, and a deliberate `popen`
   mutation that failed at the intended contract. The replacement also removes
   the old fixed-512-byte line-read fragmentation risk.
+- 2026-08-12: Corrected a standalone terminal teardown race reproduced by
+  hosted Linux managed-UI run `31624289221`. Transcript and process-exit
+  callbacks now share a private admission/marshal gate with disposal, so an
+  in-flight callback either queues before teardown and is discarded when its
+  delegate rechecks state, or observes stopped callbacks without touching a
+  disposed WinForms handle. A deterministic smoke pauses a background callback
+  at that boundary while the UI thread disposes the control, then requires both
+  sides to drain without exception or deadlock. No shell, command, transcript,
+  localization, or layout contract changes. RC2 remains immutable; protected
+  hosted evidence and a new sequential RC remain required.

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,31 @@
 # Agent Handoff
 
+## Standalone terminal callback teardown correction
+
+PR #4967's unrelated broad RC matrix reproduced a real managed-UI teardown
+fault in Linux run `31624289221`. After the terminal smoke had disposed its
+form and shell, a pending asynchronous stderr callback entered
+`StudioTerminalWindowControl.AppendTranscript()` and called `BeginInvoke`
+while Mono's X11 handle infrastructure was tearing down. The process ended in
+an unhandled `NullReferenceException` during the following shell-layout smoke.
+
+The terminal now serializes callback admission/marshaling and disposal through
+one private gate. Disposal marks callbacks stopped while holding that gate; an
+in-flight callback may enqueue only before disposal acquires it, and the queued
+delegate rechecks the stopped state before touching controls. The same boundary
+protects transcript and process-exit state updates. A focused managed smoke
+deterministically pauses a background callback at the marshal boundary, starts
+disposal on the UI thread, releases the callback, and requires both threads to
+drain without exception or deadlock. The managed project builds with zero
+warnings/errors on Linux; Mono/Xvfb is unavailable locally, so the exact hosted
+Linux smoke remains required. No terminal command, shell, transcript,
+localization, layout, runtime, package, or machine contract changes.
+
+This confirmed RC defect is separate from the launcher-trust exit-state
+correction. It landed on `main` first and is now forward-ported to
+`v1-development`; create a new immutable RC only after the launcher correction
+and both protected matrices pass. RC2 remains unchanged.
+
 ## V1 file-version isolation audit correction
 
 Independent review of the merged portable `AGETFILEVERSION()` boundary found

--- a/docs/26-localization-and-release-readiness.md
+++ b/docs/26-localization-and-release-readiness.md
@@ -82,6 +82,16 @@ pass. Permissive safety run `30566915484` also passes. #4895 is closed, and
 strict post-closure safety run `30568877447` passes without advancing external
 #4409 authority.
 
+Hosted Linux managed-UI run `31624289221` subsequently reproduced an
+asynchronous standalone-terminal teardown crash: a pending stderr callback
+could pass its stopped/disposed checks immediately before form disposal and
+then call `BeginInvoke` through Mono's torn-down X11 handle. Callback admission
+and UI marshaling now share one gate with disposal, and a deterministic smoke
+holds a callback at that boundary while teardown begins. The correction adds
+no text or catalog keys and changes no invariant command, transcript, layout,
+or machine contract. Warning-free managed compilation passes locally; hosted
+Mono/Xvfb and Windows managed matrices remain the acceptance evidence.
+
 The latest broad implementation baseline is product head `93d44395f`; the
 latest product implementation/test head is `f0c9e06e2`, while subsequent
 documentation-only coordination commits may advance the branch. Hosted Linux

--- a/vsix/Copperfin.DesignerSmokeTests/Program.EntryPoint.01.cs
+++ b/vsix/Copperfin.DesignerSmokeTests/Program.EntryPoint.01.cs
@@ -57,6 +57,7 @@ internal static partial class Program
         runner.Run(nameof(SmokeStandaloneStudioFileLayoutStoreRoundTrip), SmokeStandaloneStudioFileLayoutStoreRoundTrip);
         runner.Run(nameof(SmokeStandaloneStudioTerminalShellContract), SmokeStandaloneStudioTerminalShellContract);
         runner.Run(nameof(SmokeStandaloneStudioTerminalWindow), SmokeStandaloneStudioTerminalWindow);
+        runner.Run(nameof(SmokeStandaloneStudioTerminalCallbackTeardown), SmokeStandaloneStudioTerminalCallbackTeardown);
         runner.Run(nameof(SmokeProjectWorkspaceEntryActivation), SmokeProjectWorkspaceEntryActivation);
         runner.Run(nameof(SmokeCrossPlatformFileRevealContracts), SmokeCrossPlatformFileRevealContracts);
         runner.Run(nameof(SmokeLocalizedProjectWorkspaceChrome), SmokeLocalizedProjectWorkspaceChrome);

--- a/vsix/Copperfin.DesignerSmokeTests/Program.StandaloneTerminal.01.cs
+++ b/vsix/Copperfin.DesignerSmokeTests/Program.StandaloneTerminal.01.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Drawing;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace Copperfin.VisualStudio;
@@ -78,5 +79,68 @@ internal static partial class Program
         TearDownForm(form);
         Expect(!form.IsTerminalShellRunning,
             "standalone Terminal should stop its child shell when the form is disposed");
+    }
+
+    private static void SmokeStandaloneStudioTerminalCallbackTeardown()
+    {
+        using var form = new Form
+        {
+            Width = 640,
+            Height = 480,
+            ShowInTaskbar = false,
+            StartPosition = FormStartPosition.Manual,
+            Location = new Point(-32000, -32000)
+        };
+        using var terminal = new StudioTerminalWindowControl(
+            new CopperfinLocalization("en-US"))
+        {
+            Dock = DockStyle.Fill
+        };
+        form.Controls.Add(terminal);
+        form.Show();
+        Application.DoEvents();
+
+        using var marshalEntered = new ManualResetEventSlim(false);
+        using var allowMarshal = new ManualResetEventSlim(false);
+        Exception? callbackFailure = null;
+        terminal.BeforeCallbackMarshalForTest = () =>
+        {
+            marshalEntered.Set();
+            allowMarshal.Wait(TimeSpan.FromSeconds(5));
+        };
+
+        var callbackThread = new Thread(() =>
+        {
+            try
+            {
+                terminal.AppendTranscriptForTest("pending terminal output");
+            }
+            catch (Exception exception)
+            {
+                callbackFailure = exception;
+            }
+        })
+        {
+            IsBackground = true
+        };
+        callbackThread.Start();
+        Expect(marshalEntered.Wait(TimeSpan.FromSeconds(5)),
+            "standalone Terminal teardown smoke should reach the background callback marshal boundary");
+
+        var releaseThread = new Thread(() =>
+        {
+            Thread.Sleep(50);
+            allowMarshal.Set();
+        })
+        {
+            IsBackground = true
+        };
+        releaseThread.Start();
+        terminal.Dispose();
+        Expect(callbackThread.Join(TimeSpan.FromSeconds(5)) && releaseThread.Join(TimeSpan.FromSeconds(5)),
+            "standalone Terminal teardown should drain the in-flight callback without deadlock");
+        Application.DoEvents();
+        Expect(callbackFailure is null,
+            "standalone Terminal teardown should not marshal output through a disposed WinForms handle");
     }
 }

--- a/vsix/Copperfin.DesignerSmokeTests/Program.StandaloneTerminal.01.cs
+++ b/vsix/Copperfin.DesignerSmokeTests/Program.StandaloneTerminal.01.cs
@@ -102,11 +102,12 @@ internal static partial class Program
 
         using var marshalEntered = new ManualResetEventSlim(false);
         using var allowMarshal = new ManualResetEventSlim(false);
+        var marshalReleaseObserved = false;
         Exception? callbackFailure = null;
         terminal.BeforeCallbackMarshalForTest = () =>
         {
             marshalEntered.Set();
-            allowMarshal.Wait(TimeSpan.FromSeconds(5));
+            marshalReleaseObserved = allowMarshal.Wait(TimeSpan.FromSeconds(5));
         };
 
         var callbackThread = new Thread(() =>
@@ -140,6 +141,8 @@ internal static partial class Program
         Expect(callbackThread.Join(TimeSpan.FromSeconds(5)) && releaseThread.Join(TimeSpan.FromSeconds(5)),
             "standalone Terminal teardown should drain the in-flight callback without deadlock");
         Application.DoEvents();
+        Expect(marshalReleaseObserved,
+            "standalone Terminal teardown smoke should explicitly release the paused callback");
         Expect(callbackFailure is null,
             "standalone Terminal teardown should not marshal output through a disposed WinForms handle");
     }

--- a/vsix/Copperfin.Studio/StudioTerminalWindowControl.cs
+++ b/vsix/Copperfin.Studio/StudioTerminalWindowControl.cs
@@ -13,6 +13,7 @@ namespace Copperfin.VisualStudio;
 
 internal sealed class StudioTerminalWindowControl : UserControl
 {
+    private readonly object callbackDispatchGate = new();
     private readonly CopperfinLocalization localization;
     private readonly RichTextBox transcript;
     private readonly TextBox commandInput;
@@ -25,6 +26,8 @@ internal sealed class StudioTerminalWindowControl : UserControl
     private bool disposeStarted;
     private bool disposeCompleted;
     private bool callbacksStopped;
+
+    internal Action? BeforeCallbackMarshalForTest { get; set; }
 
     public StudioTerminalWindowControl(CopperfinLocalization localization)
     {
@@ -175,7 +178,10 @@ internal sealed class StudioTerminalWindowControl : UserControl
                 StartInfo = CreateShellStartInfo(),
                 EnableRaisingEvents = true
             };
-            callbacksStopped = false;
+            lock (callbackDispatchGate)
+            {
+                callbacksStopped = false;
+            }
             process.OutputDataReceived += OnOutputDataReceived;
             process.ErrorDataReceived += OnOutputDataReceived;
             process.Exited += OnProcessExited;
@@ -216,7 +222,10 @@ internal sealed class StudioTerminalWindowControl : UserControl
 
     internal void StopShell()
     {
-        callbacksStopped = true;
+        lock (callbackDispatchGate)
+        {
+            callbacksStopped = true;
+        }
         var process = terminalProcess;
         terminalProcess = null;
         var inputWriter = terminalInputWriter;
@@ -283,7 +292,10 @@ internal sealed class StudioTerminalWindowControl : UserControl
             }
 
             disposeStarted = true;
-            callbacksStopped = true;
+            lock (callbackDispatchGate)
+            {
+                callbacksStopped = true;
+            }
             if (handleCreationInProgress)
             {
                 disposePending = true;
@@ -344,47 +356,60 @@ internal sealed class StudioTerminalWindowControl : UserControl
 
     private void UpdateState(string text)
     {
-        if (callbacksStopped || IsDisposed || Disposing || !IsHandleCreated)
+        lock (callbackDispatchGate)
         {
-            return;
-        }
-
-        try
-        {
-            if (InvokeRequired)
+            if (callbacksStopped || IsDisposed || Disposing || !IsHandleCreated)
             {
-                BeginInvoke(new Action<string>(UpdateState), text);
                 return;
             }
 
-            stateLabel.Text = text;
-        }
-        catch (InvalidOperationException)
-        {
+            try
+            {
+                if (InvokeRequired)
+                {
+                    BeforeCallbackMarshalForTest?.Invoke();
+                    BeginInvoke(new Action<string>(UpdateState), text);
+                    return;
+                }
+
+                stateLabel.Text = text;
+            }
+            catch (InvalidOperationException)
+            {
+            }
         }
     }
 
     private void AppendTranscript(string text)
     {
-        if (callbacksStopped || IsDisposed || Disposing || !IsHandleCreated)
+        lock (callbackDispatchGate)
         {
-            return;
-        }
-
-        try
-        {
-            if (InvokeRequired)
+            if (callbacksStopped || IsDisposed || Disposing || !IsHandleCreated)
             {
-                BeginInvoke(new Action<string>(AppendTranscript), text);
                 return;
             }
 
-            transcript.AppendText(text + Environment.NewLine);
-            transcript.SelectionStart = transcript.TextLength;
-            transcript.ScrollToCaret();
+            try
+            {
+                if (InvokeRequired)
+                {
+                    BeforeCallbackMarshalForTest?.Invoke();
+                    BeginInvoke(new Action<string>(AppendTranscript), text);
+                    return;
+                }
+
+                transcript.AppendText(text + Environment.NewLine);
+                transcript.SelectionStart = transcript.TextLength;
+                transcript.ScrollToCaret();
+            }
+            catch (InvalidOperationException)
+            {
+            }
         }
-        catch (InvalidOperationException)
-        {
-        }
+    }
+
+    internal void AppendTranscriptForTest(string text)
+    {
+        AppendTranscript(text);
     }
 }


### PR DESCRIPTION
## Summary

- forward-port the reviewed terminal callback teardown serialization from main
- preserve the deterministic callback-versus-disposal regression and release documentation
- retain all current v1 portability work while resolving documentation chronology

## Validation

- dotnet build vsix/Copperfin.DesignerSmokeTests/Copperfin.DesignerSmokeTests.csproj -c Release -p:EnableWindowsTargeting=true: success, 0 warnings, 0 errors
- both forward-port commits have valid Ed25519 Git signatures and DCO sign-off
- git diff --check

## Platform gate

Local Mono/Xvfb is unavailable on this host. The protected Linux managed-UI smoke is the required behavioral gate before merge.