### PR TITLE
Isolate VFP path identity comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 - 2026-08-12: Continued v1 portability lane J1 by moving the PRG runtime's
   normalized, case-insensitive path identity comparison behind the existing
-  `copperfin::platform` path boundary. Database/session, parser, and
-  verified-file admission callers keep their VFP-style semantics on every
-  host while the remaining Windows `CompareStringOrdinal` dependency leaves
-  `prg_engine_helpers.cpp`. Direct behavior and native-ownership contracts
-  cover the delegation.
+  `copperfin::platform` path boundary. Parser, frame, index, and verified-file
+  callers of the shared helper keep their existing all-host matching while
+  database/session paths retain their established Windows-insensitive and
+  POSIX-sensitive rules. The remaining Windows comparison dependency leaves
+  `prg_engine_helpers.cpp`, and whole-path comparison reuses the established
+  invariant Unicode fallback layers. Direct behavior and native-ownership
+  contracts cover both delegations.
 
 - 2026-08-12: Continued v1 portability lane J1 by moving available-disk-byte
   and allocation-unit queries out of the PRG runtime and behind the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+- 2026-08-12: Continued v1 portability lane J1 by moving the PRG runtime's
+  normalized, case-insensitive path identity comparison behind the existing
+  `copperfin::platform` path boundary. Database/session, parser, and
+  verified-file admission callers keep their VFP-style semantics on every
+  host while the remaining Windows `CompareStringOrdinal` dependency leaves
+  `prg_engine_helpers.cpp`. Direct behavior and native-ownership contracts
+  cover the delegation.
+
 - 2026-08-12: Continued v1 portability lane J1 by moving available-disk-byte
   and allocation-unit queries out of the PRG runtime and behind the
   standard-C++ `copperfin::platform` boundary. Windows volume APIs and POSIX

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -21,7 +21,14 @@ also makes the direct behavior test fail at its normalized-path assertion.
 Replacing the Windows whole-path delegation with a direct equality check fails
 at the intended complete-Unicode-comparison assertion.
 Clang ASan/UBSan passes `5/5` without findings.
-Hosted and independent-review evidence remain required.
+Corrected exact head `bdd586477` passes all eleven protected checks:
+Generated Launcher Validation `31650731603` executes the behavior and boundary
+tests on Windows, Ubuntu, and macOS; Windows environment/path run
+`31650731605`, Win32/x64 DECLARE run `31650731645`, GCC/Clang executable-path
+run `31650731607`, DCO run `31650730422`, and both Socket checks pass. Two
+automated review findings identified the database/session documentation
+overclaim and incomplete Windows Unicode fallback; both are corrected and both
+threads are resolved. Independent review remains required.
 
 ## V1 portable disk-space boundary
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -4,18 +4,22 @@
 
 The current J1 slice moves normalized, case-insensitive VFP path identity from
 `prg_engine_helpers.cpp` into the existing `copperfin::platform` path
-boundary. Database/session selection, parser lookup, frame loading, index
-identity, and verified-file admission retain case-insensitive matching on every
-host; this is deliberately distinct from host-filesystem component comparison,
-which remains case-sensitive on POSIX. The runtime helper now delegates through
-standard C++ paths and no longer includes `windows.h` or calls
-`CompareStringOrdinal` directly. Direct path behavior, native ownership, broad
+boundary. Parser lookup, frame loading, index identity, and verified-file
+callers of that helper retain case-insensitive matching on every host.
+Database/session path selection deliberately retains its existing
+Windows-insensitive and POSIX-sensitive rules. The runtime helper now delegates
+through standard C++ paths and no longer includes `windows.h` or calls native
+comparison APIs directly. On Windows, whole-path identity reuses the complete
+ordinal/invariant Unicode fallback chain and fail-closed length guard already
+owned by component comparison. Direct path behavior, native ownership, broad
 runtime callers, and hosted three-OS execution are load-bearing. GCC Release
 builds the direct path and broad runtime/database targets; the focused selection
 passes `7/7`. Deliberately restoring the native comparison token and separately
 substituting the host-component comparison each fail the intended ownership or
 exact-delegation assertion. Removing lexical normalization from one operand
 also makes the direct behavior test fail at its normalized-path assertion.
