### PR TITLE
test(portability): correct macOS fixture assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+- 2026-08-21: Corrected two portable native-test fixtures exposed by RC3
+  macOS validation. The workspace-agent audit sink test now expects the
+  documented canonical contained path, including macOS `/var` to `/private/var`
+  canonicalization. The project-inventory invalid-name regression remains
+  fail-closed where a raw invalid UTF-8 name is representable, and no longer
+  assumes APFS will retain that raw byte sequence. Product behavior and
+  machine-readable contracts are unchanged.
+
 - 2026-08-21: Clarified the private RC evaluation guide's Windows launcher
   trust boundary. The separately successful protected signer/registry
   validation is now identified precisely, while the guide makes explicit that

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,17 @@
 # Agent Handoff
 
+## V1 macOS portable-test fixture correction
+
+RC3 macOS native validation identified two fixture assumptions, not product
+behavior defects. `WorkspaceAgentSessionAuditFileSink` intentionally exposes a
+canonical contained audit-log path; the regression now derives its expected
+path with `filesystem::canonical`, so macOS `/var` to `/private/var`
+canonicalization remains covered. APFS does not retain the test's raw invalid
+UTF-8 filename byte through `std::filesystem`, so that fail-closed inventory
+regression remains active only where the fixture is representable. Linux still
+proves rejection of the raw invalid name. No product or machine contract
+changed; a sequential RC is required after the correction merges.
+
 ## V1 runtime-surface buffering fixture correction
 
 The `test_prg_engine_runtime_surface_functions_buffering` regression now

--- a/tests/test_project_inventory.cpp
+++ b/tests/test_project_inventory.cpp
@@ -92,7 +92,11 @@ int main() {
                relative.diagnostic_code == "migration.inventory.invalid_root",
            "relative project roots must fail before filesystem traversal");
 
-#if !defined(_WIN32)
+#if !defined(_WIN32) && !defined(__APPLE__)
+    // APFS normalizes the fixture's raw invalid byte before std::filesystem
+    // exposes the directory entry. Linux preserves it, so retain the
+    // fail-closed regression there rather than asserting an invalid-name
+    // precondition that macOS cannot provide.
     const fs::path non_utf8_root = fs::temp_directory_path() / "copperfin_project_inventory_non_utf8";
     fs::remove_all(non_utf8_root, ignored);
     fs::create_directories(non_utf8_root);

--- a/tests/test_workspace_agent_audit_sink.cpp
+++ b/tests/test_workspace_agent_audit_sink.cpp
@@ -124,7 +124,10 @@ void test_persistent_lifecycle_is_content_free_and_verifiable() {
     WorkspaceAgentSessionAuditFileSink file_sink(root.path(), "agent/session.log");
     expect(file_sink.ready() && file_sink.session_sink().commit != nullptr,
            "RQ-CF-AGENT-006: a contained persistent sink configuration should be ready");
-    expect(file_sink.log_path() == root.path() / "agent/session.log",
+    std::error_code canonical_root_error;
+    const fs::path canonical_root = fs::canonical(root.path(), canonical_root_error);
+    expect(!canonical_root_error &&
+               file_sink.log_path() == canonical_root / "agent/session.log",
            "RQ-CF-AGENT-006: the sink should expose only its normalized contained log path");
 
     WorkspaceAgentSessionController controller;


### PR DESCRIPTION
## Summary

- correct the audit-sink expectation to compare against the canonical contained path
- keep the invalid UTF-8 inventory regression where its raw-byte fixture is representable
- record the RC3 macOS fixture diagnosis without changing product behavior or machine contracts

## Validation

- `cmake --build build --target test_project_inventory test_workspace_agent_audit_sink --parallel 2`
- `ctest --test-dir build --output-on-failure -R "^(test_project_inventory|test_workspace_agent_audit_sink)$"`
- `git diff --check`

## Root cause

RC3 macOS validation canonicalized the temporary-root spelling and normalized the invalid-byte test filename, invalidating two Linux-oriented fixture assumptions. The production fail-closed behavior is unchanged.