### PR TITLE
test(runtime): align buffering fixtures with current contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+- 2026-08-21: Corrected the runtime-surface buffering regression fixtures after
+  DBF creation began stamping the standard last-update date and command-undo
+  journals moved beneath the configured runtime temporary directory. The
+  `LUPDATE()` blank-date path now uses an explicitly undated DBF header, while
+  the missing-backup case deletes the actual staged journal copy. This is
+  test-only and preserves the shipped DBF stamp and fail-closed UNDO behavior.
+
 - 2026-08-21: Corrected the historical limitation text on the recovered
   `DIRECTORY()` and `FILE()` requirements. It now accurately points to the
   later completed `FILE()` and `ADIR()` visibility/attribute requirements

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,16 @@
 # Agent Handoff
 
+## V1 runtime-surface buffering fixture correction
+
+The `test_prg_engine_runtime_surface_functions_buffering` regression now
+models both current contracts accurately: `create_dbf_table_file()` stamps a
+new DBF header date under `RQ-CF-PRG-012`, so the `LUPDATE()` empty-date case
+explicitly zeroes only its disposable fixture header; and command-undo journal
+files reside below the configured `runtime-temp/command_undo` directory.
+The test still proves that a missing journal backup invokes the VFP error path
+once and retains the current verified admission. No product behavior, release
+artifact, or recovery policy changed.
+
 ## V1 current low-level file-attribute limitations
 
 The historical `RQ-CF-PRG-015` `DIRECTORY()` row no longer reports the later

--- a/tests/test_prg_engine_runtime_surface_functions_buffering.cpp
+++ b/tests/test_prg_engine_runtime_surface_functions_buffering.cpp
@@ -104,9 +104,8 @@ namespace copperfin::runtime_surface_tests
             {{.name = "NAME", .type = 'C', .length = 24U}},
             {{"Alpha"}});
         expect(create_result.ok, "LUPDATE dated fixture should be writable");
-        // create_dbf_table_file() always zeroes the header's last-update bytes (a
-        // separate, deferred gap: no DBF write path in this codebase stamps a real
-        // last-update date today). Patch them directly to exercise the real-date path.
+        // Force a specific, deterministic date rather than relying on
+        // create_dbf_table_file()'s now-stamped creation-time date (today).
         write_dbf_last_update_bytes(table_path, 124U, 3U, 15U); // 1900 + 124 = 2024-03-15
 
         const auto create_blank_result = copperfin::vfp::create_dbf_table_file(
@@ -114,6 +113,10 @@ namespace copperfin::runtime_surface_tests
             {{.name = "NAME", .type = 'C', .length = 24U}},
             {{"Beta"}});
         expect(create_blank_result.ok, "LUPDATE blank fixture should be writable");
+        // create_dbf_table_file() now stamps today's date on creation
+        // (RQ-CF-PRG-012); force a genuinely undated header to keep
+        // exercising LUPDATE()'s blank-date fallback path.
+        write_dbf_last_update_bytes(blank_table_path, 0U, 0U, 0U);
 
         write_text(
             program_path,
@@ -544,7 +547,10 @@ namespace copperfin::runtime_surface_tests
                "missing-command-undo-backup regression should pause before UNDO");
 
         fs::path backup_path;
-        for (fs::recursive_directory_iterator iterator(temp_root / "command_undo", ignored), end;
+        // make_runtime_session_options() sets options.temp_directory to
+        // working_directory / "runtime-temp"; command-undo backups land
+        // under that runtime temp root, not directly under temp_root.
+        for (fs::recursive_directory_iterator iterator(temp_root / "runtime-temp" / "command_undo", ignored), end;
              !ignored && iterator != end;
              iterator.increment(ignored))
         {


### PR DESCRIPTION
## Summary
- model LUPDATE blank-date behavior with an explicitly undated disposable DBF fixture
- locate command-undo backups under the configured runtime temporary directory
- record the test-only correction in the changelog and handoff

## Verification
- ninja: no work to do.
- Test project /home/rich/dev/Project-Copperfin/build-verify
    Start 370: test_prg_engine_runtime_surface_functions_buffering
    Test #370: test_prg_engine_runtime_surface_functions_buffering ...   Passed    0.06 sec
    Start 370: test_prg_engine_runtime_surface_functions_buffering
    Test #370: test_prg_engine_runtime_surface_functions_buffering ...   Passed    0.06 sec
    Start 370: test_prg_engine_runtime_surface_functions_buffering
    Test #370: test_prg_engine_runtime_surface_functions_buffering ...   Passed    0.07 sec
    Start 370: test_prg_engine_runtime_surface_functions_buffering
    Test #370: test_prg_engine_runtime_surface_functions_buffering ...   Passed    0.07 sec
    Start 370: test_prg_engine_runtime_surface_functions_buffering
    Test #370: test_prg_engine_runtime_surface_functions_buffering ...   Passed    0.07 sec
    Start 370: test_prg_engine_runtime_surface_functions_buffering
    Test #370: test_prg_engine_runtime_surface_functions_buffering ...   Passed    0.07 sec
    Start 370: test_prg_engine_runtime_surface_functions_buffering
    Test #370: test_prg_engine_runtime_surface_functions_buffering ...   Passed    0.07 sec
    Start 370: test_prg_engine_runtime_surface_functions_buffering
    Test #370: test_prg_engine_runtime_surface_functions_buffering ...   Passed    0.06 sec
    Start 370: test_prg_engine_runtime_surface_functions_buffering
    Test #370: test_prg_engine_runtime_surface_functions_buffering ...   Passed    0.06 sec
    Start 370: test_prg_engine_runtime_surface_functions_buffering
1/1 Test #370: test_prg_engine_runtime_surface_functions_buffering ...   Passed    0.07 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
copperfin-isolation:audit=complete              =   0.07 sec*proc (1 test)
copperfin-isolation:child-processes=none        =   0.07 sec*proc (1 test)
copperfin-isolation:environment=none            =   0.07 sec*proc (1 test)
copperfin-isolation:filesystem=process-owned    =   0.07 sec*proc (1 test)
copperfin-isolation:network=none                =   0.07 sec*proc (1 test)
copperfin-isolation:platform=portable           =   0.07 sec*proc (1 test)
copperfin-isolation:resources=none              =   0.07 sec*proc (1 test)
copperfin-isolation:samples=none                =   0.07 sec*proc (1 test)
copperfin-isolation:schedule=serial             =   0.07 sec*proc (1 test)

Total Test time (real) =   0.68 sec

The prior full-suite failure was caused by these stale fixture assumptions after the DBF date-stamp and command-journal changes. No product behavior or RC artifact changes.