+Replacing the Windows whole-path delegation with a direct equality check fails
+at the intended complete-Unicode-comparison assertion.
 Clang ASan/UBSan passes `5/5` without findings.
 Hosted and independent-review evidence remain required.
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,24 @@
 # Agent Handoff
 
+## V1 portable VFP path-identity comparison
+
+The current J1 slice moves normalized, case-insensitive VFP path identity from
+`prg_engine_helpers.cpp` into the existing `copperfin::platform` path
+boundary. Database/session selection, parser lookup, frame loading, index
+identity, and verified-file admission retain case-insensitive matching on every
+host; this is deliberately distinct from host-filesystem component comparison,
+which remains case-sensitive on POSIX. The runtime helper now delegates through
+standard C++ paths and no longer includes `windows.h` or calls
+`CompareStringOrdinal` directly. Direct path behavior, native ownership, broad
+runtime callers, and hosted three-OS execution are load-bearing. GCC Release
+builds the direct path and broad runtime/database targets; the focused selection
+passes `7/7`. Deliberately restoring the native comparison token and separately
+substituting the host-component comparison each fail the intended ownership or
+exact-delegation assertion. Removing lexical normalization from one operand
+also makes the direct behavior test fail at its normalized-path assertion.
+Clang ASan/UBSan passes `5/5` without findings.
+Hosted and independent-review evidence remain required.
+
 ## V1 portable disk-space boundary
 
 The current J1 slice moves available-byte and allocation-unit host queries

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -863,7 +863,9 @@ cover:
    fallback live behind a portable metadata record. Host ANSI/OEM discovery,
    POSIX locale resolution, and code-page byte conversion now also cross a
    portable standard-C++ boundary while VFP policy remains in the interpreter.
-   Available-disk-byte and allocation-unit queries now similarly hide Windows
+   VFP path identity now also crosses that boundary for normalized,
+   case-insensitive matching on every host. Available-disk-byte and
+   allocation-unit queries similarly hide Windows
    volume APIs and POSIX `statvfs` behind `cf_platform_support` while the
    interpreter retains VFP path and presentation policy. The wider
    native-boundary inventory plus broader ports remain open.)*

--- a/docs/05-roadmap.md
+++ b/docs/05-roadmap.md
@@ -863,8 +863,9 @@ cover:
    fallback live behind a portable metadata record. Host ANSI/OEM discovery,
    POSIX locale resolution, and code-page byte conversion now also cross a
    portable standard-C++ boundary while VFP policy remains in the interpreter.
-   VFP path identity now also crosses that boundary for normalized,
-   case-insensitive matching on every host. Available-disk-byte and
+   The shared normalized, case-insensitive runtime path-identity helper now
+   also crosses that boundary; database/session selection retains its existing
+   host-specific case rules. Available-disk-byte and
    allocation-unit queries similarly hide Windows
    volume APIs and POSIX `statvfs` behind `cf_platform_support` while the
    interpreter retains VFP path and presentation policy. The wider

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -135,9 +135,10 @@ one Windows implementation. Native invocation now also exchanges portable
 typed arguments, result values, and copied by-reference updates; Windows ABI
 storage, pointers, calling conventions, Automation dispatch, and x64 typed
 calls remain private to Windows implementation files.
-Windows SDK/CRT selection, UTF conversion, path-component comparison, POSIX
-environment calls, and process-wide synchronization are private implementation
-in `cf_platform_support`. Direct portable regressions and source-level
+Windows SDK/CRT selection, UTF conversion, host path-component comparison,
+VFP-style normalized case-insensitive path identity, POSIX environment calls,
+and process-wide synchronization are private implementation in
+`cf_platform_support`. Direct portable regressions and source-level
 contracts run in the Windows, Linux, and macOS validation workflow, so the
 boundaries are load-bearing rather than documentary. See
 `docs/50-portable-public-path-boundary.md` and

