### PR TITLE
Forward-port launcher trust correction to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7633,3 +7633,15 @@ passes `1/1`.
   sides to drain without exception or deadlock. No shell, command, transcript,
   localization, or layout contract changes. RC2 remains immutable; protected
   hosted evidence and a new sequential RC remain required.
+- 2026-08-12: Corrected the protected Windows launcher-trust orchestrator after
+  live run `31623671192` completed every valid and expected fail-closed guard
+  case but GitHub propagated the last expected exit code `4` as the workflow
+  result. The script now clears that process state only after assertions,
+  non-secret evidence writing, and protected-input cleanup succeed; its source
+  contract rejects removal, duplication, or relocation of the reset. The
+  launcher guard, signed envelope, package inventory, and invariant negative
+  exit code remain unchanged. The single-owner release-environment procedure
+  now records owner dispatch honestly instead of claiming an unavailable
+  independent reviewer; independent review becomes mandatory when a second
+  trusted maintainer exists. RC2 remains immutable and the corrected protected
+  run plus a new sequential RC remain required.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@
   the adjacent platform-boundary checks. No product, VFP9, package, debug,
   localization, or machine contract changes.
 
+- 2026-08-12: Completed the protected Windows launcher-inventory trust gate.
+  Corrected workflow run `31630819119` passed at exact merge commit
+  `111fb67d09df1413221beeebce9b684f47097053` with the dedicated external signer
+  `copperfin-launcher-2026-01`. The non-secret artifact `9155061757` has GitHub
+  and independently reproduced archive digest
+  `sha256:c66fd93daab64d3c2abee12291648987f0ebff701ca36f625bfa7d4f207582eb`;
+  its report records the exact five-file finalized inventory, one valid launch,
+  and seven stable exit-code-`4` failures before apphost start. No private-key
+  or secret markers appear in the downloaded evidence. This completes
+  #4894/#4409/#4387/#4041 without adding Authenticode, Apple
+  signing/notarization, Linux package signing, or changing ordinary unsigned
+  development behavior. RC2 remains immutable and a new sequential RC is
+  required.
+
 - 2026-08-12: Continued v1 portability lane J1 by moving
   `AGETFILEVERSION()` metadata extraction out of the PRG interpreter and behind
   a standard-C++ platform record. Windows version-resource APIs, native

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,35 @@
 # Agent Handoff
 
+## Windows launcher-trust protected-run correction
+
+The first live protected `Windows Launcher Trust Validation` run
+`31623671192` at `main` head `b458c8794` proved that the external
+`copperfin-launcher-2026-01` signer and matching one-entry registry can be
+materialized outside the checkout, bound by preflight, compiled into the
+enforced Windows guard, and used by the package-trust verifier. Provisioning,
+configuration, target builds, and the verifier contract passed. The actual
+guard walkthrough executed the valid signed launch and every expected
+fail-closed case, but the workflow step then failed because the orchestrator
+left the final expected guard exit code `4` in PowerShell's global
+`LASTEXITCODE`; GitHub's wrapper propagated that stale process state and
+skipped the non-secret evidence upload.
+
+The correction clears only that expected-negative process state, after all
+assertions, evidence writing, and cleanup have succeeded. The provisioning
+contract now requires exactly one end-of-script reset, so removing or moving
+it fails locally. No guard, signature, envelope, inventory, package, runtime,
+installer, or machine status/exit contract changes. The protected workflow
+must be rerun successfully before #4894/#4409 or their parents can close.
+
+The live `release` environment is restricted to `main` and owns the two
+launcher-trust secrets. Because the repository currently has one owner and no
+second trusted maintainer, it does not claim an independent environment
+reviewer; the explicit owner dispatch is the documented temporary authority
+boundary. Independent review becomes mandatory when another trusted
+maintainer is admitted. RC2 and its artifact set remain immutable; this
+security-validation correction requires a new sequential RC after review and
+successful protected execution, then forward-porting into `v1-development`.
+
 ## Standalone terminal callback teardown correction
 
 PR #4967's unrelated broad RC matrix reproduced a real managed-UI teardown

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,6 +1,6 @@
 # Agent Handoff
 
-## Windows launcher-trust protected-run correction
+## Windows launcher-trust protected execution complete
 
 The first live protected `Windows Launcher Trust Validation` run
 `31623671192` at `main` head `b458c8794` proved that the external
@@ -18,8 +18,16 @@ The correction clears only that expected-negative process state, after all
 assertions, evidence writing, and cleanup have succeeded. The provisioning
 contract now requires exactly one end-of-script reset, so removing or moving
 it fails locally. No guard, signature, envelope, inventory, package, runtime,
-installer, or machine status/exit contract changes. The protected workflow
-must be rerun successfully before #4894/#4409 or their parents can close.
+installer, or machine status/exit contract changes.
+
+Corrected protected run `31630819119` passes at exact `main` merge commit
+`111fb67d09df1413221beeebce9b684f47097053`. Artifact `9155061757` has GitHub
+and independently reproduced archive digest
+`sha256:c66fd93daab64d3c2abee12291648987f0ebff701ca36f625bfa7d4f207582eb`.
+The report contains exactly one valid launch (`0`, apphost started) and seven
+negative cases (`4`, apphost not started), and its downloaded files contain no
+private-key or secret markers. #4894, #4409, #4387, and #4041 now have direct
+closure evidence. RC2 remains immutable; assemble a new sequential RC.
 
 The live `release` environment is restricted to `main` and owns the two
 launcher-trust secrets. Because the repository currently has one owner and no
@@ -27,8 +35,8 @@ second trusted maintainer, it does not claim an independent environment
 reviewer; the explicit owner dispatch is the documented temporary authority
 boundary. Independent review becomes mandatory when another trusted
 maintainer is admitted. RC2 and its artifact set remain immutable; this
-security-validation correction requires a new sequential RC after review and
-successful protected execution, then forward-porting into `v1-development`.
+security-validation correction is now forward-ported into `v1-development`;
+it still requires a new sequential RC.
 
 ## Standalone terminal callback teardown correction
 
