### PR TITLE
Forward-port distinct launcher trust evidence to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   one successful signed launch, seven fail-closed negative cases, and no
   secret-material markers. This refines fixture fidelity without changing the
   trust model, signed inventory contract, or ordinary development behavior.
+  Review hardening now binds each constant name to its exact role-specific
+  literal as well as its intended sidecar path, so initializer and usage swaps
+  both fail the focused source contract.
 
 - 2026-08-12: Made the protected Windows launcher-trust fixture's dependency
   and runtime-configuration JSON payloads distinct. The signed inventory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,6 @@
   literal as well as its intended sidecar path, so initializer and usage swaps
   both fail the focused source contract.
 
-- 2026-08-12: Made the protected Windows launcher-trust fixture's dependency
-  and runtime-configuration JSON payloads distinct. The signed inventory
-  already binds path, role, and digest, so product trust behavior is unchanged;
-  the fixture evidence is now more representative and its provisioning
-  contract prevents the duplicate marker payload from returning.
-
 - 2026-08-12: Corrected the v1 native isolation inventory after independent
   review found that `test_platform_file_version_boundary_contract` fell
   through to the fail-closed `audit=pending` default. A fresh configure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+- 2026-08-12: Superseded the protected Windows launcher-trust fixture evidence
+  after differentiating the dependency and runtime-configuration sidecar
+  payloads. Protected run `31635868978` passed at exact `main` merge
+  `477035ca2df6d0eb688d58e83aee80805e932d38`; artifact `9156951212` has
+  GitHub and independently reproduced archive digest
+  `sha256:9385656df3fbbcf0408d8e0c68bb42504dc7a9f1333272f4f05b8b4cbfa29dec`.
+  Machine verification confirms five unique paths with five distinct digests,
+  one successful signed launch, seven fail-closed negative cases, and no
+  secret-material markers. This refines fixture fidelity without changing the
+  trust model, signed inventory contract, or ordinary development behavior.
+
 - 2026-08-12: Made the protected Windows launcher-trust fixture's dependency
   and runtime-configuration JSON payloads distinct. The signed inventory
   already binds path, role, and digest, so product trust behavior is unchanged;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 2026-08-12: Made the protected Windows launcher-trust fixture's dependency
