### PR TITLE
test(builder): initialize dispatch observations

### DIFF
--- a/tests/test_builder_registry.cpp
+++ b/tests/test_builder_registry.cpp
@@ -949,7 +949,11 @@ int main() {
         .executor = [&](const copperfin::studio::StudioBuilderDispatchPlan&) {
             builder_executor_called = true;
             return copperfin::studio::StudioBuilderDispatchExecutionObservation{
-                .launched = true
+                .launched = true,
+                .exit_code = 0,
+                .output = {},
+                .error = {},
+                .mutates_asset = false
             };
         }
     });
@@ -978,7 +982,13 @@ int main() {
         .admit_execution = true,
         .executor = [&](const copperfin::studio::StudioBuilderDispatchPlan&) {
             builder_executor_called = true;
-            return copperfin::studio::StudioBuilderDispatchExecutionObservation{.launched = true};
+            return copperfin::studio::StudioBuilderDispatchExecutionObservation{
+                .launched = true,
+                .exit_code = 0,
+                .output = {},
+                .error = {},
+                .mutates_asset = false
+            };
         }
     });
     expect(!builder_executor_called &&
@@ -995,7 +1005,13 @@ int main() {
         .admit_execution = true,
         .executor = [&](const copperfin::studio::StudioBuilderDispatchPlan&) {
             builder_executor_called = true;
-            return copperfin::studio::StudioBuilderDispatchExecutionObservation{.launched = true};
+            return copperfin::studio::StudioBuilderDispatchExecutionObservation{
+                .launched = true,
+                .exit_code = 0,
+                .output = {},
+                .error = {},
+                .mutates_asset = false
+            };
         }
     });
     expect(!builder_executor_called &&


### PR DESCRIPTION
## Summary
- initialize all fields in test-only builder dispatch observations
- remove GCC missing-field-initializer diagnostics from the affected fixtures

## Verification
- `cmake --build build --target test_builder_registry --parallel 8`
- `ctest --test-dir build --output-on-failure -R "^test_builder_registry$"`