@@ -47,14 +55,15 @@ protects transcript and process-exit state updates. A focused managed smoke
 deterministically pauses a background callback at the marshal boundary, starts
 disposal on the UI thread, releases the callback, and requires both threads to
 drain without exception or deadlock. The managed project builds with zero
-warnings/errors on Linux; Mono/Xvfb is unavailable locally, so the exact hosted
-Linux smoke remains required. No terminal command, shell, transcript,
-localization, layout, runtime, package, or machine contract changes.
+warnings/errors locally. Exact v1 forward-port run `31633512939` passes the
+full Linux Mono/Xvfb standalone-shell and adjacent property-grid smoke. No
+terminal command, shell, transcript, localization, layout, runtime, package,
+or machine contract changes.
 
 This confirmed RC defect is separate from the launcher-trust exit-state
-correction. It landed on `main` first and is now forward-ported to
-`v1-development`; create a new immutable RC only after the launcher correction
-and both protected matrices pass. RC2 remains unchanged.
+correction. Both corrections landed on `main`, their required protected paths
+pass, and both are now forward-ported to `v1-development`. Create a new
+immutable RC before private evaluation continues. RC2 remains unchanged.
 
 ## V1 file-version isolation audit correction
 
@@ -3290,7 +3299,7 @@ not to the current state above.
 
 - #4730 under #3217 is closed after Claude review and exact-head Windows validation. Mounted VFP9 help documents only `MultiSelect` values `0` and `1`; native PRG direct/reflective access, mode transitions, invalid-value normalization, same-PRG setup, and derived `Init` are covered by `test_prg_engine_runtime_surface_functions` on Linux and Windows. Mode `2`, mouse/keyboard selection interaction, and viewport painting remain outside this property slice. Windows evidence is under `artifacts/windows-review-4730-corrected-4f3f590c/` and the closure is recorded on GitHub issue #4730.
 
-- Current-state precedence: older #4621 entries later in this handoff describe intermediate hosted runs and their pending gates at historical heads. They are superseded by the current closure record above: hosted Windows/VFP9/Visual Studio evidence and exact-head Linux/macOS/Windows native evidence are complete, and #4621 is closed. Do not treat historical "pending" wording below as a current release status; #4403 safety traceability and #4409 protected package signing remain open separately.
+- Current-state precedence: older #4621 entries later in this handoff describe intermediate hosted runs and their pending gates at historical heads. They are superseded by the current closure record above: hosted Windows/VFP9/Visual Studio evidence and exact-head Linux/macOS/Windows native evidence are complete, and #4621 is closed. Do not treat historical "pending" wording below as a current release status. #4409 protected package signing is now complete; #4403 arm's-length safety review remains open separately.
 
 - Current #4403 validator rerun after #4621 closure: permissive validation with primary-hazard coverage passed; strict validation passed all structural, DQ/DV/HZ, and primary-hazard checks and reported exactly one intentional failure, `Issue is not closed (state=OPEN)`. No arm's-length reviewer sign-off or safety closure is claimed. The issue remains open until a genuinely independent reviewer signs off and the strict closed-issue gate can pass.
 

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -351,19 +351,21 @@ tag remains immutable, the scanner regression is corrected for sequential
 `copperfin-v0.1.0-rc.2-evaluation-bundle` artifact with GitHub-reported
 SHA-256 `501ba26642af4fb58c69e3c69ca0f29b7eb5e242a4980ea31770e83bd84605df`;
 no GitHub Release exists. This is private-evaluation availability, not human
-acceptance or authority for an official release. The complete
-official-release evidence gate remains open until #4403 receives genuine
-arm's-length safety sign-off, closes, and passes strict validation, and until
-#4409 receives the approved protected launcher-trust signer/registry secrets
-and passes enforced Windows validation. Permissive primary-hazard safety run
-`30555972170` is green but cannot substitute for that strict closure. The
-hosted Deep runner also lacked VFP9;
+acceptance or authority for an official release. The complete official-release
+evidence gate remains open until #4403 receives genuine arm's-length safety
+sign-off, closes, and passes strict validation. #4409's protected Windows
+launcher-trust gate has passed with the approved signer/registry pair in run
+`31630819119` at exact commit
+`111fb67d09df1413221beeebce9b684f47097053`. Permissive primary-hazard safety
+run `30555972170` is green but cannot substitute for #4403's strict closure.
+The hosted Deep runner also lacked VFP9;
 accepted installed-VFP9, mounted-sample, RuntimePackage/xAsset/Report/Menu, and
 live Visual Studio evidence remains the closed #4621 baseline because the final
-changes were catalog/managed/test-only. After an immutable RC artifact passes,
-the long-lived v1 development branch may begin at that exact tag while RC
-stabilization remains isolated. Neither lane may reinterpret this parallel work
-as closure of #4403 or #4409 or as authority for an official 1.0 release.
+changes were catalog/managed/test-only. Protected `v1-development` begins at
+the peeled RC2 commit under no-bypass ruleset `20582609`, while immutable RC
+stabilization remains separate. Human RC2 evaluation remains pending. Neither
+lane may reinterpret this parallel work as closure of #4403 or as authority
+for an official 1.0 release.
 
 The v1 lane also carries optional bounded DBF-header robustness coverage:
 6,757 deterministic synthetic cases plus an ASan/UBSan variant when supported.
@@ -712,8 +714,8 @@ and Windows/MSVC, and #4847's hosted SBOM gate is closed. #4621's hosted
 Windows/VFP9/Visual Studio reconciliation remains accepted as historical
 evidence for its validated binaries, while the current-head matrix continues
 to run. This does not claim complete RC readiness. Independent safety sign-off
-under #4403 and protected launcher-trust provisioning under #4409 remain
-separate release gates.
+under #4403 remains a separate release gate; the later protected run below
+supersedes this section's historical #4409 pending state.
 
 Independent local POSIX validation at synchronized head `792f1840c` passed
 `ctest --test-dir build --output-on-failure --timeout 180 --parallel 2` with