+  and runtime-configuration JSON payloads distinct. The signed inventory
+  already binds path, role, and digest, so product trust behavior is unchanged;
+  the fixture evidence is now more representative and its provisioning
+  contract prevents the duplicate marker payload from returning.
+
 - 2026-08-12: Corrected the v1 native isolation inventory after independent
   review found that `test_platform_file_version_boundary_contract` fell
   through to the fail-closed `audit=pending` default. A fresh configure

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -20,6 +20,8 @@ now respectively `40831f6757929bc14af6185082bccaadbd188d2246eb324b486e6b59792190
 and `6616eda4480368fb2615c9496a572bd52ac3b1f102d252cbdb6edca338a775d1`.
 This supersedes the earlier same-content fixture evidence without changing
 the path/role/digest trust contract or reopening the closed launcher gates.
+Review hardening binds both the exact constant-to-literal declarations and the
+constant-to-sidecar writes; swapping either layer fails the focused contract.
 
 ## Launcher-trust fixture review follow-up
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,26 @@
 # Agent Handoff
 
+## Launcher-trust distinct-payload evidence
+
+Protected run `31635868978` passes at exact `main` merge
+`477035ca2df6d0eb688d58e83aee80805e932d38` after the fixture dependency and
+runtime-configuration sidecars received distinct role-specific JSON payloads.
+Artifact `9156951212` has GitHub and independently reproduced archive digest
+`sha256:9385656df3fbbcf0408d8e0c68bb42504dc7a9f1333272f4f05b8b4cbfa29dec`.
+The provisioning and validation JSON digests are respectively
+`7adcc4ff91d5319b2969caa1e30523236d69918049481a80576472780ebc8cb7` and
+`9a475a239c492f9bf0243261506c1e00a3a93f42a68b078157b7b1e6ce78bba3`.
+
+Independent machine assertions confirm the exact signer, run, and commit;
+five unique artifact paths; five distinct valid SHA-256 values; one valid
+launch with exit `0` and apphost start; seven negative cases with exit `4`
+and no apphost start; and no private-key, passphrase, environment-secret, or
+registry-secret markers. The dependency and runtime-configuration digests are
+now respectively `40831f6757929bc14af6185082bccaadbd188d2246eb324b486e6b59792190e0`
+and `6616eda4480368fb2615c9496a572bd52ac3b1f102d252cbdb6edca338a775d1`.
+This supersedes the earlier same-content fixture evidence without changing
+the path/role/digest trust contract or reopening the closed launcher gates.
+
 ## Launcher-trust fixture review follow-up
 
 Independent inspection of protected run `31630819119` confirmed the archive
@@ -10,10 +31,9 @@ paths used the same empty JSON payload and therefore had the same digest.
 The signed trust contract was not bypassed: each inventory record binds its
 package-relative path, role, and SHA-256 digest, and identical file content is
 valid. The fixture now uses distinct valid JSON markers for those two roles,
-with a source-contract regression preventing accidental reintroduction. Rerun
-the protected Windows launcher-trust workflow after this correction is merged
-to supersede the earlier fixture evidence before assembling the next immutable
-release candidate.
+with a source-contract regression preventing accidental reintroduction. The
+protected rerun recorded above supersedes the earlier fixture-content evidence
+before assembly of the next immutable release candidate.
 
 ## Windows launcher-trust protected execution complete
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,20 @@
 # Agent Handoff
 
+## Launcher-trust fixture review follow-up
+
+Independent inspection of protected run `31630819119` confirmed the archive
+and report hashes, all eight guard outcomes, and the absence of secret
+material. It also observed that the fixture's dependency and runtime-config
+paths used the same empty JSON payload and therefore had the same digest.
+
+The signed trust contract was not bypassed: each inventory record binds its
+package-relative path, role, and SHA-256 digest, and identical file content is
+valid. The fixture now uses distinct valid JSON markers for those two roles,
+with a source-contract regression preventing accidental reintroduction. Rerun
+the protected Windows launcher-trust workflow after this correction is merged
+to supersede the earlier fixture evidence before assembling the next immutable
+release candidate.
+
 ## Windows launcher-trust protected execution complete
 
 The first live protected `Windows Launcher Trust Validation` run

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -2,26 +2,12 @@
 
 ## Launcher-trust distinct-payload evidence
 
-Protected run `31635868978` passes at exact `main` merge
-`477035ca2df6d0eb688d58e83aee80805e932d38` after the fixture dependency and
-runtime-configuration sidecars received distinct role-specific JSON payloads.
-Artifact `9156951212` has GitHub and independently reproduced archive digest
-`sha256:9385656df3fbbcf0408d8e0c68bb42504dc7a9f1333272f4f05b8b4cbfa29dec`.
-The provisioning and validation JSON digests are respectively
-`7adcc4ff91d5319b2969caa1e30523236d69918049481a80576472780ebc8cb7` and
-`9a475a239c492f9bf0243261506c1e00a3a93f42a68b078157b7b1e6ce78bba3`.
-
-Independent machine assertions confirm the exact signer, run, and commit;
-five unique artifact paths; five distinct valid SHA-256 values; one valid
-launch with exit `0` and apphost start; seven negative cases with exit `4`
-and no apphost start; and no private-key, passphrase, environment-secret, or
-registry-secret markers. The dependency and runtime-configuration digests are
-now respectively `40831f6757929bc14af6185082bccaadbd188d2246eb324b486e6b59792190e0`
-and `6616eda4480368fb2615c9496a572bd52ac3b1f102d252cbdb6edca338a775d1`.
-This supersedes the earlier same-content fixture evidence without changing
-the path/role/digest trust contract or reopening the closed launcher gates.
-Review hardening binds both the exact constant-to-literal declarations and the
-constant-to-sidecar writes; swapping either layer fails the focused contract.
+Protected run `31635868978` passes at exact `main` merge `477035ca2` with five
+distinct artifact digests and all eight guard cases passing. Canonical hashes,
+case assertions, and secret-boundary evidence are in
+`docs/safety/launcher-trust-validation-2026-08-12.md`. Review hardening binds
+both exact constant-to-literal declarations and constant-to-sidecar writes;
+initializer and usage swaps fail while whitespace-only formatting remains free.
 
 ## Launcher-trust fixture review follow-up
 

--- a/docs/safety/launcher-trust-validation-2026-08-12.md
+++ b/docs/safety/launcher-trust-validation-2026-08-12.md
@@ -83,6 +83,42 @@ trust scopes in #4894, #4409, #4387, and #4041. It does not authorize a public
 release or satisfy the separate Authenticode, Apple signing/notarization,
 Linux package signing, independent safety-review, or localization-review gates.
 
+## Superseding Distinct-Payload Execution
+
+Independent review of the corrected artifact found that the dependency and
+runtime-configuration fixture sidecars used identical minimal JSON content.
+The signed inventory still bound each path, role, and digest independently, so
+this was not a verifier bypass. The fixture was nevertheless made more
+representative by assigning valid, role-specific JSON payloads and by adding a
+source contract that rejects missing or swapped bindings.
+
+Protected run `31635868978` passed every step at exact `main` merge commit
+`477035ca2df6d0eb688d58e83aee80805e932d38`, including protected-input
+materialization, signer/registry preflight, enforced build, package contract,
+guard walkthrough, evidence upload, and protected-input cleanup. Artifact
+`9156951212` has GitHub archive digest
+`sha256:9385656df3fbbcf0408d8e0c68bb42504dc7a9f1333272f4f05b8b4cbfa29dec`;
+an independent raw download reproduced that digest. The provisioning JSON
+retains digest
+`7adcc4ff91d5319b2969caa1e30523236d69918049481a80576472780ebc8cb7`, and
+the superseding validation JSON has digest
+`9a475a239c492f9bf0243261506c1e00a3a93f42a68b078157b7b1e6ce78bba3`.
+
+Machine assertions verified the exact signer, run, and commit identities;
+five unique artifact paths; five distinct lowercase SHA-256 values; eight
+unique cases; the valid launch's exit `0`, apphost start, and passing status;
+and all seven negative cases' exit `4`, absent apphost start, and passing
+status. The dependency and runtime-configuration fixture digests are now
+distinct:
+
+- dependency sidecar: `40831f6757929bc14af6185082bccaadbd188d2246eb324b486e6b59792190e0`;
+- runtime-configuration sidecar: `6616eda4480368fb2615c9496a572bd52ac3b1f102d252cbdb6edca338a775d1`.
+
+A refined scan found no PEM private-key block, passphrase, signing-key secret
+name, or registry-secret name in either downloaded JSON file. This execution
+supersedes the earlier fixture-content evidence while preserving its valid
+trust and fail-closed conclusions.
+
 ## Release Authority Limitation
 
 The repository currently has one owner and no second trusted maintainer.

--- a/tests/run_launcher_trust_provisioning_contract_check.cmake
+++ b/tests/run_launcher_trust_provisioning_contract_check.cmake
@@ -9,9 +9,45 @@ endif()
 set(SCRIPT "${SOURCE_DIR}/scripts/prepare-windows-launcher-trust.ps1")
 set(VALIDATION_SCRIPT "${SOURCE_DIR}/scripts/run-windows-launcher-trust-validation.ps1")
 set(WORKFLOW "${SOURCE_DIR}/.github/workflows/windows-launcher-trust-validation.yml")
+set(FIXTURE "${SOURCE_DIR}/tests/test_windows_launcher_trust_fixture.cpp")
 foreach(REQUIRED_FILE IN ITEMS "${SCRIPT}" "${VALIDATION_SCRIPT}" "${WORKFLOW}")
     if(NOT EXISTS "${REQUIRED_FILE}")
         message(FATAL_ERROR "launcher trust provisioning file is missing: ${REQUIRED_FILE}")
+    endif()
+endforeach()
+
+if(NOT EXISTS "${FIXTURE}")
+    message(FATAL_ERROR "launcher trust fixture source is missing: ${FIXTURE}")
+endif()
+
+file(READ "${FIXTURE}" FIXTURE_CONTENT)
+foreach(REQUIRED_TEXT IN ITEMS
+    "constexpr char kDependenciesFixturePayload[] ="
+    "{\\\"fixture\\\":\\\"dependencies\\\"}\\n"
+    "constexpr char kRuntimeConfigurationFixturePayload[] ="
+    "{\\\"fixture\\\":\\\"runtime-configuration\\\"}\\n"
+    "kDependenciesFixturePayload);"
+    "kRuntimeConfigurationFixturePayload);"
+)
+    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_TEXT}" POSITION)
+    if(POSITION EQUAL -1)
+        message(FATAL_ERROR
+            "launcher trust fixture must retain distinct dependency and runtime-configuration payloads: ${REQUIRED_TEXT}")
+    endif()
+endforeach()
+
+set(DEPENDENCIES_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.deps.json",
+               kDependenciesFixturePayload);]=])
+set(RUNTIME_CONFIGURATION_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json",
+               kRuntimeConfigurationFixturePayload);]=])
+foreach(REQUIRED_BINDING IN ITEMS
+    "${DEPENDENCIES_FIXTURE_BINDING}"
+    "${RUNTIME_CONFIGURATION_FIXTURE_BINDING}"
+)
+    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_BINDING}" POSITION)
+    if(POSITION EQUAL -1)
+        message(FATAL_ERROR
+            "launcher trust fixture payload is not bound to its intended sidecar")
     endif()
 endforeach()
 

--- a/tests/run_launcher_trust_provisioning_contract_check.cmake
+++ b/tests/run_launcher_trust_provisioning_contract_check.cmake
@@ -21,33 +21,24 @@ if(NOT EXISTS "${FIXTURE}")
 endif()
 
 file(READ "${FIXTURE}" FIXTURE_CONTENT)
-foreach(REQUIRED_TEXT IN ITEMS
-    "constexpr char kDependenciesFixturePayload[] ="
-    "{\\\"fixture\\\":\\\"dependencies\\\"}\\n"
-    "constexpr char kRuntimeConfigurationFixturePayload[] ="
-    "{\\\"fixture\\\":\\\"runtime-configuration\\\"}\\n"
-    "kDependenciesFixturePayload);"
-    "kRuntimeConfigurationFixturePayload);"
-)
-    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_TEXT}" POSITION)
-    if(POSITION EQUAL -1)
-        message(FATAL_ERROR
-            "launcher trust fixture must retain distinct dependency and runtime-configuration payloads: ${REQUIRED_TEXT}")
-    endif()
-endforeach()
-
+set(DEPENDENCIES_FIXTURE_DECLARATION [=[constexpr char kDependenciesFixturePayload[] =
+    "{\"fixture\":\"dependencies\"}\n";]=])
+set(RUNTIME_CONFIGURATION_FIXTURE_DECLARATION [=[constexpr char kRuntimeConfigurationFixturePayload[] =
+    "{\"fixture\":\"runtime-configuration\"}\n";]=])
 set(DEPENDENCIES_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.deps.json",
                kDependenciesFixturePayload);]=])
 set(RUNTIME_CONFIGURATION_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json",
                kRuntimeConfigurationFixturePayload);]=])
-foreach(REQUIRED_BINDING IN ITEMS
+foreach(REQUIRED_FIXTURE_CONTRACT IN ITEMS
+    "${DEPENDENCIES_FIXTURE_DECLARATION}"
+    "${RUNTIME_CONFIGURATION_FIXTURE_DECLARATION}"
     "${DEPENDENCIES_FIXTURE_BINDING}"
     "${RUNTIME_CONFIGURATION_FIXTURE_BINDING}"
 )
-    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_BINDING}" POSITION)
+    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_FIXTURE_CONTRACT}" POSITION)
     if(POSITION EQUAL -1)
         message(FATAL_ERROR
-            "launcher trust fixture payload is not bound to its intended sidecar")
+            "launcher trust fixture payload declaration or sidecar binding is incorrect")
     endif()
 endforeach()
 

--- a/tests/run_launcher_trust_provisioning_contract_check.cmake
+++ b/tests/run_launcher_trust_provisioning_contract_check.cmake
@@ -21,21 +21,18 @@ if(NOT EXISTS "${FIXTURE}")
 endif()
 
 file(READ "${FIXTURE}" FIXTURE_CONTENT)
-set(DEPENDENCIES_FIXTURE_DECLARATION [=[constexpr char kDependenciesFixturePayload[] =
-    "{\"fixture\":\"dependencies\"}\n";]=])
-set(RUNTIME_CONFIGURATION_FIXTURE_DECLARATION [=[constexpr char kRuntimeConfigurationFixturePayload[] =
-    "{\"fixture\":\"runtime-configuration\"}\n";]=])
-set(DEPENDENCIES_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.deps.json",
-               kDependenciesFixturePayload);]=])
-set(RUNTIME_CONFIGURATION_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json",
-               kRuntimeConfigurationFixturePayload);]=])
+string(REGEX REPLACE "[ \t\r\n]+" " " FIXTURE_NORMALIZED "${FIXTURE_CONTENT}")
+set(DEPENDENCIES_FIXTURE_DECLARATION [=[constexpr char kDependenciesFixturePayload[] = "{\"fixture\":\"dependencies\"}\n";]=])
+set(RUNTIME_CONFIGURATION_FIXTURE_DECLARATION [=[constexpr char kRuntimeConfigurationFixturePayload[] = "{\"fixture\":\"runtime-configuration\"}\n";]=])
+set(DEPENDENCIES_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.deps.json", kDependenciesFixturePayload);]=])
+set(RUNTIME_CONFIGURATION_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json", kRuntimeConfigurationFixturePayload);]=])
 foreach(REQUIRED_FIXTURE_CONTRACT IN ITEMS
     "${DEPENDENCIES_FIXTURE_DECLARATION}"
     "${RUNTIME_CONFIGURATION_FIXTURE_DECLARATION}"
     "${DEPENDENCIES_FIXTURE_BINDING}"
     "${RUNTIME_CONFIGURATION_FIXTURE_BINDING}"
 )
-    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_FIXTURE_CONTRACT}" POSITION)
+    string(FIND "${FIXTURE_NORMALIZED}" "${REQUIRED_FIXTURE_CONTRACT}" POSITION)
     if(POSITION EQUAL -1)
         message(FATAL_ERROR
             "launcher trust fixture payload declaration or sidecar binding is incorrect")

--- a/tests/run_launcher_trust_provisioning_contract_check.cmake
+++ b/tests/run_launcher_trust_provisioning_contract_check.cmake
@@ -32,10 +32,18 @@ foreach(REQUIRED_FIXTURE_CONTRACT IN ITEMS
     "${DEPENDENCIES_FIXTURE_BINDING}"
     "${RUNTIME_CONFIGURATION_FIXTURE_BINDING}"
 )
-    string(FIND "${FIXTURE_NORMALIZED}" "${REQUIRED_FIXTURE_CONTRACT}" POSITION)
+    # The source normalization above collapses every whitespace run to one
+    # space. Remove those spaces from both sides so purely stylistic spacing
+    # cannot weaken or trip the semantic name/value and path/name checks.
+    string(REPLACE " " "" FIXTURE_CONTRACT_TOKENS "${FIXTURE_NORMALIZED}")
+    string(REPLACE " " "" REQUIRED_FIXTURE_CONTRACT_TOKENS
+        "${REQUIRED_FIXTURE_CONTRACT}")
+    string(FIND "${FIXTURE_CONTRACT_TOKENS}"
+        "${REQUIRED_FIXTURE_CONTRACT_TOKENS}" POSITION)
     if(POSITION EQUAL -1)
         message(FATAL_ERROR
-            "launcher trust fixture payload declaration or sidecar binding is incorrect")
+            "launcher trust fixture payload declaration or sidecar binding is incorrect: "
+            "${REQUIRED_FIXTURE_CONTRACT}")
     endif()
 endforeach()
 

--- a/tests/test_windows_launcher_trust_fixture.cpp
+++ b/tests/test_windows_launcher_trust_fixture.cpp
@@ -21,6 +21,11 @@
 
 namespace {
 
+constexpr char kDependenciesFixturePayload[] =
+    "{\"fixture\":\"dependencies\"}\n";
+constexpr char kRuntimeConfigurationFixturePayload[] =
+    "{\"fixture\":\"runtime-configuration\"}\n";
+
 #if !defined(_WIN32)
 constexpr const char* kMarkerEnvironment = "COPPERFIN_TEST_LAUNCHER_TRUST_MARKER";
 #endif
@@ -108,8 +113,10 @@ int prepare_fixture(
         return 2;
     }
     write_text(package_root / "Copperfin.GeneratedLauncher.dll", "launcher dll fixture\n");
-    write_text(package_root / "Copperfin.GeneratedLauncher.deps.json", "{}\n");
-    write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json", "{}\n");
+    write_text(package_root / "Copperfin.GeneratedLauncher.deps.json",
+               kDependenciesFixturePayload);
+    write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json",
+               kRuntimeConfigurationFixturePayload);
 
     std::vector<copperfin::package_trust::LauncherInventoryArtifact> artifacts{
         {"public_apphost", public_name, file_digest(package_root / public_name)},


### PR DESCRIPTION
## Summary

- forward-port the distinct dependency/runtime-configuration fixture payloads
- preserve the exact path-to-role source contract
- forward-port protected run 31635868978 and artifact 9156951212 evidence
- retain v1-specific roadmap and history while keeping RC/main and v1 separate

## Verification

- fixture source and provisioning contract are byte-identical to reviewed main correction 9cd8acaa8
- safety evidence is byte-identical to signed main evidence head f735ffe6d
- built the portable fixture generator locally
- focused package-document, provisioning, and safety-workflow contracts passed 3/3
- git diff --check passed

Signed-off-by: rhamenator <rhamenator@gmail.com>