### PR TITLE
Isolate control-flow fault recovery fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 2026-08-21: Began the #2564 test-module refactor by moving the owned
+  caught-runtime-fault/RETRY fixture into
+  `test_prg_engine_control_flow_fault_recovery.cpp` while preserving its
+  existing control-flow executable, invocation order, assertions, and
+  behavior. This is a test-structure-only change.
+
 - 2026-08-21: Generated C# transpilation now preserves parsed FoxPro `SELECT`
   statements as queryable `LinqQueryDescriptor` catalog entries with exact SQL,
   ordered projections/explicit aliases, filter, grouping, and recognized

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,14 @@
 # Agent Handoff
 
+## V1 control-flow test-module refactor
+
+The first bounded #2564 structural slice separates the owned caught-runtime-
+fault/`RETRY` fixture into `test_prg_engine_control_flow_fault_recovery.cpp`
+while retaining the existing `test_prg_engine_control_flow` executable and
+invocation order. It changes no runtime code, requirements, user-facing
+contract, RC tag, or artifact. A fresh Release configure/build and focused
+CTest pass `1/1`; next action is protected-check completion before merging.
+
 ## V1 RC6 exact-tag private-evaluation evidence
 
 Immutable tag `v0.1.0-rc.6` at `1208ebbd7babf65fcb8f46ada0b1316289328a6e`

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5531,6 +5531,7 @@ copperfin_add_test(test_prg_engine_control_flow cf_xbase_runtime
     test_prg_engine_control_flow_error_handler_commands.cpp
     test_prg_engine_control_flow_bare_null.cpp
     test_prg_engine_control_flow_error_handling_and_faults.cpp
+    test_prg_engine_control_flow_fault_recovery.cpp
     test_prg_engine_control_flow_runtime_guardrails_and_lifecycle.cpp
     test_prg_engine_control_flow_routine_calls_parameters.cpp
     test_prg_engine_control_flow_routine_calls_continuations_01.cpp

--- a/tests/test_prg_engine_control_flow_error_handling_and_faults.cpp
+++ b/tests/test_prg_engine_control_flow_error_handling_and_faults.cpp
@@ -3938,55 +3938,6 @@ void test_retry_with_no_fault_checkpoint_is_noop() {
     fs::remove_all(temp_root, ignored);
 }
 
-void test_runtime_faults_preserve_state_and_allow_retry() {
-    // We will execute a script that intentionally causes a runtime C++ exception (like LOG(-1))
-    // We will verify that we can RETRY and the cursor/session state is preserved.
-    namespace fs = std::filesystem;
-    const fs::path temp_root =
-        fs::absolute(fs::temp_directory_path()) /
-        ("copperfin_prg_engine_runtime_fault_retry_" + std::to_string(_getpid()));
-    std::error_code ignored;
-    fs::remove_all(temp_root, ignored);
-    fs::create_directories(temp_root);
-
-    const fs::path main_path = temp_root / "runtime_fault_test.prg";
-    write_text(main_path,
-        "CREATE CURSOR test_cursor (id I)\n"
-        "INSERT INTO test_cursor VALUES (1)\n"
-        "INSERT INTO test_cursor VALUES (2)\n"
-        "GO TOP\n"
-        "x = -1\n"
-        "ON ERROR DO my_error_handler\n"
-        "? LOG(x)\n" // This throws std::runtime_error first time
-        "PROCEDURE my_error_handler\n"
-        "    x = 1\n"
-        "    RETRY\n"
-        "ENDPROC\n"
-    );
-
-    {
-        const auto options =
-            make_runtime_session_options(main_path, temp_root, false);
-        const fs::path runtime_temp = options.temp_directory;
-        expect(runtime_temp.is_absolute(), "#4075: caught-fault runtime temp should be absolute");
-        expect(
-            runtime_temp.parent_path().lexically_normal() == temp_root.lexically_normal(),
-            "#4075: caught-fault runtime temp should remain beneath its fixture owner");
-        auto session = copperfin::runtime::PrgRuntimeSession::create(options);
-        const auto state = session.run(copperfin::runtime::DebugResumeAction::continue_run);
-
-        if (!state.completed) {
-            std::cerr << "Script stopped. Reason: " << copperfin::runtime::debug_pause_reason_name(state.reason)
-                      << ", message: " << state.message << std::endl;
-        }
-
-        expect(state.completed, "Script should complete after handling fault");
-    }
-
-    fs::remove_all(temp_root, ignored);
-    expect(!fs::exists(temp_root), "#4075: caught-fault fixture should clean its owned runtime state");
-}
-
 void test_aerror_line_number_is_innermost_faulting_line_not_catch_site() {
     // #256: AERROR()[1,5] inside a CATCH block must report the innermost faulting
     // line (inside the deeply nested routine), not the TRY/CATCH site.

--- a/tests/test_prg_engine_control_flow_fault_recovery.cpp
+++ b/tests/test_prg_engine_control_flow_fault_recovery.cpp
@@ -1,0 +1,53 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "test_prg_engine_control_flow_support.h"
+
+namespace cf_test_prg_engine_control_flow {
+
+void test_runtime_faults_preserve_state_and_allow_retry() {
+    namespace fs = std::filesystem;
+    const fs::path temp_root =
+        fs::absolute(fs::temp_directory_path()) /
+        ("copperfin_prg_engine_runtime_fault_retry_" + std::to_string(_getpid()));
+    std::error_code ignored;
+    fs::remove_all(temp_root, ignored);
+    fs::create_directories(temp_root);
+
+    const fs::path main_path = temp_root / "runtime_fault_test.prg";
+    write_text(main_path,
+        "CREATE CURSOR test_cursor (id I)\n"
+        "INSERT INTO test_cursor VALUES (1)\n"
+        "INSERT INTO test_cursor VALUES (2)\n"
+        "GO TOP\n"
+        "x = -1\n"
+        "ON ERROR DO my_error_handler\n"
+        "? LOG(x)\n"
+        "PROCEDURE my_error_handler\n"
+        "    x = 1\n"
+        "    RETRY\n"
+        "ENDPROC\n");
+
+    {
+        const auto options = make_runtime_session_options(main_path, temp_root, false);
+        const fs::path runtime_temp = options.temp_directory;
+        expect(runtime_temp.is_absolute(), "#4075: caught-fault runtime temp should be absolute");
+        expect(runtime_temp.parent_path().lexically_normal() == temp_root.lexically_normal(),
+               "#4075: caught-fault runtime temp should remain beneath its fixture owner");
+        auto session = copperfin::runtime::PrgRuntimeSession::create(options);
+        const auto state = session.run(copperfin::runtime::DebugResumeAction::continue_run);
+
+        if (!state.completed) {
+            std::cerr << "Script stopped. Reason: " << copperfin::runtime::debug_pause_reason_name(state.reason)
+                      << ", message: " << state.message << std::endl;
+        }
+
+        expect(state.completed, "Script should complete after handling fault");
+    }
+
+    fs::remove_all(temp_root, ignored);
+    expect(!fs::exists(temp_root), "#4075: caught-fault fixture should clean its owned runtime state");
+}
+
+}  // namespace cf_test_prg_engine_control_flow


### PR DESCRIPTION
## Summary
- move the caught-runtime-fault and `RETRY` fixture into an owned control-flow test module
- retain the existing `test_prg_engine_control_flow` executable and invocation order
- record the narrow #2564 maintainability evidence

## Scope
Test structure and documentation only. No runtime code, VFP behavior, user-facing contract, RC tag, or artifact changes.

## Verification
- `cmake -S . -B /tmp/copperfin-v1-error-handling-test-modules-build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build /tmp/copperfin-v1-error-handling-test-modules-build --target test_prg_engine_control_flow --parallel 2`
- `ctest --test-dir /tmp/copperfin-v1-error-handling-test-modules-build --output-on-failure -R ^'test_prg_engine_control_flow$'` (1/1 passed)\n- `ctest --test-dir /tmp/copperfin-v1-error-handling-test-modules-build --output-on-failure -R ^'test_repository_community_contract$'` (1/1 passed)