### PR TITLE
Fix shell-command test platform linkage

### DIFF
--- a/.github/workflows/windows-environment-validation.yml
+++ b/.github/workflows/windows-environment-validation.yml
@@ -49,7 +49,7 @@ jobs:
         run: cmake -S . -B "$env:RUNNER_TEMP/copperfin-environment-build" -DCOPPERFIN_BUILD_TESTS=ON
 
       - name: Build environment and executable path regressions
-        run: cmake --build "$env:RUNNER_TEMP/copperfin-environment-build" --config Release --parallel 2 --target test_platform_path test_platform_environment test_localization test_licensing_status test_build_host_output test_runtime_host_implicit_path_launch test_tool_license_path_launch test_studio_host_report_section_selection_diagnostics
+        run: cmake --build "$env:RUNNER_TEMP/copperfin-environment-build" --config Release --parallel 2 --target test_platform_path test_platform_environment test_localization test_licensing_status test_build_host_output test_runtime_host_implicit_path_launch test_tool_license_path_launch test_studio_host_shell_command test_studio_host_report_section_selection_diagnostics
 
       - name: Run environment and executable path regressions
-        run: ctest --test-dir "$env:RUNNER_TEMP/copperfin-environment-build" -C Release --output-on-failure -R "^(test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_localization|test_licensing_status|test_build_host_output|test_runtime_host_implicit_path_launch|test_tool_license_path_launch|test_studio_host_report_section_selection_diagnostics)$"
+        run: ctest --test-dir "$env:RUNNER_TEMP/copperfin-environment-build" -C Release --output-on-failure -R "^(test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_localization|test_licensing_status|test_build_host_output|test_runtime_host_implicit_path_launch|test_tool_license_path_launch|test_studio_host_shell_command|test_studio_host_report_section_selection_diagnostics)$"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+- 2026-08-12: Corrected the standalone Studio shell-command regression's
+  portable-path dependency after Windows Deep Validation exposed an unresolved
+  `path_to_utf8_string()` link. The test target now links
+  `cf_platform_support`, and the focused Windows environment/path workflow
+  builds and runs it directly. This is test/workflow wiring only; product and
+  VFP9 behavior are unchanged. See
+  `docs/50-portable-public-path-boundary.md`.
+
 - 2026-08-12: Made Copperfin's DO-178C-inspired development-assurance
   discipline an explicit project-wide quality baseline without claiming
   compliance, certification, an assigned software level, or suitability for a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
   `cf_platform_support`, and the focused Windows environment/path workflow
   builds and runs it directly. This is test/workflow wiring only; product and
   VFP9 behavior are unchanged. See
-  `docs/50-portable-public-path-boundary.md`.
+  `docs/50-portable-public-path-boundary.md`. Exact implementation head
+  `0221329d2` passes the complete protected matrix, including the corrected
+  target inside Windows focused run `31665231456` (`12/12`).
 
 - 2026-08-12: Made Copperfin's DO-178C-inspired development-assurance
   discipline an explicit project-wide quality baseline without claiming

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -8,8 +8,11 @@ reported `LNK2019`/`LNK1120`: the standalone
 Unicode-path assertion but did not link `cf_platform_support`. The target now
 declares that dependency, passes its focused GCC Release build/execution `1/1`,
 and is included in the focused Windows environment/path workflow. Product
-shell-command and path behavior are unchanged; exact-head Windows evidence is
-required before merge. See `docs/50-portable-public-path-boundary.md`.
+shell-command and path behavior are unchanged. Exact signed/DCO implementation
+head `0221329d2` passes all eleven protected checks; focused Windows run
+`31665231456` directly builds the corrected target and passes it inside the
+`12/12` selection. The remaining protected run IDs and review disposition are
+recorded in `docs/50-portable-public-path-boundary.md`.
 
 ## V1 workspace-agent authority policy
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,16 @@
 # Agent Handoff
 
+## V1 shell-command portable-path test linkage
+
+Windows Deep Validation `31662374490` compiled for 44 minutes before MSVC
+reported `LNK2019`/`LNK1120`: the standalone
+`test_studio_host_shell_command` target uses `path_to_utf8_string()` in its
+Unicode-path assertion but did not link `cf_platform_support`. The target now
+declares that dependency, passes its focused GCC Release build/execution `1/1`,
+and is included in the focused Windows environment/path workflow. Product
+shell-command and path behavior are unchanged; exact-head Windows evidence is
+required before merge. See `docs/50-portable-public-path-boundary.md`.
+
 ## V1 workspace-agent authority policy
 
 The project-wide DO-178C-inspired assurance baseline is now continuous and

--- a/docs/50-portable-public-path-boundary.md
+++ b/docs/50-portable-public-path-boundary.md
@@ -119,6 +119,15 @@ full-build side effect. This correction changes test and workflow wiring only;
 it does not alter shell-command, path-conversion, VFP9, package, or runtime
 behavior.
 
+Exact signed/DCO implementation head `0221329d2` passes all eleven protected
+checks. Windows Environment and Executable Path Validation `31665231456`
+directly builds the corrected target and passes the shell-command regression
+inside its `12/12` focused selection. Generated Launcher Validation
+`31665231514` passes on Windows, Ubuntu, and macOS; Windows DECLARE ABI
+Validation `31665231503` passes Win32 and x64; GCC/Clang executable-path
+validation `31665231465`, DCO `31665230464`, and both Socket checks pass. No
+review thread or product-behavior finding remains at that implementation head.
+
 ## Remaining J1 work
 
 This boundary is a seed, not a blanket portability claim. Later independently

