### PR TITLE
chore(runtime): remove MSVC warning noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 2026-08-21: Removed confirmed Windows/MSVC unused-parameter and
+  local-shadowing diagnostics from runtime implementation seams without
+  changing runtime behavior, public contracts, or user-visible output.
+
 - 2026-08-21: Corrected two portable native-test fixtures exposed by RC3
   macOS validation. The workspace-agent audit sink test now expects the
   documented canonical contained path, including macOS `/var` to `/private/var`

--- a/src/runtime/native_declared_library.cpp
+++ b/src/runtime/native_declared_library.cpp
@@ -102,6 +102,9 @@ namespace copperfin::runtime
             bool allow_ansi_fallback,
             NativeDeclaredLibraryLoadResult &result)
         {
+#if defined(_WIN64)
+            (void)parameter_types;
+#endif
             const std::array<std::string, 2U> export_names{function_name, function_name + "A"};
             const std::size_t export_name_count = allow_ansi_fallback ? export_names.size() : 1U;
             for (std::size_t export_index = 0U; export_index < export_name_count; ++export_index)

--- a/src/runtime/prg_engine_arrays.inl
+++ b/src/runtime/prg_engine_arrays.inl
@@ -257,7 +257,7 @@
                 const std::string predicate_parameter_name = normalize_memory_variable_identifier(predicate_block.parameter);
                 std::map<std::string, std::optional<PrgValue>> saved_globals;
                 std::map<std::string, std::optional<PrgValue>> saved_locals;
-                auto snapshot_predicate_binding = [&](Frame &frame, const std::string &name)
+                auto snapshot_predicate_binding = [&](Frame &predicate_frame, const std::string &name)
                 {
                     if (name.empty() || saved_globals.contains(name))
                     {
@@ -271,7 +271,7 @@
                     {
                         saved_globals[name] = std::nullopt;
                     }
-                    if (const auto local = frame.locals.find(name); local != frame.locals.end())
+                    if (const auto local = predicate_frame.locals.find(name); local != predicate_frame.locals.end())
                     {
                         saved_locals[name] = local->second;
                     }
@@ -282,12 +282,12 @@
                 };
                 if (predicate_search && !stack.empty())
                 {
-                    Frame &frame = stack.back();
+                    Frame &predicate_frame = stack.back();
                     for (const std::string &name : predicate_metadata_names)
                     {
-                        snapshot_predicate_binding(frame, name);
+                        snapshot_predicate_binding(predicate_frame, name);
                     }
-                    snapshot_predicate_binding(frame, predicate_parameter_name);
+                    snapshot_predicate_binding(predicate_frame, predicate_parameter_name);
                 }
                 auto restore_predicate_bindings = [&]()
                 {
@@ -295,7 +295,7 @@
                     {
                         return;
                     }
-                    Frame &frame = stack.back();
+                    Frame &predicate_frame = stack.back();
                     for (const auto &[name, value] : saved_globals)
                     {
                         if (value)
@@ -311,11 +311,11 @@
                     {
                         if (value)
                         {
-                            frame.locals[name] = *value;
+                            predicate_frame.locals[name] = *value;
                         }
                         else
                         {
-                            frame.locals.erase(name);
+                            predicate_frame.locals.erase(name);
                         }
                     }
                 };
@@ -330,18 +330,18 @@
                     {
                         return false;
                     }
-                    Frame &frame = stack.back();
+                    Frame &predicate_frame = stack.back();
                     const std::size_t row = array_columns > 0U ? (linear_index / array_columns) + 1U : linear_index + 1U;
                     const std::size_t column = array_columns > 0U ? (linear_index % array_columns) + 1U : 1U;
-                    assign_variable(frame, "_ASCANVALUE", value);
-                    assign_variable(frame, "_ASCANINDEX", make_number_value(static_cast<double>(linear_index + 1U)));
-                    assign_variable(frame, "_ASCANROW", make_number_value(static_cast<double>(row)));
-                    assign_variable(frame, "_ASCANCOLUMN", make_number_value(static_cast<double>(column)));
+                    assign_variable(predicate_frame, "_ASCANVALUE", value);
+                    assign_variable(predicate_frame, "_ASCANINDEX", make_number_value(static_cast<double>(linear_index + 1U)));
+                    assign_variable(predicate_frame, "_ASCANROW", make_number_value(static_cast<double>(row)));
+                    assign_variable(predicate_frame, "_ASCANCOLUMN", make_number_value(static_cast<double>(column)));
                     if (!predicate_block.parameter.empty())
                     {
-                        assign_variable(frame, predicate_block.parameter, value);
+                        assign_variable(predicate_frame, predicate_block.parameter, value);
                     }
-                    return value_as_bool(evaluate_expression(predicate_block.expression, frame));
+                    return value_as_bool(evaluate_expression(predicate_block.expression, predicate_frame));
                 };
                 const std::size_t start = raw_start <= 0.0
                                               ? 1U

--- a/src/runtime/prg_engine_flow.inl
+++ b/src/runtime/prg_engine_flow.inl
@@ -1580,8 +1580,8 @@
 
             if (!output_path.parent_path().empty())
             {
-                std::error_code ignored;
-                std::filesystem::create_directories(output_path.parent_path(), ignored);
+                std::error_code create_output_directory_error;
+                std::filesystem::create_directories(output_path.parent_path(), create_output_directory_error);
             }
 
             std::ofstream output(output_path, std::ios::binary);

--- a/src/runtime/prg_engine_records.inl
+++ b/src/runtime/prg_engine_records.inl
@@ -2722,9 +2722,9 @@
                 {
                     const int buffering_mode = cursor->buffering_mode;
                     cursor->buffering_mode = 1;
-                    const bool appended = append_blank_record(*cursor);
+                    const bool append_succeeded = append_blank_record(*cursor);
                     cursor->buffering_mode = buffering_mode;
-                    if (!appended)
+                    if (!append_succeeded)
                     {
                         return make_boolean_value(false);
                     }

--- a/src/runtime/prg_engine_verified_file_security.inl
+++ b/src/runtime/prg_engine_verified_file_security.inl
@@ -114,6 +114,7 @@
 #if !defined(_WIN32)
             const bool use_exact_path = exact_paths_on_posix;
 #else
+            (void)exact_paths_on_posix;
             const bool use_exact_path = false;
 #endif
             const std::string normalized_path = copperfin::platform::path_to_utf8_string(

--- a/src/runtime/runtime_pipeline_fxp_and_archive_manifest.cpp
+++ b/src/runtime/runtime_pipeline_fxp_and_archive_manifest.cpp
@@ -28,6 +28,9 @@ std::string staged_content_relative_path(
 std::map<std::string, StagedContentFile> collect_staged_content_files(
     const RuntimePackagePlan& plan,
     std::string* error = nullptr) {
+#if defined(_WIN32)
+    (void)error;
+#endif
     std::map<std::string, StagedContentFile> files;
     const std::filesystem::path content_root =
         copperfin::platform::path_from_utf8_string(plan.content_root);

--- a/src/runtime/runtime_pipeline_public_api.cpp
+++ b/src/runtime/runtime_pipeline_public_api.cpp
@@ -274,6 +274,7 @@ public:
         const std::filesystem::path& lock_identity_path,
         const std::string& identity) {
 #if defined(_WIN32)
+        (void)lock_identity_path;
         const std::wstring mutex_name = L"Local\\CopperfinPackageRoot-" +
             std::wstring(identity.begin(), identity.end());
         mutex_handle_ = static_cast<void*>(::CreateMutexW(nullptr, FALSE, mutex_name.c_str()));
@@ -2253,24 +2254,24 @@ RuntimePackagePlan create_runtime_package_plan(
         if (root_value.empty()) {
             continue;
         }
-        const std::filesystem::path root = normalize_existing_path_spelling(
+        const std::filesystem::path external_root = normalize_existing_path_spelling(
             copperfin::platform::path_from_utf8_string(root_value).lexically_normal());
         std::error_code root_error;
-        if (!std::filesystem::is_directory(root, root_error) || root_error) {
+        if (!std::filesystem::is_directory(external_root, root_error) || root_error) {
             plan.warnings.push_back(runtime_text(
                 "Runtime.Package.Warning.ExternalIncludeRootUnavailable",
                 {{"path", root_value}}));
             continue;
         }
-        admitted_external_roots.push_back(root);
+        admitted_external_roots.push_back(external_root);
     }
     const auto external_relative_path = [&](const std::filesystem::path& source_path)
         -> std::optional<std::filesystem::path> {
         const std::filesystem::path normalized_source =
             normalize_existing_path_spelling(source_path);
-        for (const auto& root : admitted_external_roots) {
+        for (const auto& admitted_root : admitted_external_roots) {
             const std::filesystem::path normalized_root =
-                normalize_existing_path_spelling(root);
+                normalize_existing_path_spelling(admitted_root);
             const auto relative = normalized_source.lexically_relative(normalized_root);
             bool contained = !relative.empty() && !relative.is_absolute();
             for (const auto& component : relative) {
@@ -2281,7 +2282,7 @@ RuntimePackagePlan create_runtime_package_plan(
             }
             if (contained) {
                 const std::string root_name = sanitize_file_name(
-                    copperfin::platform::path_to_utf8_string(root.filename()));
+                    copperfin::platform::path_to_utf8_string(admitted_root.filename()));
                 return std::filesystem::path("external") / root_name / relative;
             }
         }


### PR DESCRIPTION
## Summary
- remove confirmed MSVC unused-parameter and local-shadowing diagnostics in runtime implementation seams
- preserve all runtime behavior, public contracts, and user-visible output
- record the maintenance correction in CHANGELOG

## Validation
- `g++ -fsyntax-only` for `prg_engine.cpp`, `runtime_pipeline_fxp_and_archive_manifest.cpp`, and `runtime_pipeline_public_api.cpp` with the configured Release warning flags
- protected Windows/MSVC CI required for the Windows-only paths

Signed-off-by: rhamenator <rhamenator@gmail.com>