### PR TITLE
Bind launcher fixture payload literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   one successful signed launch, seven fail-closed negative cases, and no
   secret-material markers. This refines fixture fidelity without changing the
   trust model, signed inventory contract, or ordinary development behavior.
+  Review hardening now binds each constant name to its exact role-specific
+  literal as well as its intended sidecar path, so initializer and usage swaps
+  both fail the focused source contract.
 
 - 2026-08-12: Made the protected Windows launcher-trust fixture's dependency
   and runtime-configuration JSON payloads distinct. The signed inventory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,6 @@
   literal as well as its intended sidecar path, so initializer and usage swaps
   both fail the focused source contract.
 
-- 2026-08-12: Made the protected Windows launcher-trust fixture's dependency
-  and runtime-configuration JSON payloads distinct. The signed inventory
-  already binds path, role, and digest, so product trust behavior is unchanged;
-  the fixture evidence is now more representative and its provisioning
-  contract prevents the duplicate marker payload from returning.
-
 - 2026-08-12: Completed the protected Windows launcher-inventory trust gate.
   Corrected workflow run `31630819119` passed at exact merge commit
   `111fb67d09df1413221beeebce9b684f47097053` with the dedicated external signer

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -20,6 +20,8 @@ now respectively `40831f6757929bc14af6185082bccaadbd188d2246eb324b486e6b59792190
 and `6616eda4480368fb2615c9496a572bd52ac3b1f102d252cbdb6edca338a775d1`.
 This supersedes the earlier same-content fixture evidence without changing
 the path/role/digest trust contract or reopening the closed launcher gates.
+Review hardening binds both the exact constant-to-literal declarations and the
+constant-to-sidecar writes; swapping either layer fails the focused contract.
 
 ## Launcher-trust fixture review follow-up
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -2,26 +2,12 @@
 
 ## Launcher-trust distinct-payload evidence
 
-Protected run `31635868978` passes at exact `main` merge
-`477035ca2df6d0eb688d58e83aee80805e932d38` after the fixture dependency and
-runtime-configuration sidecars received distinct role-specific JSON payloads.
-Artifact `9156951212` has GitHub and independently reproduced archive digest
-`sha256:9385656df3fbbcf0408d8e0c68bb42504dc7a9f1333272f4f05b8b4cbfa29dec`.
-The provisioning and validation JSON digests are respectively
-`7adcc4ff91d5319b2969caa1e30523236d69918049481a80576472780ebc8cb7` and
-`9a475a239c492f9bf0243261506c1e00a3a93f42a68b078157b7b1e6ce78bba3`.
-
-Independent machine assertions confirm the exact signer, run, and commit;
-five unique artifact paths; five distinct valid SHA-256 values; one valid
-launch with exit `0` and apphost start; seven negative cases with exit `4`
-and no apphost start; and no private-key, passphrase, environment-secret, or
-registry-secret markers. The dependency and runtime-configuration digests are
-now respectively `40831f6757929bc14af6185082bccaadbd188d2246eb324b486e6b59792190e0`
-and `6616eda4480368fb2615c9496a572bd52ac3b1f102d252cbdb6edca338a775d1`.
-This supersedes the earlier same-content fixture evidence without changing
-the path/role/digest trust contract or reopening the closed launcher gates.
-Review hardening binds both the exact constant-to-literal declarations and the
-constant-to-sidecar writes; swapping either layer fails the focused contract.
+Protected run `31635868978` passes at exact `main` merge `477035ca2` with five
+distinct artifact digests and all eight guard cases passing. Canonical hashes,
+case assertions, and secret-boundary evidence are in
+`docs/safety/launcher-trust-validation-2026-08-12.md`. Review hardening binds
+both exact constant-to-literal declarations and constant-to-sidecar writes;
+initializer and usage swaps fail while whitespace-only formatting remains free.
 
 ## Launcher-trust fixture review follow-up
 

--- a/tests/run_launcher_trust_provisioning_contract_check.cmake
+++ b/tests/run_launcher_trust_provisioning_contract_check.cmake
@@ -21,33 +21,24 @@ if(NOT EXISTS "${FIXTURE}")
 endif()
 
 file(READ "${FIXTURE}" FIXTURE_CONTENT)
-foreach(REQUIRED_TEXT IN ITEMS
-    "constexpr char kDependenciesFixturePayload[] ="
-    "{\\\"fixture\\\":\\\"dependencies\\\"}\\n"
-    "constexpr char kRuntimeConfigurationFixturePayload[] ="
-    "{\\\"fixture\\\":\\\"runtime-configuration\\\"}\\n"
-    "kDependenciesFixturePayload);"
-    "kRuntimeConfigurationFixturePayload);"
-)
-    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_TEXT}" POSITION)
-    if(POSITION EQUAL -1)
-        message(FATAL_ERROR
-            "launcher trust fixture must retain distinct dependency and runtime-configuration payloads: ${REQUIRED_TEXT}")
-    endif()
-endforeach()
-
+set(DEPENDENCIES_FIXTURE_DECLARATION [=[constexpr char kDependenciesFixturePayload[] =
+    "{\"fixture\":\"dependencies\"}\n";]=])
+set(RUNTIME_CONFIGURATION_FIXTURE_DECLARATION [=[constexpr char kRuntimeConfigurationFixturePayload[] =
+    "{\"fixture\":\"runtime-configuration\"}\n";]=])
 set(DEPENDENCIES_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.deps.json",
                kDependenciesFixturePayload);]=])
 set(RUNTIME_CONFIGURATION_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json",
                kRuntimeConfigurationFixturePayload);]=])
-foreach(REQUIRED_BINDING IN ITEMS
+foreach(REQUIRED_FIXTURE_CONTRACT IN ITEMS
+    "${DEPENDENCIES_FIXTURE_DECLARATION}"
+    "${RUNTIME_CONFIGURATION_FIXTURE_DECLARATION}"
     "${DEPENDENCIES_FIXTURE_BINDING}"
     "${RUNTIME_CONFIGURATION_FIXTURE_BINDING}"
 )
-    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_BINDING}" POSITION)
+    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_FIXTURE_CONTRACT}" POSITION)
     if(POSITION EQUAL -1)
         message(FATAL_ERROR
-            "launcher trust fixture payload is not bound to its intended sidecar")
+            "launcher trust fixture payload declaration or sidecar binding is incorrect")
     endif()
 endforeach()
 

--- a/tests/run_launcher_trust_provisioning_contract_check.cmake
+++ b/tests/run_launcher_trust_provisioning_contract_check.cmake
@@ -21,21 +21,18 @@ if(NOT EXISTS "${FIXTURE}")
 endif()
 
 file(READ "${FIXTURE}" FIXTURE_CONTENT)
-set(DEPENDENCIES_FIXTURE_DECLARATION [=[constexpr char kDependenciesFixturePayload[] =
-    "{\"fixture\":\"dependencies\"}\n";]=])
-set(RUNTIME_CONFIGURATION_FIXTURE_DECLARATION [=[constexpr char kRuntimeConfigurationFixturePayload[] =
-    "{\"fixture\":\"runtime-configuration\"}\n";]=])
-set(DEPENDENCIES_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.deps.json",
-               kDependenciesFixturePayload);]=])
-set(RUNTIME_CONFIGURATION_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json",
-               kRuntimeConfigurationFixturePayload);]=])
+string(REGEX REPLACE "[ \t\r\n]+" " " FIXTURE_NORMALIZED "${FIXTURE_CONTENT}")
+set(DEPENDENCIES_FIXTURE_DECLARATION [=[constexpr char kDependenciesFixturePayload[] = "{\"fixture\":\"dependencies\"}\n";]=])
+set(RUNTIME_CONFIGURATION_FIXTURE_DECLARATION [=[constexpr char kRuntimeConfigurationFixturePayload[] = "{\"fixture\":\"runtime-configuration\"}\n";]=])
+set(DEPENDENCIES_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.deps.json", kDependenciesFixturePayload);]=])
+set(RUNTIME_CONFIGURATION_FIXTURE_BINDING [=[write_text(package_root / "Copperfin.GeneratedLauncher.runtimeconfig.json", kRuntimeConfigurationFixturePayload);]=])
 foreach(REQUIRED_FIXTURE_CONTRACT IN ITEMS
     "${DEPENDENCIES_FIXTURE_DECLARATION}"
     "${RUNTIME_CONFIGURATION_FIXTURE_DECLARATION}"
     "${DEPENDENCIES_FIXTURE_BINDING}"
     "${RUNTIME_CONFIGURATION_FIXTURE_BINDING}"
 )
-    string(FIND "${FIXTURE_CONTENT}" "${REQUIRED_FIXTURE_CONTRACT}" POSITION)
+    string(FIND "${FIXTURE_NORMALIZED}" "${REQUIRED_FIXTURE_CONTRACT}" POSITION)
     if(POSITION EQUAL -1)
         message(FATAL_ERROR
             "launcher trust fixture payload declaration or sidecar binding is incorrect")

--- a/tests/run_launcher_trust_provisioning_contract_check.cmake
+++ b/tests/run_launcher_trust_provisioning_contract_check.cmake
@@ -32,10 +32,18 @@ foreach(REQUIRED_FIXTURE_CONTRACT IN ITEMS
     "${DEPENDENCIES_FIXTURE_BINDING}"
     "${RUNTIME_CONFIGURATION_FIXTURE_BINDING}"
 )
-    string(FIND "${FIXTURE_NORMALIZED}" "${REQUIRED_FIXTURE_CONTRACT}" POSITION)
+    # The source normalization above collapses every whitespace run to one
+    # space. Remove those spaces from both sides so purely stylistic spacing
+    # cannot weaken or trip the semantic name/value and path/name checks.
+    string(REPLACE " " "" FIXTURE_CONTRACT_TOKENS "${FIXTURE_NORMALIZED}")
+    string(REPLACE " " "" REQUIRED_FIXTURE_CONTRACT_TOKENS
+        "${REQUIRED_FIXTURE_CONTRACT}")
+    string(FIND "${FIXTURE_CONTRACT_TOKENS}"
+        "${REQUIRED_FIXTURE_CONTRACT_TOKENS}" POSITION)
     if(POSITION EQUAL -1)
         message(FATAL_ERROR
-            "launcher trust fixture payload declaration or sidecar binding is incorrect")
+            "launcher trust fixture payload declaration or sidecar binding is incorrect: "
+            "${REQUIRED_FIXTURE_CONTRACT}")
     endif()
 endforeach()
 


### PR DESCRIPTION
## Summary

- bind each fixture payload constant to its exact role-specific JSON literal
- retain exact constant-to-sidecar path binding checks
- correct the regression claim without changing fixture or product bytes

## Verification

- reproduced the initializer-swap mutation reported on PR #4975; the corrected contract rejects it
- prior usage-swap mutation remains rejected
- corrected contract is byte-identical to mutation-proven v1 head a0ff6c34b
- package-document, launcher-provisioning, and safety-workflow contracts pass 3/3
- git diff --check passes

Signed-off-by: rhamenator <rhamenator@gmail.com>