### PR TITLE
test(runtime): retain strict CURVAL fixture results

### DIFF
--- a/tests/test_prg_engine_runtime_surface_functions_buffering.cpp
+++ b/tests/test_prg_engine_runtime_surface_functions_buffering.cpp
@@ -689,10 +689,11 @@ namespace copperfin::runtime_surface_tests
         std::error_code ignored;
         fs::remove_all(temp_root, ignored);
         fs::create_directories(temp_root);
-        expect(copperfin::vfp::create_dbf_table_file(
-                   upper_path.string(), {{.name = "NAME", .type = 'C', .length = 24U}}, {{"Upper"}}).ok &&
-                   copperfin::vfp::create_dbf_table_file(
-                       lower_path.string(), {{.name = "NAME", .type = 'C', .length = 24U}}, {{"Lower"}}).ok,
+        const auto upper_create_result = copperfin::vfp::create_dbf_table_file(
+            upper_path.string(), {{.name = "NAME", .type = 'C', .length = 24U}}, {{"Upper"}});
+        const auto lower_create_result = copperfin::vfp::create_dbf_table_file(
+            lower_path.string(), {{.name = "NAME", .type = 'C', .length = 24U}}, {{"Lower"}});
+        expect(upper_create_result.ok && lower_create_result.ok,
                "case-distinct strict CURVAL fixtures should be writable on POSIX");
 
         write_text(


### PR DESCRIPTION
## Summary

- retain both strict-CURVAL DBF fixture results before combining their success state;
- remove GCC's dangling-temporary warning from the POSIX case-distinct admission regression;
- preserve the fixture data, test assertions, and runtime behavior unchanged.

## Root cause

The test combined two `create_dbf_table_file(...).ok` reads from temporary result objects in one expression. GCC 15 diagnosed the nested temporary/initializer-list lifetime conservatively under `-Wdangling-pointer`.

## Validation

- Direct GCC 15 Release compile of the changed translation unit with `-Wall -Wextra -Wpedantic`: passed with no diagnostics.
- Current v1 baseline full CTest: 390/390 passed; two documented platform-conditioned checks skipped.