@@ -734,14 +736,12 @@ runtime equivalents twice at the same product head: RuntimePackage, XAsset,
 Report, and Menu, with the installed VFP9 prerequisite present. The artifacts
 are recorded under the Windows host's
 `E:\Project-Copperfin\artifacts\windows-mounted-vfp9-validation\` path.
-The complete RC evidence gate remains unclaimed while #4403 independent
-review/closure and #4409 protected launcher-trust provisioning remain open.
-The #4894 audit slice corrects the protected job so provisioning now drives an
-external signer over a finalized inventory and exercises the actual enforced
-guard across valid and fail-closed cases; exact protected execution still
-requires the externally approved registry/key pair and does not weaken #4409;
-the accepted #4621 hosted baseline remains separate from an exact-head live
-Visual Studio UI rerun.
+The complete official-release evidence gate remains unclaimed while #4403
+independent review/closure remains open. The #4894 audit slice corrected the
+protected job so provisioning drives an external signer over a finalized
+inventory and exercises the actual enforced guard across valid and fail-closed
+cases. The accepted #4621 hosted baseline remains separate from an exact-head
+live Visual Studio UI rerun.
 
 The #4898 Linux launcher-key generator has completed its bounded tool,
 walkthrough, independent-review, and DQ/DV/HZ evidence. The non-secret record
@@ -756,16 +756,15 @@ with MSVC, Linux `30559930560` and macOS `30559930719` pass `316/316`, and the
 exact VSIX, managed-UI, installer, security/SBOM, executable-path, Windows
 environment/path, and DECLARE ABI workflows pass. Generated-launcher run
 `30559417230` passes at the exact duplicate-signer implementation head
-`3968fabff`. This evidence completes the missing workflow mechanics; it does
-not provide an approved key, protected run, #4409 closure, or release authority.
+`3968fabff`. This evidence completed the missing workflow mechanics before the
+approved protected execution recorded below.
 
 Security audit child #4895 binds that manual job to the fixed GitHub Actions
 `release` environment so configured required-reviewer, no-self-review, branch,
 and environment-secret protections apply before the runner receives signing
 authority. Source control does not create or configure that environment. An
-administrator must still establish its protection rules and approved secrets,
-then complete the #4409 run; an absent or unprotected environment is not RC
-evidence. Independent review found and correction head `0a8a43080` closes one
+absent or unprotected environment is not RC evidence. Independent review found
+and correction head `0a8a43080` closes one
 test gap by requiring the exact sole `contents: read` permission block; the
 same reviewer passes the corrected slice. Exact corrected test head
 `0a8a43080` passes hosted Linux/macOS Native `316/316` and Windows Native
@@ -774,8 +773,19 @@ contract. The VSIX, managed-UI, installer, security/SBOM, executable-path,
 Windows environment/path, and DECLARE ABI gates pass. Corrected-head permissive
 safety run `30566915484` also passes for #4895; neither result supplies external
 release authority. #4895 is closed after independent review and synchronized
-evidence; strict post-closure safety run `30568877447` passes. #4409 remains
-open.
+evidence; strict post-closure safety run `30568877447` passes.
+
+Corrected protected run `31630819119` passes at exact `main` merge commit
+`111fb67d09df1413221beeebce9b684f47097053` using signer
+`copperfin-launcher-2026-01`. Artifact `9155061757` has GitHub and independently
+reproduced archive digest
+`sha256:c66fd93daab64d3c2abee12291648987f0ebff701ca36f625bfa7d4f207582eb`.
+Its non-secret report contains the exact five-artifact finalized inventory,
+one valid launch (`0`, apphost started), and seven negative cases (`4`, apphost
+not started); a marker scan found no private-key or secret content. This
+satisfies #4894/#4409/#4387/#4041. It does not satisfy #4403, authorize a public
+release, or add Authenticode, Apple signing/notarization, or Linux package
+signing. RC2 remains immutable; assemble a new sequential RC.
 
 The same build tree produced Linux DEB, RPM, and TGZ packages with CPack at
 `c95cf269d`; the package/document/install contract subset passed `4/4`.

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -743,12 +743,13 @@ inventory and exercises the actual enforced guard across valid and fail-closed
 cases. The accepted #4621 hosted baseline remains separate from an exact-head
 live Visual Studio UI rerun.
 
-The #4898 Linux launcher-key generator has completed its bounded tool,
-walkthrough, independent-review, and DQ/DV/HZ evidence. The non-secret record
-is archived in
-`docs/safety/traceability-report-2026-08-08-launcher-keygen.md`. GitHub still
-has no `release` environment, so this child does not satisfy #4409 or authorize
-a protected Windows launcher-trust claim.
+The #4898 Linux launcher-key generator completed its bounded tool,
+walkthrough, independent-review, and DQ/DV/HZ evidence before the protected
+execution recorded below. The non-secret record is archived in
+`docs/safety/traceability-report-2026-08-08-launcher-keygen.md`. That child did
+not by itself satisfy #4409 or authorize a protected Windows launcher-trust
+claim; the subsequently configured `release` environment and successful
+protected run `31630819119` supply that distinct evidence.
 
 The implementation-side #4894 matrix is current at exact head `f0c9e06e2`:
 Windows native `30559930672` passes `315/315` after building the new fixture

--- a/docs/23-phase-a-dependency-breakdown.md
+++ b/docs/23-phase-a-dependency-breakdown.md
@@ -53,10 +53,13 @@ again unless a regression or fresh compatibility evidence creates a new gap.
   by this implementation slice.
 - Security audit child `#4895` binds the manual signer/guard job to the fixed
   GitHub Actions `release` environment and locks that invariant in the workflow
