### PR TITLE
Adopt solo-maintainer assurance model

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/general_contribution.md
+++ b/.github/PULL_REQUEST_TEMPLATE/general_contribution.md
@@ -25,6 +25,7 @@
 
 ## Checklist
 
+- [ ] I performed an explicit self-review; I do not claim independent verification unless separate reviewer evidence is attached
 - [ ] Existing tests pass, and I added/updated tests if behavior changed
 - [ ] User-visible strings are localized (or none changed) — see [docs/22-vfp-language-reference-coverage.md](../../docs/22-vfp-language-reference-coverage.md) if touching runtime language coverage
 - [ ] I updated `CHANGELOG.md` if this is a lasting, user-visible change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+- 2026-08-13: Adopted a solo-maintainer assurance model for development
+  changes. Per-pull-request independent human approval is not required;
+  protected automated quality, security, traceability, testing, provenance,
+  and change-control gates remain in force. Self-review and automation are not
+  represented as independent verification. Independent human review is now a
+  documented completed-project or first-stable-release readiness gate, with
+  earlier review retained where a project-specific safety or security risk
+  requires it. No product or runtime behavior changed.
+
 - 2026-08-12: Superseded the protected Windows launcher-trust fixture evidence
   after differentiating the dependency and runtime-configuration sidecar
   payloads. Protected run `31635868978` passed at exact `main` merge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,14 @@ appropriate `Co-authored-by` trailer and preserve each person's sign-off.
 6. Address review feedback without rewriting another contributor's work or
    attribution.
 
+Project Copperfin currently uses a solo-maintainer development model. The
+maintainer may self-review and merge development pull requests after required
+automated gates pass; that evidence must not be described as independent
+verification. Independent human review is a completed-project or first-stable-
+release readiness activity under
+[`docs/RELEASE-READINESS-REVIEW.md`](docs/RELEASE-READINESS-REVIEW.md). A
+documented safety or security risk may require earlier human review.
+
 Maintainers may ask for smaller scope, additional evidence, provenance
 clarification, or independent review before merging. Submission does not
 guarantee acceptance.