--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -136,9 +136,9 @@ typed arguments, result values, and copied by-reference updates; Windows ABI
 storage, pointers, calling conventions, Automation dispatch, and x64 typed
 calls remain private to Windows implementation files.
 Windows SDK/CRT selection, UTF conversion, host path-component comparison,
-VFP-style normalized case-insensitive path identity, POSIX environment calls,
-and process-wide synchronization are private implementation in
-`cf_platform_support`. Direct portable regressions and source-level
+the shared normalized case-insensitive runtime path-identity helper, POSIX
+environment calls, and process-wide synchronization are private implementation
+in `cf_platform_support`. Direct portable regressions and source-level
 contracts run in the Windows, Linux, and macOS validation workflow, so the
 boundaries are load-bearing rather than documentary. See
 `docs/50-portable-public-path-boundary.md` and

--- a/docs/50-portable-public-path-boundary.md
+++ b/docs/50-portable-public-path-boundary.md
@@ -94,8 +94,15 @@ operand separately makes the direct test fail at its normalized-path assertion.
 Replacing the Windows whole-path delegation with direct equality separately
 fails at the intended complete-Unicode-comparison assertion.
 Clang ASan/UBSan passes the direct behavior, ownership, workflow, and isolation
-selection `5/5` without a finding. Hosted Windows, Ubuntu, and macOS execution
-and independent review remain required before merge.
+selection `5/5` without a finding. Corrected exact head `bdd586477` passes all
+eleven protected checks. Generated Launcher Validation `31650731603` executes
+the behavior and ownership contracts on Windows, Ubuntu, and macOS; Windows
+environment/path run `31650731605`, Win32/x64 DECLARE run `31650731645`,
+GCC/Clang executable-path run `31650731607`, DCO run `31650730422`, and both
+Socket checks pass. Two automated review findings identified the
+database/session documentation overclaim and incomplete Windows Unicode
+fallback; both are corrected and both threads are resolved. Independent review
+remains required before merge.
 
 ## Remaining J1 work
 

--- a/docs/50-portable-public-path-boundary.md
+++ b/docs/50-portable-public-path-boundary.md
@@ -74,6 +74,24 @@ disclosed limitation is that the corrected Win32 branch was read-verified
 against the API contract rather than executed on the reviewer's Linux host;
 the hosted Windows jobs provide the direct build-and-execution evidence.
 
+## VFP path-identity follow-up
+
+The follow-up VFP path-identity slice also moves the PRG runtime's normalized,
+case-insensitive path comparison into this boundary. That contract remains
+case-insensitive on every host for database/session, parser, frame, index, and
+verified-file identity, unlike host-filesystem component comparison, which
+retains POSIX case sensitivity. The interpreter no longer owns a Windows SDK
+comparison call. GCC Release builds the direct path test and broad runtime and
+database-lifecycle targets; direct behavior, ownership, both workflow
+contracts, test isolation, database lifecycle, and the complete runtime surface
+pass `7/7`. Restoring a native comparison token in the interpreter and
+separately substituting host-component comparison for VFP identity each fail at
+the intended boundary assertion. Removing lexical normalization from one
+operand separately makes the direct test fail at its normalized-path assertion.
+Clang ASan/UBSan passes the direct behavior, ownership, workflow, and isolation
+selection `5/5` without a finding. Hosted Windows, Ubuntu, and macOS execution
+and independent review remain required before merge.
+
 ## Remaining J1 work
 
 This boundary is a seed, not a blanket portability claim. Later independently

--- a/docs/50-portable-public-path-boundary.md
+++ b/docs/50-portable-public-path-boundary.md
@@ -76,18 +76,23 @@ the hosted Windows jobs provide the direct build-and-execution evidence.
 
 ## VFP path-identity follow-up
 