-  contract. Required reviewers, prevention of self-review, `main` branch
-  restriction, environment-scoped approved secrets, and the actual approved
-  run remain external #4409 configuration/evidence rather than repository
-  implementation. Independent review found and correction head `0a8a43080`
+  contract. Independent reviewers and prevention of self-review remain
+  mandatory when a second trusted maintainer is available; the current
+  single-owner topology instead requires an explicit recorded owner dispatch,
+  `main` branch restriction, environment-scoped approved secrets, and honest
+  disclosure that no independent approval occurred. Those authority steps and
+  the actual approved run remain external #4409 configuration/evidence rather
+  than repository implementation. Independent review found and correction head `0a8a43080`
   closes the missing exact `contents: read` regression guard; the same reviewer
   passes the corrected slice. That exact corrected head passes hosted
   Linux/macOS Native `316/316` and Windows Native `315/315`; each explicitly
@@ -65,6 +68,14 @@ again unless a regression or fresh compatibility evidence creates a new gap.
   DECLARE ABI gates pass; corrected-head permissive safety run `30566915484`
   also passes. #4895 is closed, and strict post-closure safety run `30568877447`
   passes; #4409 remains open for external release authority.
+- The first live protected run `31623671192` proved the external signer/registry
+  binding, enforced Windows build, and package-trust verifier, then executed
+  the valid launch and all seven negative guard cases. The workflow still
+  failed because its PowerShell orchestrator leaked the final expected guard
+  exit code `4` into GitHub's step wrapper, which skipped evidence upload. The
+  correction clears only that expected process state after assertions,
+  evidence writing, and cleanup; a successful protected rerun and new
+  immutable RC remain required.
 - RC regression `#4893` removes the separate net472 fixture's nested shell and
   cold-child readiness races. Owning parents record helper PIDs immediately
   from `Process.Start`; native Windows stress passes `9/9`, exact VSIX

--- a/docs/23-phase-a-dependency-breakdown.md
+++ b/docs/23-phase-a-dependency-breakdown.md
@@ -38,8 +38,9 @@ again unless a regression or fresh compatibility evidence creates a new gap.
   `30550948703` passes Linux `316/316`, Windows `315/315`, and macOS `316/316`;
   Windows Deep `30550946359` passes native, VSIX/resources, managed/net472,
   standalone Studio, DesignerSmoke, and debugger stages. Exact VSIX, Linux UI,
-  installers, security/SBOM, and individual native runs also pass. The v1 queue
-  remains behind external release authorities #4403 and #4409.
+  installers, security/SBOM, and individual native runs also pass. The separate
+  #4403 independent safety authority remains open; #4409's protected Windows
+  launcher-trust authority is now satisfied by the evidence below.
 - Release-trust audit child `#4894` found that #4409's protected job stopped at
   provisioning and verifier-unit coverage. The corrected implementation binds
   an explicit approved signer ID to the external registry, signs a canonical
@@ -48,9 +49,7 @@ again unless a regression or fresh compatibility evidence creates a new gap.
   evidence, and removes protected temporary inputs. Exact head `f0c9e06e2`
   passes Windows native `315/315`, Linux/macOS `316/316`, and the VSIX,
   managed-UI, installer, security, path, and ABI gates; generated-launcher run
-  `30559417230` passes at duplicate-signer head `3968fabff`. Externally approved
-  protected execution remains #4409's release authority and is not substituted
-  by this implementation slice.
+  `30559417230` passes at duplicate-signer head `3968fabff`.
 - Security audit child `#4895` binds the manual signer/guard job to the fixed
   GitHub Actions `release` environment and locks that invariant in the workflow
   contract. Independent reviewers and prevention of self-review remain
@@ -67,15 +66,20 @@ again unless a regression or fresh compatibility evidence creates a new gap.
   installer, security/SBOM, executable-path, Windows environment/path, and
   DECLARE ABI gates pass; corrected-head permissive safety run `30566915484`
   also passes. #4895 is closed, and strict post-closure safety run `30568877447`
-  passes; #4409 remains open for external release authority.
+  passes.
 - The first live protected run `31623671192` proved the external signer/registry
   binding, enforced Windows build, and package-trust verifier, then executed
   the valid launch and all seven negative guard cases. The workflow still
   failed because its PowerShell orchestrator leaked the final expected guard
   exit code `4` into GitHub's step wrapper, which skipped evidence upload. The
   correction clears only that expected process state after assertions,
-  evidence writing, and cleanup; a successful protected rerun and new
-  immutable RC remain required.
+  evidence writing, and cleanup. Corrected protected run `31630819119` passes
+  at merge commit `111fb67d09df1413221beeebce9b684f47097053`; artifact
+  `9155061757` has independently reproduced archive digest
+  `sha256:c66fd93daab64d3c2abee12291648987f0ebff701ca36f625bfa7d4f207582eb`.
+  Its report records one valid launch (`0`, apphost started) and all seven
+  negative cases (`4`, apphost not started), with no secret markers. This
+  satisfies #4894/#4409/#4387/#4041; a new immutable RC remains required.
 - RC regression `#4893` removes the separate net472 fixture's nested shell and
   cold-child readiness races. Owning parents record helper PIDs immediately
   from `Process.Start`; native Windows stress passes `9/9`, exact VSIX

--- a/docs/26-localization-and-release-readiness.md
+++ b/docs/26-localization-and-release-readiness.md
@@ -47,24 +47,18 @@ artifact workflow. That path records the English source-of-truth and preserves
 the Spanish/Portuguese human-review warning, but it neither publishes a GitHub
 Release nor claims protected signing or independent safety approval. Permissive
 #4403 primary-hazard safety run `30555972170` passes; genuine arm's-length