--- a/docs/DO-178C-ASSURANCE-POLICY.md
+++ b/docs/DO-178C-ASSURANCE-POLICY.md
@@ -1,0 +1,47 @@
+# Software Assurance Policy
+
+## Status and intent
+
+This repository uses a **DO-178C-inspired** software-assurance baseline for change control, requirements traceability, verification, configuration management, and problem reporting. This policy improves engineering rigor; it does **not** claim FAA approval, airborne suitability, RTCA DO-178C compliance, or certification of this software.
+
+No Design Assurance Level (DAL) is assigned unless a project-specific certification plan and system safety assessment say otherwise. Objectives such as verification independence, structural coverage, MC/DC, qualified tools, certification liaison, and formal life-cycle data are applied only when the documented project context requires them.
+
+Normative certification work must use an authorized copy of RTCA DO-178C and applicable supplements. Public references include [FAA AC 20-115D](https://www.faa.gov/regulations_policies/advisory_circulars/index.cfm/go/document.information/documentID/1032046) and the [RTCA DO-178 family overview](https://www.rtca.org/do-178/).
+
+## Solo-maintainer review model
+
+This repository is maintained by a solo developer. Independent human approval is not required for each development pull request. The maintainer may self-review and merge after the required automated quality, test, security, traceability, and change-control gates pass.
+
+Self-review and automated verification are not independent verification, and repository records must not represent them as such. Independent human review is deferred to the completed-project or first-stable-release readiness gate described in [`RELEASE-READINESS-REVIEW.md`](RELEASE-READINESS-REVIEW.md). A project-specific risk assessment may bring human review forward for a particular change.
+
+## Change-control objectives
+
+Every non-trivial change must provide reviewable evidence for:
+
+1. **Source** — link the requirement, issue, vulnerability, or maintenance objective that motivates the change.
+2. **Impact** — identify affected behavior, interfaces, data, safety/security properties, and compatibility.
+3. **Implementation** — keep the change bounded, understandable, and under version control.
+4. **Verification** — add or update tests at the lowest effective level and record commands/results.
+5. **Traceability** — map the source to changed artifacts and verification evidence in the pull request.
+6. **Review** — perform explicit self-review during development; obtain independent human review at the release-readiness gate or earlier when a documented project risk requires it.
+
+Derived requirements and assumptions must be called out explicitly. A change must not silently weaken an existing safety, security, privacy, or compatibility constraint.
+
+## Verification baseline
+
+- CI must build or validate the project and execute its automated test suite.
+- New behavior and corrected defects require regression tests unless the pull request documents why automation is impractical and supplies alternate evidence.
+- Static analysis, dependency review, and CodeQL (for supported languages) are enforcement gates.
+- Tests must be deterministic, isolated from production systems, and free of embedded credentials.
+- Coverage claims must name the tool, scope, and measurement. A passing test count alone is not a coverage claim.
+- Safety-critical projects must maintain project-specific plans for requirements, design, verification, configuration management, quality assurance, certification liaison, coverage objectives, and tool qualification.
+
+## Configuration management and release evidence
+
+The default branch is the controlled baseline. Dependencies and automation actions should be locked or pinned where practical. Release evidence should include the source revision, build/test logs, dependency inventory, known-problem disposition, artifact checksums or signatures when artifacts are distributed, and the completed human-review record required by the release-readiness gate.
+
+GitHub issues are the problem-reporting system. Security defects must be reported privately according to `SECURITY.md`. Closed problems must record a disposition such as fixed, duplicate, deferred with rationale, or not planned with rationale.
+
+## Exceptions
+
+An exception must be documented in the pull request with scope, rationale, risk, compensating evidence, owner, and an expiration or review date. Permanent silent exceptions are not allowed.

--- a/docs/DO-178C-ASSURANCE-POLICY.md
+++ b/docs/DO-178C-ASSURANCE-POLICY.md
@@ -31,7 +31,7 @@ Derived requirements and assumptions must be called out explicitly. A change mus
 
 - CI must build or validate the project and execute its automated test suite.
 - New behavior and corrected defects require regression tests unless the pull request documents why automation is impractical and supplies alternate evidence.
-- Static analysis, dependency review, and CodeQL (for supported languages) are enforcement gates.
+- Automated security and quality checks configured for the affected scope must pass before merge. Static analysis, dependency review, and CodeQL are required only when corresponding supported workflows are present; no unavailable check is claimed as an enforcement gate.
 - Tests must be deterministic, isolated from production systems, and free of embedded credentials.
 - Coverage claims must name the tool, scope, and measurement. A passing test count alone is not a coverage claim.
 - Safety-critical projects must maintain project-specific plans for requirements, design, verification, configuration management, quality assurance, certification liaison, coverage objectives, and tool qualification.

--- a/docs/RELEASE-READINESS-REVIEW.md
+++ b/docs/RELEASE-READINESS-REVIEW.md
@@ -1,0 +1,39 @@
+# Release-Readiness Human Review
+
+## Purpose
+
+Independent human review is a release-readiness activity for this solo-maintained repository, not a required approval on every development pull request.
+
+Complete this review before either:
+
+- the first stable release;
+- declaring the project complete for its intended scope; or
+- representing the software as independently reviewed for downstream or production use.
+
+Until then, development records may cite self-review and automated verification but must state that independent human review is pending.
+
+## Review packet
+
+Provide the reviewer with:
+
+1. the intended scope, requirements, assumptions, and documented exclusions;
+2. the architecture, trust boundaries, interfaces, and important design decisions;
+3. traceability from requirements or objectives to implementation and verification;
+4. automated and manual test evidence, coverage claims, and known test limitations;
+5. security analysis, dependency state, static-analysis results, and unresolved alerts;
+6. known defects, deferred work, compatibility constraints, and residual risks;
+7. reproducible build and release instructions plus artifact provenance; and
+8. the exact source revision and release candidate being reviewed.
+
+## Review record
+
+Archive the following in a release issue, release notes, or another durable repository record:
+
+- reviewer name and relevant qualifications;
+- review date, scope, source revision, and release candidate;
+- findings and their severity;
+- resolution or explicit risk acceptance for each finding;
+- limitations of the review; and
+- the final recommendation: approved, approved with limitations, or not approved.
+
+Do not claim independent review while blocking high-severity findings remain unresolved or without an explicit, documented risk disposition.


### PR DESCRIPTION
## Summary

- Adopt the owner-directed solo-maintainer assurance model across Project Copperfin.
- Permit development pull requests to rely on explicit self-review plus protected automated gates without claiming independent verification.
- Defer independent human review to the completed-project or first-stable-release readiness gate, while preserving earlier review where a documented safety or security risk requires it.
- No product/runtime behavior changes.
- Related issue: none; direct contemporaneous owner instruction authorized this governance update.

## Testing

- `cmake -DCOPPERFIN_SOURCE_ROOT="$PWD" -P tests/run_repository_community_contract_check.cmake`
- `cmake -DSOURCE_DIR="$PWD" -P tests/run_safety_traceability_workflow_contract_check.cmake`
- `git diff --check`
- Result: passed.

## Contribution Licensing And Provenance

- [x] I have the right to submit this contribution and every included file.
- [x] I license my contribution under GPL-3.0-only with the Copperfin Application, Runtime, and Toolchain Exception 1.0; I retain my copyright and make no copyright assignment.
- [x] Every commit has my `Signed-off-by` trailer.
- [x] This change contains no third-party material.
- [x] This change contains no secrets, signing material, personal/customer data, restricted source, or decompiled proprietary code.

## Checklist

- [x] I performed an explicit self-review; independent verification is not claimed.
- [x] Existing focused community and safety workflow-contract tests pass.
- [x] No user-visible runtime strings changed.
- [x] `CHANGELOG.md` records the lasting governance change.
- [x] The policy states the development and release-review boundaries explicitly.