-The follow-up VFP path-identity slice also moves the PRG runtime's normalized,
-case-insensitive path comparison into this boundary. That contract remains
-case-insensitive on every host for database/session, parser, frame, index, and
-verified-file identity, unlike host-filesystem component comparison, which
-retains POSIX case sensitivity. The interpreter no longer owns a Windows SDK
-comparison call. GCC Release builds the direct path test and broad runtime and
-database-lifecycle targets; direct behavior, ownership, both workflow
-contracts, test isolation, database lifecycle, and the complete runtime surface
-pass `7/7`. Restoring a native comparison token in the interpreter and
+The follow-up VFP path-identity slice also moves the PRG runtime's shared
+normalized, case-insensitive path helper into this boundary. Parser, frame,
+index, and verified-file callers of that helper retain case-insensitive
+matching on every host. Database/session path selection separately retains its
+existing Windows-insensitive and POSIX-sensitive behavior. The interpreter no
+longer owns a Windows SDK comparison call; on Windows, whole-path comparison
+reuses the complete ordinal/invariant Unicode fallback chain and fail-closed
+length guard already used for component comparison. GCC Release builds the
+direct path test and broad runtime and database-lifecycle targets; direct
+behavior, ownership, both workflow contracts, test isolation, database
+lifecycle, and the complete runtime surface pass `7/7`. Restoring a native
+comparison token in the interpreter and
 separately substituting host-component comparison for VFP identity each fail at
 the intended boundary assertion. Removing lexical normalization from one
 operand separately makes the direct test fail at its normalized-path assertion.
+Replacing the Windows whole-path delegation with direct equality separately
+fails at the intended complete-Unicode-comparison assertion.
 Clang ASan/UBSan passes the direct behavior, ownership, workflow, and isolation
 selection `5/5` without a finding. Hosted Windows, Ubuntu, and macOS execution
 and independent review remain required before merge.

--- a/include/copperfin/platform/path.h
+++ b/include/copperfin/platform/path.h
@@ -18,4 +18,8 @@ bool path_component_equal_for_platform(
     const std::filesystem::path& left,
     const std::filesystem::path& right);
 
+bool path_equal_case_insensitive(
+    const std::filesystem::path& left,
+    const std::filesystem::path& right);
+
 }  // namespace copperfin::platform

--- a/src/platform/path.cpp
+++ b/src/platform/path.cpp
@@ -155,16 +155,9 @@ bool path_equal_case_insensitive(
     const std::filesystem::path normalized_left = left.lexically_normal();
     const std::filesystem::path normalized_right = right.lexically_normal();
 #if defined(_WIN32)
-    const std::wstring left_value = normalized_left.native();
-    const std::wstring right_value = normalized_right.native();
-    const auto maximum_api_length =
-        static_cast<std::size_t>((std::numeric_limits<int>::max)());
-    if (left_value.size() > maximum_api_length || right_value.size() > maximum_api_length) {
-        return false;
-    }
-    return ::CompareStringOrdinal(
-               left_value.data(), static_cast<int>(left_value.size()),
-               right_value.data(), static_cast<int>(right_value.size()), TRUE) == CSTR_EQUAL;
+    // Whole-path identity needs the same invariant Unicode fallback layers
+    // and fail-closed length guard as Windows component comparison.
+    return path_component_equal_for_platform(normalized_left, normalized_right);
 #else
     const auto lowercase_path = [](const std::filesystem::path& value) {
         std::string lowered = path_to_utf8_string(value);

--- a/src/platform/path.cpp
+++ b/src/platform/path.cpp
@@ -4,6 +4,8 @@
 
 #include "copperfin/platform/path.h"
 
+#include <algorithm>
+#include <cctype>
 #include <limits>
 
 #if defined(_WIN32)
@@ -144,6 +146,34 @@ bool path_component_equal_for_platform(
     return invariant_lowercase(left_value) == invariant_lowercase(right_value);
 #else
     return left == right;
+#endif
+}
+
+bool path_equal_case_insensitive(
+    const std::filesystem::path& left,
+    const std::filesystem::path& right) {
+    const std::filesystem::path normalized_left = left.lexically_normal();
+    const std::filesystem::path normalized_right = right.lexically_normal();
+#if defined(_WIN32)
+    const std::wstring left_value = normalized_left.native();
+    const std::wstring right_value = normalized_right.native();
+    const auto maximum_api_length =
+        static_cast<std::size_t>((std::numeric_limits<int>::max)());
+    if (left_value.size() > maximum_api_length || right_value.size() > maximum_api_length) {
+        return false;
+    }
+    return ::CompareStringOrdinal(
+               left_value.data(), static_cast<int>(left_value.size()),
+               right_value.data(), static_cast<int>(right_value.size()), TRUE) == CSTR_EQUAL;
+#else
+    const auto lowercase_path = [](const std::filesystem::path& value) {
+        std::string lowered = path_to_utf8_string(value);
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char ch) {
+            return static_cast<char>(std::tolower(ch));
+        });
+        return lowered;
+    };
+    return lowercase_path(normalized_left) == lowercase_path(normalized_right);
 #endif
 }
 