--- a/docs/50-portable-public-path-boundary.md
+++ b/docs/50-portable-public-path-boundary.md
@@ -104,6 +104,21 @@ database/session documentation overclaim and incomplete Windows Unicode
 fallback; both are corrected and both threads are resolved. Independent review
 remains required before merge.
 
+## Shell-command regression linkage correction
+
+Windows Deep Validation run `31662374490` exposed a test-build gap after the
+portable path boundary was adopted: `test_studio_host_shell_command` calls
+`path_to_utf8_string()` for its Unicode launch-path assertion, but its
+self-contained target did not link `cf_platform_support`. MSVC therefore
+reported `LNK2019`/`LNK1120` after 44 minutes of otherwise successful native
+compilation. The test target now declares the same platform-library dependency
+that its source consumes. The focused Windows environment/path workflow also
+builds and runs this real shell-command regression so the linkage and Unicode
+argument behavior remain direct Windows evidence rather than an incidental
+full-build side effect. This correction changes test and workflow wiring only;
+it does not alter shell-command, path-conversion, VFP9, package, or runtime
+behavior.
+
 ## Remaining J1 work
 
 This boundary is a seed, not a blanket portability claim. Later independently

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -631,6 +631,9 @@ add_executable(test_studio_host_shell_command
     test_studio_host_shell_command.cpp
     ../apps/copperfin_studio_host/studio_host_main_shell_command.cpp
 )
+target_link_libraries(test_studio_host_shell_command PRIVATE
+    cf_platform_support
+)
 target_include_directories(test_studio_host_shell_command PRIVATE
     ${CMAKE_SOURCE_DIR}/apps/copperfin_studio_host
     ${CMAKE_SOURCE_DIR}/include

--- a/tests/run_native_platform_workflow_contract_check.cmake
+++ b/tests/run_native_platform_workflow_contract_check.cmake
@@ -326,13 +326,13 @@ require_text(".github/workflows/windows-environment-validation.yml"
     "name: Windows Environment and Executable Path Validation"
     "focused Windows environment workflow identity")
 require_text(".github/workflows/windows-environment-validation.yml"
-    "--target test_platform_path test_platform_environment test_localization test_licensing_status test_build_host_output test_runtime_host_implicit_path_launch test_tool_license_path_launch test_studio_host_report_section_selection_diagnostics"
+    "--target test_platform_path test_platform_environment test_localization test_licensing_status test_build_host_output test_runtime_host_implicit_path_launch test_tool_license_path_launch test_studio_host_shell_command test_studio_host_report_section_selection_diagnostics"
     "focused Windows environment target inventory")
 require_text(".github/workflows/windows-environment-validation.yml"
     [=[cmake -S . -B "$env:RUNNER_TEMP/copperfin-environment-build" -DCOPPERFIN_BUILD_TESTS=ON]=]
     "out-of-tree configure command")
 require_text(".github/workflows/windows-environment-validation.yml"
-    [=[ctest --test-dir "$env:RUNNER_TEMP/copperfin-environment-build" -C Release --output-on-failure -R "^(test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_localization|test_licensing_status|test_build_host_output|test_runtime_host_implicit_path_launch|test_tool_license_path_launch|test_studio_host_report_section_selection_diagnostics)$"]=]
+    [=[ctest --test-dir "$env:RUNNER_TEMP/copperfin-environment-build" -C Release --output-on-failure -R "^(test_platform_path|test_platform_path_boundary_contract|test_platform_environment|test_platform_environment_boundary_contract|test_platform_executable_path_boundary_contract|test_localization|test_licensing_status|test_build_host_output|test_runtime_host_implicit_path_launch|test_tool_license_path_launch|test_studio_host_shell_command|test_studio_host_report_section_selection_diagnostics)$"]=]
     "out-of-tree localization, runtime-host, and Studio-host CTest contract")
 require_text(".github/workflows/build-vsix.yml"
     "name: Build Visual Studio VSIX"


### PR DESCRIPTION
## Scope

Test/workflow-only correction. Windows Deep Validation run 31662374490 exposed that test_studio_host_shell_command calls path_to_utf8_string but its standalone target did not link cf_platform_support. No product, VFP9, package, runtime, or shell-command behavior changes.

## Traceability

- Behavior requirement: N/A; this repairs verification dependency wiring and does not change product behavior.
- Architecture and verification authority: docs/50-portable-public-path-boundary.md.
- Failure evidence: Windows Deep Validation 31662374490, MSVC LNK2019/LNK1120 after the native build reached test_studio_host_shell_command.
- Reverse traceability: tests/CMakeLists.txt and the focused Windows environment/path workflow.

## Verification

- GCC Release focused build and test: 1/1.
- Native isolation plus focused behavior: 2/2.
- Native platform workflow contract: pass.
- GitHub Actions immutable-pin/read-only contract: pass.
- Exact-head Windows environment/path validation is required before merge.

## Risk and rollback

Severity none for product behavior; low for verification reach. Rollback is the single signed/DCO commit. The failure mode of rollback is directly reproducible as an unresolved MSVC link.