-review, formal issue closure, and strict validation remain required. #4409
-cannot run its enforced trust gate because no protected repository
-signer/registry secrets are configured. Audit child #4894 corrects that gate's
-implementation: the protected signer now signs a finalized inventory and the
-actual enforced guard records valid launch and stable exit-code-4 failures
-without exposing private material. That implementation does not replace the
-missing approved signer/registry or its required protected Windows run. Do not
-present the MVP RC as an official release. Once the immutable RC1 artifact
-passes, v1 development may proceed on its dedicated branch from the exact RC1
-commit while those external authorities and the RC stabilization lane remain
-separate.
+review, formal issue closure, and strict validation remain required. The
+protected #4409 Windows launcher-trust gate now passes at commit
+`111fb67d09df1413221beeebce9b684f47097053` in run `31630819119` using the
+approved external signer/registry pair. This does not satisfy the separate
+independent safety or linguistic-review gates and does not make an existing RC
+an official release. v1 development remains isolated from RC stabilization.
 
 The corrected mechanics are platform-validated at exact head `f0c9e06e2`:
 Windows native run `30559930672` passes `315/315` after compiling the fixture
 with MSVC, Linux/macOS native runs pass `316/316`, and the exact VSIX,
 managed-UI, installer, security, path, and ABI gates are green. No localized
-catalog or invariant diagnostic contract changed in #4894. The approved
-protected signer execution remains an external release gate.
+catalog or invariant diagnostic contract changed in #4894.
 
 Audit child #4895 additionally binds the signer/guard job to the fixed GitHub
 Actions `release` environment. The release administrator must restrict the
@@ -82,18 +76,7 @@ Windows Native `315/315`; each explicitly passes the focused
 permission/provisioning contract. The VSIX, managed-UI, installer,
 security/SBOM, executable-path, Windows environment/path, and DECLARE ABI gates
 pass. Permissive safety run `30566915484` also passes. #4895 is closed, and
-strict post-closure safety run `30568877447` passes without advancing external
-#4409 authority.
-
-Hosted Linux managed-UI run `31624289221` subsequently reproduced an
-asynchronous standalone-terminal teardown crash: a pending stderr callback
-could pass its stopped/disposed checks immediately before form disposal and
-then call `BeginInvoke` through Mono's torn-down X11 handle. Callback admission
-and UI marshaling now share one gate with disposal, and a deterministic smoke
-holds a callback at that boundary while teardown begins. The correction adds
-no text or catalog keys and changes no invariant command, transcript, layout,
-or machine contract. Warning-free managed compilation passes locally; hosted
-Mono/Xvfb and Windows managed matrices remain the acceptance evidence.
+strict post-closure safety run `30568877447` passes.
 
 The first live protected run `31623671192` passed external signer/registry
 preflight, configured and built the enforced Windows guard, and passed the
@@ -102,8 +85,24 @@ seven expected fail-closed cases, but the workflow step failed because the
 PowerShell orchestrator left the final expected exit code `4` in global process
 state. GitHub propagated that stale value and skipped the non-secret evidence
 upload. The correction resets only that process state after assertions,
-evidence generation, and cleanup. A successful rerun remains required before
-the protected trust gate can close.
+evidence generation, and cleanup. Corrected run `31630819119` passes every
+step and uploads artifact `9155061757`, whose independently reproduced archive
+digest is
+`sha256:c66fd93daab64d3c2abee12291648987f0ebff701ca36f625bfa7d4f207582eb`.
+The report records a valid launch and seven exit-code-`4` pre-start failures;
+the downloaded evidence contains no private-key or secret markers.
+
+Hosted Linux managed-UI run `31624289221` subsequently reproduced an
+asynchronous standalone-terminal teardown crash: a pending stderr callback
+could pass its stopped/disposed checks immediately before form disposal and
+then call `BeginInvoke` through Mono's torn-down X11 handle. Callback admission
+and UI marshaling now share one gate with disposal, and a deterministic smoke
+holds a callback at that boundary while teardown begins. The correction adds
+no text or catalog keys and changes no invariant command, transcript, layout,
+or machine contract. Warning-free managed compilation passes locally. Exact
+v1 forward-port run `31633512939` passes the Linux Mono/Xvfb standalone-shell
+and adjacent property-grid smoke; the accepted Windows managed matrix remains
+unchanged.
 
 The latest broad implementation baseline is product head `93d44395f`; the
 latest product implementation/test head is `f0c9e06e2`, while subsequent

--- a/docs/26-localization-and-release-readiness.md
+++ b/docs/26-localization-and-release-readiness.md
@@ -67,11 +67,14 @@ catalog or invariant diagnostic contract changed in #4894. The approved
 protected signer execution remains an external release gate.
 
 Audit child #4895 additionally binds the signer/guard job to the fixed GitHub
-Actions `release` environment. The release administrator must configure a
-required reviewer, prevent self-review, restrict the environment to `main`,
-and provision both approved secrets at environment scope. The repository does
-not perform or claim those authority-bearing steps, and no localized or
-machine-readable contract changes in this workflow-only slice. Independent
+Actions `release` environment. The release administrator must restrict the
+environment to `main` and provision both approved secrets at environment
+scope. When a second trusted maintainer is available, a required reviewer and
+prevention of self-review are mandatory. In the current single-owner topology,
+an explicit recorded owner dispatch replaces the unavailable independent
+approval and the limitation must be disclosed. Secret contents remain outside
+source control, and no localized or machine-readable contract changes in this
+workflow-only slice. Independent
 review found and correction head `0a8a43080` closes the missing exact
 `contents: read` regression guard; the same reviewer passes the corrected
 slice. That exact corrected head passes hosted Linux/macOS Native `316/316` and
@@ -91,6 +94,16 @@ holds a callback at that boundary while teardown begins. The correction adds
 no text or catalog keys and changes no invariant command, transcript, layout,
 or machine contract. Warning-free managed compilation passes locally; hosted
 Mono/Xvfb and Windows managed matrices remain the acceptance evidence.
+
+The first live protected run `31623671192` passed external signer/registry
+preflight, configured and built the enforced Windows guard, and passed the
+package-trust verifier. Its actual walkthrough reached the valid launch and all
+seven expected fail-closed cases, but the workflow step failed because the
+PowerShell orchestrator left the final expected exit code `4` in global process
+state. GitHub propagated that stale value and skipped the non-secret evidence
+upload. The correction resets only that process state after assertions,
+evidence generation, and cleanup. A successful rerun remains required before
+the protected trust gate can close.
 
 The latest broad implementation baseline is product head `93d44395f`; the
 latest product implementation/test head is `f0c9e06e2`, while subsequent

