### PR TITLE
chore(security): make authority token type explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 2026-08-21: Made the fixed byte type explicit when creating private
+  workspace-agent authority tokens, removing MSVC's spurious unsigned
+  conversion warnings without changing authority semantics or public policy.
+
 - 2026-08-21: Removed confirmed Windows/MSVC unused-parameter and
   local-shadowing diagnostics from runtime implementation seams without
   changing runtime behavior, public contracts, or user-visible output.

--- a/include/copperfin/security/workspace_agent_session.h
+++ b/include/copperfin/security/workspace_agent_session.h
@@ -610,7 +610,7 @@ private:
         process_parser_boundary_;
     bool process_environment_configuration_supplied_ = false;
     std::shared_ptr<const std::uint8_t> process_launch_controller_authority_ =
-        std::make_shared<const std::uint8_t>(0U);
+        std::make_shared<const std::uint8_t>(std::uint8_t{0U});
     mutable std::uint64_t next_materialized_process_image_ = 1U;
 };
 

--- a/src/security/workspace_agent_environment.cpp
+++ b/src/security/workspace_agent_environment.cpp
@@ -389,7 +389,7 @@ WorkspaceAgentIsolatedEnvironmentBoundary::WorkspaceAgentIsolatedEnvironmentBoun
     : session_storage_root_(std::move(session_storage_root)),
       executable_directories_(std::move(executable_directories)),
       windows_system_root_(std::move(windows_system_root)),
-      cleanup_authority_(std::make_shared<const std::uint8_t>(0U)) {}
+      cleanup_authority_(std::make_shared<const std::uint8_t>(std::uint8_t{0U})) {}
 
 std::optional<WorkspaceAgentIsolatedEnvironmentBoundary>
 WorkspaceAgentIsolatedEnvironmentBoundary::create(


### PR DESCRIPTION
## Summary
- make fixed workspace-agent authority-token byte arguments explicitly `uint8_t`
- remove confirmed MSVC C4244 diagnostics without changing token value, authority semantics, or access policy
- record the maintenance correction in CHANGELOG

## Validation
- `g++ -fsyntax-only` with configured warning flags for `workspace_agent_environment.cpp` and `workspace_agent_session.cpp`
- protected Windows environment/path and native validation required

Signed-off-by: rhamenator <rhamenator@gmail.com>