### PR TITLE
docs(release): clarify RC launcher-trust scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+- 2026-08-21: Clarified the private RC evaluation guide's Windows launcher
+  trust boundary. The separately successful protected signer/registry
+  validation is now identified precisely, while the guide makes explicit that
+  a candidate whose own manifest records
+  `signing.windows_launcher_release_trust` as `NOT_RUN` remains unsigned
+  evaluation output. The RC workflow contract prevents that exact-evidence
+  distinction from being silently removed.
+
 - 2026-08-21: Corrected the runtime-surface buffering regression fixtures after
   DBF creation began stamping the standard last-update date and command-undo
   journals moved beneath the configured runtime temporary directory. The

--- a/docs/35-rc1-evaluation-guide.md
+++ b/docs/35-rc1-evaluation-guide.md
@@ -74,13 +74,26 @@ other restricted material to Project Copperfin or to a public issue.
 
 ## Signing And Review Limits
 
-This evaluation workflow does not claim completion of the protected Windows
-launcher release-trust approval. Unless that separate protected process has
-been completed and directly evidenced, treat generated Windows launchers as
-evaluation output rather than approved release-trusted inventory. The Windows
-installer also does not claim Authenticode signing. Project Copperfin does not
-currently support Apple platform signing/notarization or Linux distribution
-package signing.
+The protected Windows launcher-trust procedure has separately passed in
+workflow run `31630819119` at commit
+`111fb67d09df1413221beeebce9b684f47097053`. That run proved the approved
+signer/registry procedure and its fail-closed launcher-guard cases; its
+non-secret evidence is recorded in
+`docs/safety/launcher-trust-validation-2026-08-12.md`.
+
+That separate procedure does **not** authenticate the contents of this RC
+bundle. The private RC-candidate workflow intentionally receives no signing
+secret, and its exact-candidate
+`signing.windows_launcher_release_trust` manifest field is therefore
+`NOT_RUN`. Treat generated Windows launchers in any bundle carrying that value
+as evaluation output, not as approved release-trusted inventory. A future
+candidate may claim that inventory boundary only when its own exact-tagged
+workflow performs and records the enforced signing validation; evidence from a
+different run must not be inferred into the bundle.
+
+The Windows installer also does not claim Authenticode signing. Project
+Copperfin does not currently support Apple platform signing/notarization or
+Linux distribution package signing.
 
 English is the authoritative reviewed documentation and UI source for the RC.
 Shipped non-English and pseudo-localized catalogs remain subject to the

--- a/tests/run_rc_candidate_workflow_contract_check.cmake
+++ b/tests/run_rc_candidate_workflow_contract_check.cmake
@@ -81,6 +81,22 @@ require_manifest_schema_text("\"schema_version\": { \"const\": 3 }" "schema-v3 i
 require_manifest_schema_text("\"windows_installed_cli_smoke\"" "Windows installer lifecycle evidence")
 require_manifest_schema_text("\"windows_supported_prg_open_and_command\"" "Windows VSIX lifecycle evidence")
 
+set(rc_guide_path "${SOURCE_DIR}/docs/35-rc1-evaluation-guide.md")
+file(READ "${rc_guide_path}" rc_guide)
+string(REPLACE "\r\n" "\n" rc_guide "${rc_guide}")
+string(REPLACE "\n" " " rc_guide_normalized "${rc_guide}")
+foreach(required_guide_text IN ITEMS
+        "31630819119"
+        "signing.windows_launcher_release_trust"
+        "does **not** authenticate the contents of this RC bundle"
+        "evidence from a different run must not be inferred into the bundle")
+    string(FIND "${rc_guide_normalized}" "${required_guide_text}" guide_text_offset)
+    if(guide_text_offset EQUAL -1)
+        message(FATAL_ERROR
+            "RC evaluation guide lacks current launcher-trust scope wording: ${required_guide_text}")
+    endif()
+endforeach()
+
 foreach(traceability_file IN ITEMS
         scripts/assemble-rc-candidate.py
         docs/contracts/rc-validation-manifest-v3.schema.json


### PR DESCRIPTION
## Summary

- Distinguish the completed protected Windows launcher-trust procedure from an RC bundle's own exact-candidate evidence.
- State that current RC manifests record `signing.windows_launcher_release_trust` as `NOT_RUN` because the private candidate workflow intentionally has no signing secrets.
- Lock the distinction in the RC workflow contract.

## Evidence

- `ctest --test-dir /home/rich/dev/Project-Copperfin/build-verify --output-on-failure -R '^(test_rc_candidate_workflow_contract|test_rc_candidate_assembly)$'` — 2/2 passed.
- `git diff --check` passed.

No product, package, signing material, or immutable RC artifact changes.