--- a/docs/29-package-trust-contract.md
+++ b/docs/29-package-trust-contract.md
@@ -111,10 +111,10 @@ The signing/guard job is bound to the fixed GitHub Actions environment
 `release`; the environment name is not a dispatch input or expression. Before
 any protected run, a repository administrator must:
 
-1. create the `release` environment and configure one or more required
-   reviewers;
-2. enable prevention of self-review so the dispatcher cannot approve the same
-   run;
+1. create the `release` environment and, when a second trusted maintainer is
+   available, configure one or more required reviewers;
+2. enable prevention of self-review whenever an independent reviewer is
+   configured;
 3. restrict deployment branches to `main`;
 4. create environment-scoped
    `COPPERFIN_LAUNCHER_TRUST_REGISTRY_HEADER` and
@@ -122,13 +122,18 @@ any protected run, a repository administrator must:
 5. confirm the same secret names are not being supplied as repository-level
    substitutes for the release ceremony.
 
-An environment that is absent, has no required reviewer, permits self-review,
-or admits branches other than `main` is not protected release evidence. The
-job must remain pending until the configured reviewer approves it, and secret
-material must not become available to the runner before that approval. The
-repository intentionally does not create the environment, select its reviewer,
-or provision its secrets in source control; those are external #4409 release
-authority.
+For a single-owner repository with no second trusted maintainer, the recorded
+owner-only manual dispatch, fixed workflow/environment binding, `main`-only
+deployment policy, environment-scoped secrets, and absence of other write
+access form the available release-authority boundary; claiming independent
+approval in that topology would be false. When another trusted maintainer is
+admitted, required independent review and prevention of self-review become
+mandatory before a later official release. An environment that is absent or
+admits branches other than `main` is not protected release evidence. When a
+reviewer is configured, the job must remain pending until that reviewer
+approves it, and secret material must not become available before approval.
+The repository intentionally does not provision secret contents in source
+control; those remain external #4409 release authority.
 
 The protected job derives a canonical `app.cftrust` from an exact finalized
 fixture inventory, signs it with the external key reference through the native
@@ -142,6 +147,9 @@ are uploaded. This workflow path is implemented under
 #4894 and its fixed release-environment binding is enforced under #4895, but it
 is release evidence only after an externally approved registry and key execute
 it successfully through the configured environment approval.
+In the documented single-owner exception, an explicit owner dispatch replaces
+the unavailable independent environment approval and must be disclosed in the
+validation evidence and release limitations.
 
 ## Platform Policy
 

--- a/docs/29-package-trust-contract.md
+++ b/docs/29-package-trust-contract.md
@@ -133,7 +133,8 @@ admits branches other than `main` is not protected release evidence. When a
 reviewer is configured, the job must remain pending until that reviewer
 approves it, and secret material must not become available before approval.
 The repository intentionally does not provision secret contents in source
-control; those remain external #4409 release authority.
+control; they remain outside source control as environment-scoped release
+authority inputs.
 
 The protected job derives a canonical `app.cftrust` from an exact finalized
 fixture inventory, signs it with the external key reference through the native
@@ -143,17 +144,22 @@ removed/duplicate/case-ambiguous inventory records, and modified or removed
 signature sidecars must all return exit code `4` without starting that apphost.
 Only the signer ID, commit/run identity, finalized direct artifact names/roles
 and SHA-256 digests, invariant case results, and non-secret provisioning facts
-are uploaded. This workflow path is implemented under
-#4894 and its fixed release-environment binding is enforced under #4895, but it
-is release evidence only after an externally approved registry and key execute
-it successfully through the configured environment approval.
-In the documented single-owner exception, an explicit owner dispatch replaces
-the unavailable independent environment approval and must be disclosed in the
-validation evidence and release limitations.
+are uploaded. This workflow path is implemented under #4894 and its fixed
+release-environment binding is enforced under #4895, but it is release evidence
+only after the workflow executes successfully with an externally approved
+registry/key pair through the configured environment approval. In the documented
+single-owner exception, an explicit owner dispatch replaces the unavailable
+independent environment approval and must be disclosed in the validation evidence
+and release limitations.
 
 ## Platform Policy
 
-For an enforced release build, Windows generated-launcher packages require both trust sidecars and reject unsigned or unknown-signer inventories before managed apphost startup. The guard retains the existing containment, regular-file, physical-identity, and SHA-256 checks after signature verification. Until an approved release signer and registry are provisioned, ordinary development packages intentionally use the unsigned fallback and must not be presented as meeting the Windows release trust boundary.
+For an enforced release build, Windows generated-launcher packages require both
+trust sidecars and reject unsigned or unknown-signer inventories before managed
+apphost startup. The guard retains the existing containment, regular-file,
+physical-identity, and SHA-256 checks after signature verification. Ordinary
+development packages intentionally use the unsigned fallback and must not be
+presented as meeting the Windows release trust boundary.
 
 POSIX and macOS do not claim this Windows trust boundary yet. Until platform-specific release signing and verification are approved, they retain the current unsigned inventory behavior and report the trust capability as unsupported rather than treating a recomputed unsigned inventory as authenticated.
 
@@ -166,8 +172,7 @@ verification vector. The Windows `test_generated_launcher_process` regression
 also proves malformed trust sidecars fail before managed startup. The #4894
 fixture and protected orchestrator cover the external signer-to-guard path and
 record whether the internal apphost started for every case. No private or
-machine-specific key is embedded. The protected workflow must still run with
-the approved registry/key pair before the release trust boundary is claimed.
+machine-specific key is embedded.
 
 Implementation evidence is current at head `f0c9e06e2`. Windows native run
 `30559930672` built `test_windows_launcher_trust_fixture` with MSVC and passed
