### PR TITLE
test(safety): establish GCC coverage baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 2026-08-20: Established a reproducible, opt-in GCC coverage measurement
+  baseline for the DBF and Visual Asset integrity surface. The bounded
+  13-test run passed; source-level line and branch results plus explicit
+  non-release, non-MC/DC, and non-project-wide limits are retained in
+  `docs/safety/test-coverage-gap-analysis.md`.
+
 - 2026-08-20: Package/debug IR manifests now preserve the stable
   `on_key_command`, `on_escape`, and `on_page` opcodes for the corresponding
   parsed VFP event statements, rather than silently representing them as

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,9 @@ option(COPPERFIN_BUILD_TESTS "Build Copperfin tests" ON)
 option(COPPERFIN_BUILD_ROBUSTNESS_TESTS
     "Build optional bounded parser robustness tests (not a release gate)"
     OFF)
+option(COPPERFIN_ENABLE_GNU_COVERAGE
+    "Instrument native targets with GCC coverage data (local assurance evidence only)"
+    OFF)
 option(COPPERFIN_REQUIRE_SQLITE_CONNECTOR
     "Fail configuration when the read-only SQLite federation connector is unavailable"
     OFF)
@@ -60,6 +63,19 @@ option(COPPERFIN_ENABLE_PRODUCT_LICENSING
 option(COPPERFIN_ENFORCE_LAUNCHER_TRUST
     "Require signed app.cftrust metadata in the Windows generated-launcher guard"
     OFF)
+
+# Coverage instrumentation is deliberately opt-in and GCC-only. It is useful
+# for local assurance evidence but is not a shipping, package, or release
+# configuration; mixing compiler-specific coverage flags into those builds
+# would change their provenance and validation contract.
+if(COPPERFIN_ENABLE_GNU_COVERAGE)
+    if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        message(FATAL_ERROR
+            "COPPERFIN_ENABLE_GNU_COVERAGE requires the GNU C++ compiler")
+    endif()
+    add_compile_options(-fprofile-arcs -ftest-coverage -O0)
+    add_link_options(-fprofile-arcs -ftest-coverage)
+endif()
 set(COPPERFIN_LAUNCHER_TRUST_REGISTRY_HEADER
     "${CMAKE_CURRENT_SOURCE_DIR}/include/copperfin/package/launcher_trust_registry_empty.h"
     CACHE FILEPATH

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,19 @@
 # Agent Handoff
 
+## V1 scoped native GCC coverage baseline
+
+`COPPERFIN_ENABLE_GNU_COVERAGE=ON` is an opt-in GNU-only, local-assurance
+configuration. It must not be used to build shipping packages, installers, or
+release artifacts. The initial direct measurement exercised 13 DBF and Visual
+Asset write/undo tests under GCC 15.2.0, all passing. It records source-file
+line and branch results for `dbf_table.cpp`,
+`visual_asset_editor_record_and_snapshot.cpp`, and
+`visual_asset_editor_undo.cpp`; the full reproduction command, exact metrics,
+and clear exclusions (no aggregate, threshold, MC/DC, or certification claim)
+are in `docs/safety/test-coverage-gap-analysis.md`. A serial full-suite run
+under instrumentation is not yet evidence because `test_studio_host_json`
+exceeded its ordinary timeout.
+
 ## V1 package/debug IR event-opcode fidelity
 
 The package debug sidecar now classifies parsed `ON KEY LABEL`, `ON ESCAPE`,

--- a/docs/safety/test-coverage-gap-analysis.md
+++ b/docs/safety/test-coverage-gap-analysis.md
@@ -301,9 +301,56 @@ This section was refreshed against the current main tree on 2026-07-21. The orig
 
 The focused evidence above does not replace the required cross-platform validation matrix or the safety traceability workflow. Before a release tag, run `scripts/validate-safety-traceability.ps1` or the Safety Traceability Gate workflow against the intended release issue set and archive its report.
 
+### GCC measurement baseline (2026-08-20)
+
+An opt-in, local-only GCC coverage configuration now provides a reproducible
+measurement baseline for the highest-risk DBF and Visual Asset write/undo
+surface. It is intentionally separate from shipping, installer, package, and
+release configurations: configure a Debug build with
+`-DCOPPERFIN_ENABLE_GNU_COVERAGE=ON` and a GNU C++ compiler. The option applies
+GCC profile and test-coverage instrumentation only; it is not a release
+provenance claim.
+
+The recorded run used GCC 15.2.0 and passed all 13 selected tests:
+`test_dbf_table`, `test_visual_asset_editor`, and the 11
+`test_studio_host_real_sample_*_round_trip` delete/restore and undo scenarios.
+That scope exercises DBF parsing and persistence, Visual Asset snapshot/undo,
+and real VFP9 FRX/LBX restore behavior relevant to `HZ-data-corruption-01` and
+`RQ-CF-PRG-012`. The conditionally unavailable object-distribute sample is
+handled by its established test condition; this result is not a claim that the
+sample was present on every host.
+
+`gcov -b -c` reported the following source-file results. Percentages exclude
+standard-library/header output and are intentionally not combined into a
+misleading project-wide aggregate.
+
+| Source | Lines executed | Branches executed | Branches taken at least once |
+| --- | --- | --- | --- |
+| `src/vfp/dbf_table.cpp` | 81.56% (1,903 lines) | 77.26% (3,008) | 47.54% (3,008) |
+| `src/vfp/visual_asset_editor_record_and_snapshot.cpp` | 87.44% (597 lines) | 78.67% (1,416) | 48.31% (1,416) |
+| `src/vfp/visual_asset_editor_undo.cpp` | 87.83% (304 lines) | 91.33% (496) | 53.83% (496) |
+
+Reproduce this bounded evidence with a fresh Debug build directory, then run:
+
+```sh
+cmake -S . -B build-coverage -G Ninja -DCMAKE_BUILD_TYPE=Debug \
+  -DCOPPERFIN_BUILD_TESTS=ON -DCOPPERFIN_ENABLE_GNU_COVERAGE=ON
+cmake --build build-coverage
+ctest --test-dir build-coverage --output-on-failure -R \
+  '^(test_dbf_table|test_visual_asset_editor|test_studio_host_real_sample_(settings_delete_restore|object_nudge|object_align|object_distribute|object_resize|object_snap|object_delete_restore|object_deleted_preview|section_delete_restore|section_deleted_preview|grouping_deleted_preview)_round_trip)$'
+gcov -b -c build-coverage/CMakeFiles/copperfin_vfp.dir/src/vfp/dbf_table.cpp.gcda
+```
+
+This is a scoped statement/branch measurement, not an MC/DC analysis, target
+threshold, project-wide coverage result, certification assertion, or evidence
+that every CTest completed under instrumentation. In particular, a prior
+serial instrumented full-suite attempt exceeded the ordinary timeout for the
+child-process-heavy `test_studio_host_json`; that broad run was not used for
+this baseline and remains a separate test-infrastructure concern.
+
 Remaining checklist:
 
 - [x] GAP-01 through GAP-09 have current focused evidence references
-- [ ] Coverage measurement baseline established (GCOV or equivalent)
+- [x] Scoped GCC coverage measurement baseline established for DBF and Visual Asset integrity paths
 - [x] This document refreshed to reflect current focused evidence
 - [ ] Hazard register reviewed for any new hazards introduced by runtime additions since this refresh


### PR DESCRIPTION
## Summary

- add an opt-in GNU-only local coverage configuration
- retain direct GCOV line and branch evidence for the DBF and Visual Asset integrity surface
- document exact scope and limitations so this cannot be mistaken for release, whole-project, MC/DC, or certification evidence

## Validation

- scoped instrumented CTest: 13/13 passed (82.59s)
- git diff --check

The selected scope covers test_dbf_table, test_visual_asset_editor, and 11 real VFP9 Visual Asset delete/restore or undo round-trip tests.