### PR TITLE
docs(standalone): define extension boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 2026-08-21: Established the standalone Studio extension boundary: it will
+  not load arbitrary VSIX packages or Copperfin's own Visual Studio extension.
+  Any future standalone extensibility must use a distinct host-owned,
+  versioned, fail-closed native plugin model with explicit publisher trust,
+  capabilities, lifecycle audit, and separately designed authority boundaries.
+
 - 2026-08-21: Made the fixed byte type explicit when creating private
   workspace-agent authority tokens, removing MSVC's spurious unsigned
   conversion warnings without changing authority semantics or public policy.

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,14 @@
 # Agent Handoff
 
+## V1 standalone extension decision
+
+Standalone Studio does not load arbitrary VSIX packages or Copperfin's own
+Visual Studio extension. A future plugin surface is a separate host-owned,
+versioned native model that must fail closed on unsupported manifests, ABI,
+publisher trust, or capability requests and must not gain ambient authority.
+This closes the documented standalone-extension decision only; it does not
+implement plugins or complete the broader IDE umbrella.
+
 ## V1 RC4 Windows-native correction
 
 Immutable RC4's exact-tag Windows native suite exposed one containment defect

--- a/docs/19-polyglot-and-ai-subprojects.md
+++ b/docs/19-polyglot-and-ai-subprojects.md
@@ -769,6 +769,32 @@ Not every language needs first-class embedding.
 
 The important thing is a stable, signed, well-audited extension model.
 
+### Standalone Studio Extension Decision
+
+The standalone Studio does not load Visual Studio extensions, VSIX packages,
+or the Copperfin Visual Studio extension. A VSIX depends on the Visual Studio
+shell, MEF composition, service lifetimes, command routing, and package
+lifecycle; treating one as a generic Studio plugin would create an unaudited
+host-compatibility and trust boundary. In particular, loading Copperfin's own
+VSIX into Copperfin Studio is prohibited: it would make the standalone host
+recursively host a product integration designed for a different shell.
+
+If Studio gains extensions, it shall use a distinct, host-owned native plugin
+model. The future model must be versioned and fail closed: the host must admit
+an explicitly supported manifest and ABI, authenticate the publisher against
+an approved trust registry, bind an explicit capability set, and record
+lifecycle/audit outcomes. A missing, malformed, untrusted, revoked, or
+unsupported plugin must not load. Plugins receive no ambient access to project
+files, credentials, process execution, network access, or runtime mutation;
+any such authority requires a separately designed, policy-controlled boundary.
+
+This is a product decision and scope boundary, not an implemented plugin API.
+Arbitrary third-party VSIX compatibility, VSIX discovery, VSIX installation,
+MEF emulation, and general managed-code loading remain unsupported. A future
+native-plugin implementation requires its own requirement recovery, trust and
+sandbox design, user-visible consent model where applicable, lifecycle
+verification, and Windows/macOS/Linux evidence before it can be exposed.
+
 ## MCP And AI Story
 
 Copperfin now has a first dedicated, provider-independent MCP host surface:


### PR DESCRIPTION
Closes #2998

## Summary
- decide that standalone Studio does not load arbitrary VSIX packages or Copperfin’s own VSIX
- define the future host-owned native-plugin boundary and fail-closed trust/capability expectations
- retain explicit unsupported scope instead of implying a plugin implementation

## Verification
- `cmake -DSOURCE_DIR=/tmp/copperfin-v1-standalone-extension-policy -P tests/run_polyglot_contract_check.cmake`
- `git diff --check`