@@ -175,5 +180,12 @@ Implementation evidence is current at head `f0c9e06e2`. Windows native run
 Generated-launcher run `30559417230` passed at the exact duplicate-signer head
 `3968fabff`, and independent review confirmed the signer, registry, evidence,
 and cleanup boundaries. Permissive safety run `30559107092` produced artifact
-`8766084663`. These results validate the implementation contract only; the
-approved protected execution required by #4409 remains outstanding.
+`8766084663`. Corrected protected execution `31630819119` then passed at
+`111fb67d09df1413221beeebce9b684f47097053` with signer
+`copperfin-launcher-2026-01`. Artifact `9155061757` has independently matched
+archive digest
+`sha256:c66fd93daab64d3c2abee12291648987f0ebff701ca36f625bfa7d4f207582eb`;
+its report contains the exact five-artifact inventory, one valid launch, and
+seven exit-code-`4` failures before apphost start. This satisfies #4409's
+Windows launcher-trust execution boundary while leaving platform signing and
+ordinary unsigned development behavior unchanged.

--- a/docs/safety/launcher-trust-validation-2026-08-12.md
+++ b/docs/safety/launcher-trust-validation-2026-08-12.md
@@ -1,0 +1,59 @@
+# Windows Launcher-Trust Validation Evidence — 2026-08-12
+
+## Scope
+
+This record links the protected external signer procedure to its safety and
+security evidence without recording private key material. It covers only the
+Windows pre-execution launcher guard. Authenticode, Apple signing/notarization,
+Linux package signing, and ordinary unsigned development builds remain
+separate limitations.
+
+## Traceability
+
+| Requirement | Verification | Hazards |
+| --- | --- | --- |
+| `DQ-MVP-4894-protected-launcher-signing-procedure` | `DV-MVP-4894-workflow-contract`; `DV-MVP-4894-enforced-guard-walkthrough`; `DV-MVP-4894-independent-review` | `HZ-system-failure-01`; `HZ-doc-command-01` |
+| `DQ-MVP-4894-non-secret-evidence-boundary` | `DV-MVP-4894-workflow-contract`; `DV-MVP-4894-independent-review` | `HZ-system-failure-01`; `HZ-doc-command-01` |
+
+## First Protected Execution
+
+Run `31623671192` used the non-secret signer ID
+`copperfin-launcher-2026-01` at `main` commit
+`b458c8794369cb65811e3c5041f8d3804a678e9d`. The `release` environment was
+restricted to `main` and supplied the private signing key and matching public
+registry through environment-scoped secrets. The log did not disclose either
+secret.
+
+The run passed protected-input materialization, signer/registry preflight, the
+enforced native build, and the package-trust verifier. The guard walkthrough
+then executed the valid signed launch and the modified/removed artifact,
+removed/duplicate/case-ambiguous inventory, and modified/removed signature
+cases. Expected negative cases returned invariant exit code `4` before the
+internal apphost started.
+
+The job nevertheless failed after the matrix because the orchestration script
+left the last expected guard exit code in PowerShell's global `LASTEXITCODE`.
+GitHub's wrapper propagated that stale value and skipped the non-secret
+evidence upload. This is a procedural result-state defect; it does not show a
+signature, registry, verifier, or guard bypass.
+
+## Correction And Gate State
+
+The correction clears the expected-negative process state only after every
+case assertion, evidence write, and protected-input cleanup completes. The
+workflow source contract requires exactly one reset at the end of the script.
+Removing, duplicating, or moving the reset must fail the focused contract.
+
+`DV-MVP-4894-enforced-guard-walkthrough` remains **pending** until a corrected
+protected Windows run passes and its uploaded JSON is inspected. This record
+must be amended with the exact corrected commit, run, artifact digest, eight
+case results, and independent review before #4894/#4409 close or a new RC is
+assembled.
+
+## Release Authority Limitation
+
+The repository currently has one owner and no second trusted maintainer. The
+run therefore uses a recorded owner-only manual dispatch rather than claiming
+independent environment approval. The environment remains `main`-only and the
+secrets remain environment-scoped. Required independent review and prevention
+of self-review become mandatory when another trusted maintainer is admitted.

--- a/docs/safety/launcher-trust-validation-2026-08-12.md
+++ b/docs/safety/launcher-trust-validation-2026-08-12.md
@@ -37,23 +37,57 @@ GitHub's wrapper propagated that stale value and skipped the non-secret
 evidence upload. This is a procedural result-state defect; it does not show a
 signature, registry, verifier, or guard bypass.
 
-## Correction And Gate State
+## Corrected Protected Execution
 
 The correction clears the expected-negative process state only after every
 case assertion, evidence write, and protected-input cleanup completes. The
 workflow source contract requires exactly one reset at the end of the script.
 Removing, duplicating, or moving the reset must fail the focused contract.
 
