### PR TITLE
Emit required checks for every v1 pull request

### DIFF
--- a/.github/workflows/executable-path-validation.yml
+++ b/.github/workflows/executable-path-validation.yml
@@ -14,6 +14,9 @@ on:
       - "resources/locales/**"
       - "src/**"
       - "tests/**"
+  # v1-development requires both matrix job contexts on every pull request.
+  # Keep the focused paths for auditability, with a final catch-all so a
+  # skipped required context cannot block documentation-only work indefinitely.
   pull_request:
     paths:
       - ".github/workflows/executable-path-validation.yml"
@@ -26,6 +29,7 @@ on:
       - "resources/locales/**"
       - "src/**"
       - "tests/**"
+      - "**"
 
 permissions:
   contents: read

--- a/.github/workflows/windows-environment-validation.yml
+++ b/.github/workflows/windows-environment-validation.yml
@@ -16,6 +16,8 @@ on:
       - "resources/locales/**"
       - "src/**"
       - "tests/**"
+  # v1-development requires this context on every pull request. Preserve the
+  # focused inventory while the catch-all prevents docs-only PR deadlocks.
   pull_request:
     paths:
       - ".github/workflows/windows-environment-validation.yml"
@@ -29,6 +31,7 @@ on:
       - "resources/locales/**"
       - "src/**"
       - "tests/**"
+      - "**"
 
 permissions:
   contents: read

--- a/.github/workflows/windows-x86-declare-validation.yml
+++ b/.github/workflows/windows-x86-declare-validation.yml
@@ -13,6 +13,8 @@ on:
       - "resources/locales/**"
       - "src/**"
       - "tests/**"
+  # v1-development requires both matrix job contexts on every pull request.
+  # Preserve the focused inventory; the catch-all avoids skipped check names.
   pull_request:
     paths:
       - ".github/workflows/windows-x86-declare-validation.yml"
@@ -22,6 +24,7 @@ on:
       - "resources/locales/**"
       - "src/**"
       - "tests/**"
+      - "**"
 
 permissions:
   contents: read


### PR DESCRIPTION
The v1 ruleset requires GCC, Clang, Windows environment, and Win32/x64 DECLARE job contexts on every PR. Their pull-request path filters previously skipped docs-only changes, leaving compliant PRs permanently unmergeable. Retain the focused path inventories and add an explicit catch-all so the required contexts are always emitted.\n\nValidation:\n- `cmake -DCOPPERFIN_SOURCE_DIR=/home/rich/dev/Project-Copperfin-v1-required-check-contexts -P cmake/validate_focused_workflow_path_filters.cmake`\n- `ctest --test-dir /home/rich/copperfin-build-tagno-debug --output-on-failure -R "^(test_focused_workflow_path_filters|test_native_platform_workflow_contract)$"` (2/2)