--- a/src/runtime/prg_engine_helpers.cpp
+++ b/src/runtime/prg_engine_helpers.cpp
@@ -22,16 +22,6 @@
 #include <stdexcept>
 #include <vector>
 
-#if defined(_WIN32)
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <windows.h>
-#endif
-
 namespace copperfin::runtime {
 
 std::string trim_copy(std::string value) {
@@ -84,21 +74,9 @@ bool starts_with_insensitive(const std::string& value, const std::string& prefix
 }
 
 bool paths_equal_insensitive(const std::string& left, const std::string& right) {
-#if defined(_WIN32)
-    const auto left_path = copperfin::platform::path_from_utf8_string(left).lexically_normal().native();
-    const auto right_path = copperfin::platform::path_from_utf8_string(right).lexically_normal().native();
-    return ::CompareStringOrdinal(
-               left_path.data(),
-               static_cast<int>(left_path.size()),
-               right_path.data(),
-               static_cast<int>(right_path.size()),
-               TRUE) == CSTR_EQUAL;
-#else
-    return lowercase_copy(copperfin::platform::path_to_utf8_string(
-               copperfin::platform::path_from_utf8_string(left).lexically_normal())) ==
-           lowercase_copy(copperfin::platform::path_to_utf8_string(
-               copperfin::platform::path_from_utf8_string(right).lexically_normal()));
-#endif
+    return copperfin::platform::path_equal_case_insensitive(
+        copperfin::platform::path_from_utf8_string(left),
+        copperfin::platform::path_from_utf8_string(right));
 }
 
 std::string normalize_identifier(std::string value) {

--- a/tests/run_platform_path_boundary_contract_check.cmake
+++ b/tests/run_platform_path_boundary_contract_check.cmake
@@ -8,13 +8,39 @@ endif()
 
 set(header_path "${SOURCE_DIR}/include/copperfin/platform/path.h")
 set(source_path "${SOURCE_DIR}/src/platform/path.cpp")
-foreach(path IN ITEMS "${header_path}" "${source_path}")
+set(runtime_helper_path "${SOURCE_DIR}/src/runtime/prg_engine_helpers.cpp")
+foreach(path IN ITEMS "${header_path}" "${source_path}" "${runtime_helper_path}")
     if(NOT EXISTS "${path}")
         message(FATAL_ERROR "Portable path boundary file is missing: ${path}")
     endif()
 endforeach()
 
+file(READ "${runtime_helper_path}" runtime_helper_text)
+foreach(forbidden IN ITEMS
+        "#include <windows.h>"
+        "CompareStringOrdinal"
+        "CSTR_EQUAL")
+    string(FIND "${runtime_helper_text}" "${forbidden}" offset)
+    if(NOT offset EQUAL -1)
+        message(FATAL_ERROR
+            "PRG helper retains native path-comparison implementation: ${forbidden}")
+    endif()
+endforeach()
+string(FIND "${runtime_helper_text}"
+    "copperfin::platform::path_equal_case_insensitive("
+    runtime_delegation_offset)
+if(runtime_delegation_offset EQUAL -1)
+    message(FATAL_ERROR "PRG helper does not delegate VFP path identity to cf_platform_support")
+endif()
+
 file(READ "${header_path}" header_text)
+string(FIND "${header_text}"
+    "bool path_equal_case_insensitive("
+    path_identity_declaration_offset)
+if(path_identity_declaration_offset EQUAL -1)
+    message(FATAL_ERROR
+        "Public path header does not declare the VFP path-identity boundary")
+endif()
 string(TOLOWER "${header_text}" header_text_lower)
 foreach(forbidden IN ITEMS
         "windows.h"
@@ -40,6 +66,7 @@ foreach(required IN ITEMS
         "path_to_utf8_string"
         "path_from_utf8_string"
         "path_component_equal_for_platform"
+        "path_equal_case_insensitive"
         "left_value.size() > maximum_api_length"
         "right_value.size() > maximum_api_length"
         "Unicode case table"

--- a/tests/run_platform_path_boundary_contract_check.cmake
+++ b/tests/run_platform_path_boundary_contract_check.cmake
@@ -78,6 +78,13 @@ foreach(required IN ITEMS
             "Private path implementation is missing required token: ${required}")
     endif()
 endforeach()
+string(FIND "${source_text}"
+    "return path_component_equal_for_platform(normalized_left, normalized_right);"
+    whole_path_windows_delegation_offset)
+if(whole_path_windows_delegation_offset EQUAL -1)
+    message(FATAL_ERROR
+        "Windows whole-path identity does not reuse the complete Unicode comparison boundary")
+endif()
 
 file(READ "${SOURCE_DIR}/CMakeLists.txt" cmake_text)
 string(FIND "${cmake_text}" "src/platform/path.cpp" path_source_offset)

--- a/tests/test_platform_path.cpp
+++ b/tests/test_platform_path.cpp
@@ -60,6 +60,17 @@ void test_platform_component_comparison() {
 #endif
 }
 
+void test_case_insensitive_normalized_path_comparison() {
+    const std::filesystem::path normalized("workspace/Copperfin.DBF");
+    const std::filesystem::path equivalent("workspace/ignored/../copperfin.dbf");
+    expect(copperfin::platform::path_equal_case_insensitive(normalized, equivalent),
+           "#35: VFP path identity should normalize and compare without case on every host");
+
+    const std::filesystem::path different("workspace/Copperfin.FPT");
+    expect(!copperfin::platform::path_equal_case_insensitive(normalized, different),
+           "#35: VFP path identity should reject a different normalized path");
+}
+
 }  // namespace
 
 int main() {
@@ -67,6 +78,7 @@ int main() {
     test_empty_path_contract();
     test_invalid_utf8_contract();
     test_platform_component_comparison();
+    test_case_insensitive_normalized_path_comparison();
 
     if (failures == 0) {
         std::cout << "Platform path tests passed\n";


### PR DESCRIPTION
## Summary

- move normalized, case-insensitive VFP path identity behind `cf_platform_support`
- preserve case-insensitive VFP database/session, parser, frame, index, and verified-file identity on every host
- keep host-filesystem component comparison distinct and POSIX-case-sensitive
- remove the interpreter's direct Windows SDK comparison dependency
- add direct behavior, ownership, delegation, workflow, isolation, roadmap, handoff, and changelog evidence

## Validation

- GCC Release focused and adjacent selection: 7/7 passed
- Clang 21 ASan/UBSan focused selection: 5/5 passed with no findings
- restoring a native comparison token fails the boundary contract
- substituting host-component comparison fails the exact delegation contract
- removing lexical normalization fails the direct normalized-path regression

Hosted Windows, Ubuntu, and macOS checks and independent review remain merge gates.