-`DV-MVP-4894-enforced-guard-walkthrough` remains **pending** until a corrected
-protected Windows run passes and its uploaded JSON is inspected. This record
-must be amended with the exact corrected commit, run, artifact digest, eight
-case results, and independent review before #4894/#4409 close or a new RC is
-assembled.
+Corrected protected run `31630819119` passed at exact `main` merge commit
+`111fb67d09df1413221beeebce9b684f47097053`. The run used signer ID
+`copperfin-launcher-2026-01`, a valid one-entry external registry, and the
+fixed `release` environment restricted to `main`. Every workflow step passed,
+including protected-input cleanup.
+
+Artifact `9155061757`,
+`copperfin-windows-launcher-trust-provisioning`, has GitHub archive digest
+`sha256:c66fd93daab64d3c2abee12291648987f0ebff701ca36f625bfa7d4f207582eb`.
+An independent download produced the same archive digest. Its two non-secret
+JSON files have these SHA-256 digests:
+
+- provisioning: `7adcc4ff91d5319b2969caa1e30523236d69918049481a80576472780ebc8cb7`;
+- validation: `845459b1f83e587002aebc51d2f98a8db03edce9f1e9dc74bac3ab3a56563fa9`.
+
+The validation report records exactly five finalized package artifacts and
+eight unique cases. `valid-signed-launch` returned `0`, started the internal
+apphost, and passed. `modified-artifact`, `removed-artifact`,
+`removed-inventory-record`, `duplicate-inventory-record`,
+`case-ambiguous-inventory-record`, `modified-signature-sidecar`, and
+`removed-signature-sidecar` each returned `4`, did not start the internal
+apphost, and passed. Machine assertions independently verified the schema,
+signer, commit/run identity, unique case and artifact counts, 64-character
+lowercase SHA-256 values, and all exit/start/status invariants. A marker scan
+found no private-key or secret material in the downloaded evidence.
+
+The exact PR head passed all 17 hosted checks before merge, including Linux,
+Windows, and macOS native validation, both executable-path compilers, Windows
+environment/path and DECLARE lanes, managed UI, all installers, VSIX,
+security/SBOM, DCO, and socket checks. Independent source review verified that
+the end-of-script process-state reset cannot mask a thrown failure and that
+the focused contract rejects a missing, duplicated, or misplaced reset.
+
+`DV-MVP-4894-enforced-guard-walkthrough` and the non-secret evidence boundary
+are therefore satisfied. This evidence closes the Windows launcher-inventory
+trust scopes in #4894, #4409, #4387, and #4041. It does not authorize a public
+release or satisfy the separate Authenticode, Apple signing/notarization,
+Linux package signing, independent safety-review, or localization-review gates.
 
 ## Release Authority Limitation
 
-The repository currently has one owner and no second trusted maintainer. The
-run therefore uses a recorded owner-only manual dispatch rather than claiming
-independent environment approval. The environment remains `main`-only and the
-secrets remain environment-scoped. Required independent review and prevention
-of self-review become mandatory when another trusted maintainer is admitted.
+The repository currently has one owner and no second trusted maintainer.
+The corrected run therefore uses a recorded owner-only manual dispatch rather
+than claiming independent environment approval. The environment remains
+`main`-only and the secrets remain environment-scoped. Required independent
+review and prevention of self-review become mandatory when another trusted
+maintainer is admitted.

--- a/scripts/run-windows-launcher-trust-validation.ps1
+++ b/scripts/run-windows-launcher-trust-validation.ps1
@@ -158,3 +158,10 @@ try {
     Remove-Item Env:COPPERFIN_TEST_LAUNCHER_TRUST_MARKER -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $packageRoot -Recurse -Force -ErrorAction SilentlyContinue
 }
+
+# The final matrix case intentionally returns guard exit code 4. GitHub's pwsh
+# wrapper propagates a surviving LASTEXITCODE after this script returns, so
+# clear that expected-negative process state only after every assertion,
+# evidence write, and cleanup step has completed successfully.
+$global:LASTEXITCODE = 0
+Write-Host "Launcher trust validation passed $($results.Count) case(s)."

--- a/tests/run_launcher_trust_provisioning_contract_check.cmake
+++ b/tests/run_launcher_trust_provisioning_contract_check.cmake
@@ -50,12 +50,30 @@ foreach(REQUIRED_TEXT IN ITEMS
     "exit_code"
     "package_relative_name"
     "sha256"
+    "clear that expected-negative process state"
+    "\$global:LASTEXITCODE = 0"
 )
     string(FIND "${VALIDATION_SCRIPT_CONTENT}" "${REQUIRED_TEXT}" POSITION)
     if(POSITION EQUAL -1)
         message(FATAL_ERROR "launcher trust validation is missing required contract text: ${REQUIRED_TEXT}")
     endif()
 endforeach()
+
+string(REGEX MATCHALL "\\$global:LASTEXITCODE[ ]*=[ ]*0"
+    EXPLICIT_SUCCESS_STATE_RESETS "${VALIDATION_SCRIPT_CONTENT}")
+list(LENGTH EXPLICIT_SUCCESS_STATE_RESETS EXPLICIT_SUCCESS_STATE_RESET_COUNT)
+if(NOT EXPLICIT_SUCCESS_STATE_RESET_COUNT EQUAL 1)
+    message(FATAL_ERROR
+        "launcher trust validation must clear expected-negative process state exactly once")
+endif()
+
+string(REGEX MATCH
+    "\\$global:LASTEXITCODE[ ]*=[ ]*0[^\n]*\nWrite-Host[^\n]*\n*$"
+    EXPLICIT_SUCCESS_STATE_AT_END "${VALIDATION_SCRIPT_CONTENT}")
+if(NOT EXPLICIT_SUCCESS_STATE_AT_END)
+    message(FATAL_ERROR
+        "launcher trust validation must clear expected-negative process state only after cleanup")
+endif()
 
 file(READ "${WORKFLOW}" WORKFLOW_CONTENT)
 foreach(REQUIRED_TEXT IN ITEMS


### PR DESCRIPTION
## Summary

- forward-port the reviewed launcher-trust PowerShell exit-state correction from main
- forward-port the successful protected Windows run evidence and closure state
- preserve all newer v1 roadmap, portability, terminal, and optional robustness history
- remove contradictory current-state wording that still described the completed launcher-trust gate as pending

## Validation

- test_package_document_install passed
- test_launcher_trust_provisioning_contract passed
- test_safety_traceability_workflow_contract passed
- corrected orchestrator and provisioning-contract blobs exactly match the reviewed main correction
- safety evidence blob exactly matches the reviewed protected-run evidence
- both commits have valid Ed25519 Git signatures and DCO sign-off
- git diff --check

## Windows evidence

Protected Windows run 31630819119 passed on the exact identical orchestrator and contract bytes at main commit 111fb67d09df1413221beeebce9b684f47097053. The release environment is intentionally main-only, so this forward-port does not weaken that authority boundary by dispatching protected secrets on v1-development.