### PR TITLE
Fix Studio install MCP contract fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7782,3 +7782,8 @@ passes `1/1`.
   independent reviewer; independent review becomes mandatory when a second
   trusted maintainer exists. RC2 remains immutable and the corrected protected
   run plus a new sequential RC remain required.
+- 2026-08-13: Corrected the standalone Studio install-contract fixture to
+  stage the required Windows `copperfin_mcp_host.exe` added with the read-only
+  MCP host. The contract regression now also removes that executable and
+  proves the incomplete installed inventory fails closed. Product packaging
+  and runtime behavior are unchanged.

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,14 @@
 # Agent Handoff
 
+## V1 Studio install-contract MCP fixture
+
+Windows Deep Validation at managed-policy head `387dae521` built the complete
+native tree, then found one pre-existing test-fixture mismatch: the production
+Studio install contract correctly requires `bin/copperfin_mcp_host.exe`, but
+its synthetic passing fixture did not create that file. The fixture now stages
+the required executable and directly proves that removing it fails closed.
+This is test-only; installed inventory and product behavior are unchanged.
+
 ## V1 shell-command portable-path test linkage
 
 Windows Deep Validation `31662374490` compiled for 44 minutes before MSVC

--- a/tests/run_studio_install_contract_test.cmake
+++ b/tests/run_studio_install_contract_test.cmake
@@ -22,6 +22,7 @@ foreach(path IN ITEMS
         "bin/studio/Copperfin.Studio.exe"
         "bin/studio/Copperfin.Studio.exe.config"
         "bin/copperfin_studio_host.exe"
+        "bin/copperfin_mcp_host.exe"
         "share/copperfin/locales/en-US/strings.json"
         "share/copperfin/locales/es-419/strings.json"
         "share/copperfin/locales/pt-BR/strings.json"
@@ -44,6 +45,20 @@ execute_process(
 if(NOT complete_result EQUAL 0)
     message(FATAL_ERROR "Relative install-root Studio contract fixture should pass")
 endif()
+
+file(REMOVE "${TEST_ROOT}/bin/copperfin_mcp_host.exe")
+execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+        -DWIN32=TRUE
+        "-DBINARY_DIR=${relative_binary_dir}"
+        "-DINSTALL_ROOT=${relative_test_root}"
+        -P "${CMAKE_CURRENT_LIST_DIR}/run_studio_install_contract_check.cmake"
+    WORKING_DIRECTORY "${source_root}"
+    RESULT_VARIABLE missing_mcp_host_result)
+if(missing_mcp_host_result EQUAL 0)
+    message(FATAL_ERROR "Studio contract fixture without the installed MCP host should fail")
+endif()
+file(WRITE "${TEST_ROOT}/bin/copperfin_mcp_host.exe" "contract fixture\n")
 
 file(WRITE "${TEST_ROOT}/bin/studio/unexpected.txt" "unexpected\n")
 execute_process(


### PR DESCRIPTION
## Gap

Windows Deep Validation run `31670086731` at managed-policy head `387dae52183284e6cc290b9a1ee05d22b7f53310` built the complete native tree, then failed only `test_studio_install_contract`: the production contract correctly requires installed `bin/copperfin_mcp_host.exe`, but the synthetic passing fixture was not updated when the read-only MCP host was added.

## Change

- Stage `bin/copperfin_mcp_host.exe` in the complete Windows Studio install fixture.
- Remove it in a dedicated negative case and require the production inventory check to fail.
- Restore it before the existing unexpected-Studio-file negative case.

This is test-only. Installed inventory, packaging, runtime, localization, and VFP9 behavior are unchanged.

## Traceability

- Governing requirement/claim: the existing Windows standalone Studio installed-inventory contract in `tests/run_studio_install_contract_check.cmake`, derived from the product packaging definition that installs `copperfin_mcp_host`.
- Allowed source: explicit product/package policy and the production CMake install manifest; current implementation is comparison evidence, not a recovered VFP requirement.
- Reverse traceability: `tests/run_studio_install_contract_test.cmake` exercises both the complete installed inventory and missing-MCP-host rejection.
- Hazard/reach: test-only correction; it strengthens detection of incomplete distributed binaries. No product rollback behavior changes.

## Verification

- Direct script execution: passes; expected missing-MCP and unexpected-file negative diagnostics observed.
- Focused CTest selection: `test_studio_install_contract`, repository community contract, native platform workflow contract, GitHub Actions contract, and native test isolation contract pass `5/5`.
- `git diff --check`: passes.

## Checklist

- [x] Signed commit and DCO sign-off
- [x] No product behavior change
- [x] No release tag or artifact mutation
- [x] No certification or independent-review claim
