### PR TITLE
build(vfp): initialize asset probe results explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+- 2026-08-21: Explicitly initialized the read-only CDX/index-probe result
+  aggregates and removed an unused CDX helper, eliminating current GCC/MSVC
+  diagnostic noise without changing legacy asset interpretation, public result
+  layouts, localized messages, or machine-readable output.
+
 - 2026-08-21: Continued #2564 test-module refactoring by moving the focused
   SQL/OLE `AERROR()` metadata fixture into
   `test_prg_engine_control_flow_aerror_sql_ole_metadata.cpp`. The existing

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,13 @@
 # Agent Handoff
 
+## V1 asset-probe warning hygiene
+
+The read-only CDX/index-probe boundary explicitly initializes every result
+aggregate field and omits an unused CDX helper. This is build-quality only:
+preserve parsed bytes, result layouts, localized diagnostics, and
+machine-readable inspection output. A fresh Release build of `test_vfp_assets`
+has no diagnostics from these translation units and the executable passes.
+
 ## V1 AERROR SQL/OLE metadata test module
 
 The next bounded #2564 structural slice owns the focused SQL/OLE `AERROR()`

--- a/src/vfp/cdx_header.cpp
+++ b/src/vfp/cdx_header.cpp
@@ -158,10 +158,6 @@ std::string collapse_identifier(const std::string& value) {
     return normalized;
 }
 
-std::vector<PrintableRun> collect_printable_runs(const std::vector<std::uint8_t>& bytes) {
-    return collect_printable_runs(bytes, 0U, bytes.size());
-}
-
 std::vector<PrintableRun> collect_printable_runs(
     const std::vector<std::uint8_t>& bytes,
     std::size_t start,
@@ -462,6 +458,8 @@ std::vector<CdxTagDescriptor> collect_directory_leaf_tags(
 
             tags.push_back({
                 .name_hint = chunk,
+                .key_expression_hint = {},
+                .for_expression_hint = {},
                 .tag_page_offset_hint = looks_like_tag_page_offset(
                     read_le_u32(bytes, page_hint_offset),
                     page_size,
@@ -469,6 +467,8 @@ std::vector<CdxTagDescriptor> collect_directory_leaf_tags(
                     ? read_le_u32(bytes, page_hint_offset)
                     : 0U,
                 .name_offset_hint = static_cast<std::uint32_t>(name_offset),
+                .key_expression_offset_hint = 0U,
+                .for_expression_offset_hint = 0U,
                 .inferred_name = false
             });
         }
@@ -762,7 +762,12 @@ bool CdxHeader::looks_like_cdx() const {
 
 CdxParseResult parse_cdx_header(const std::vector<std::uint8_t>& bytes, std::uint64_t file_size) {
     if (bytes.size() < 16U) {
-        return {.ok = false, .error = cdx_header_text("Vfp.CdxHeader.Error.ShortProbe")};
+        return {
+            .ok = false,
+            .header = {},
+            .tags = {},
+            .error = cdx_header_text("Vfp.CdxHeader.Error.ShortProbe")
+        };
     }
 
     CdxHeader header;
@@ -778,10 +783,20 @@ CdxParseResult parse_cdx_header(const std::vector<std::uint8_t>& bytes, std::uin
     header.key_pool_length_hint = header.raw_words[7];
 
     if (!header.looks_like_cdx()) {
-        return {.ok = false, .header = header, .error = cdx_header_text("Vfp.CdxHeader.Error.InvalidValues")};
+        return {
+            .ok = false,
+            .header = header,
+            .tags = {},
+            .error = cdx_header_text("Vfp.CdxHeader.Error.InvalidValues")
+        };
     }
 
-    CdxParseResult result{.ok = true, .header = header};
+    CdxParseResult result{
+        .ok = true,
+        .header = header,
+        .tags = {},
+        .error = {}
+    };
     if (bytes.size() > 16U) {
         result.tags = extract_tag_descriptors(bytes, header.page_size, header.key_length_hint);
     }
@@ -792,17 +807,32 @@ CdxParseResult parse_cdx_header_from_file(const std::string& path) {
     const std::filesystem::path native_path = copperfin::platform::path_from_utf8_string(path);
     std::ifstream input(native_path, std::ios::binary);
     if (!input) {
-        return {.ok = false, .error = cdx_header_text("Vfp.CdxHeader.Error.OpenFileFailed")};
+        return {
+            .ok = false,
+            .header = {},
+            .tags = {},
+            .error = cdx_header_text("Vfp.CdxHeader.Error.OpenFileFailed")
+        };
     }
 
     std::error_code file_size_error;
     const std::uint64_t file_size = static_cast<std::uint64_t>(
         std::filesystem::file_size(native_path, file_size_error));
     if (file_size_error) {
-        return {.ok = false, .error = cdx_header_text("Vfp.CdxHeader.Error.ReadProbeFailed")};
+        return {
+            .ok = false,
+            .header = {},
+            .tags = {},
+            .error = cdx_header_text("Vfp.CdxHeader.Error.ReadProbeFailed")
+        };
     }
     if (file_size < 16U) {
-        return {.ok = false, .error = cdx_header_text("Vfp.CdxHeader.Error.ReadProbeFailed")};
+        return {
+            .ok = false,
+            .header = {},
+            .tags = {},
+            .error = cdx_header_text("Vfp.CdxHeader.Error.ReadProbeFailed")
+        };
     }
 
     std::vector<std::uint8_t> bytes(static_cast<std::size_t>(file_size), 0U);

--- a/src/vfp/index_probe.cpp
+++ b/src/vfp/index_probe.cpp
@@ -310,7 +310,7 @@ IndexParseResult parse_cdx_family_probe(
     IndexKind kind) {
     const CdxParseResult cdx_result = parse_cdx_header(bytes, file_size);
     if (!cdx_result.ok) {
-        return {.ok = false, .error = cdx_result.error};
+        return {.ok = false, .probe = {}, .error = cdx_result.error};
     }
 
     IndexProbe probe;
@@ -361,12 +361,16 @@ IndexParseResult parse_cdx_family_probe(
     }
     probe.multi_tag = true;
     probe.production_candidate = (kind == IndexKind::cdx);
-    return {.ok = true, .probe = probe};
+    return {.ok = true, .probe = probe, .error = {}};
 }
 
 IndexParseResult parse_fox_idx_probe(const std::vector<std::uint8_t>& bytes, std::uint64_t file_size) {
     if (bytes.size() < 512U) {
-        return {.ok = false, .error = index_probe_text("Vfp.IndexProbe.Error.VisualFoxProIdxHeaderTooSmall")};
+        return {
+            .ok = false,
+            .probe = {},
+            .error = index_probe_text("Vfp.IndexProbe.Error.VisualFoxProIdxHeaderTooSmall")
+        };
     }
 
     IndexProbe probe;
@@ -406,12 +410,16 @@ IndexParseResult parse_fox_idx_probe(const std::vector<std::uint8_t>& bytes, std
         };
     }
 
-    return {.ok = true, .probe = probe};
+    return {.ok = true, .probe = probe, .error = {}};
 }
 
 IndexParseResult parse_dbase_ndx_probe(const std::vector<std::uint8_t>& bytes, std::uint64_t file_size) {
     if (bytes.size() < 512U) {
-        return {.ok = false, .error = index_probe_text("Vfp.IndexProbe.Error.DbaseNdxHeaderTooSmall")};
+        return {
+            .ok = false,
+            .probe = {},
+            .error = index_probe_text("Vfp.IndexProbe.Error.DbaseNdxHeaderTooSmall")
+        };
     }
 
     const std::uint32_t root_block = read_le_u32(bytes, 0U);
@@ -457,12 +465,16 @@ IndexParseResult parse_dbase_ndx_probe(const std::vector<std::uint8_t>& bytes, s
         };
     }
 
-    return {.ok = true, .probe = probe};
+    return {.ok = true, .probe = probe, .error = {}};
 }
 
 IndexParseResult parse_dbase_mdx_probe(const std::vector<std::uint8_t>& bytes, std::uint64_t file_size) {
     if (bytes.size() < 512U) {
-        return {.ok = false, .error = index_probe_text("Vfp.IndexProbe.Error.DbaseMdxProbeTooSmall")};
+        return {
+            .ok = false,
+            .probe = {},
+            .error = index_probe_text("Vfp.IndexProbe.Error.DbaseMdxProbeTooSmall")
+        };
     }
 
     IndexProbe probe;
@@ -600,7 +612,7 @@ IndexParseResult parse_dbase_mdx_probe(const std::vector<std::uint8_t>& bytes, s
     probe.normalization_hint = probe.tags.front().normalization_hint;
     probe.collation_hint = probe.tags.front().collation_hint;
 
-    return {.ok = true, .probe = probe};
+    return {.ok = true, .probe = probe, .error = {}};
 }
 
 }  // namespace
@@ -676,28 +688,48 @@ IndexParseResult parse_index_probe(
         case IndexKind::mdx:
             return parse_dbase_mdx_probe(bytes, file_size);
         case IndexKind::unknown:
-            return {.ok = false, .error = index_probe_text("Vfp.IndexProbe.Error.UnknownExtension")};
+            return {
+                .ok = false,
+                .probe = {},
+                .error = index_probe_text("Vfp.IndexProbe.Error.UnknownExtension")
+            };
     }
-    return {.ok = false, .error = index_probe_text("Vfp.IndexProbe.Error.UnsupportedType")};
+    return {
+        .ok = false,
+        .probe = {},
+        .error = index_probe_text("Vfp.IndexProbe.Error.UnsupportedType")
+    };
 }
 
 IndexParseResult parse_index_probe_from_file(const std::string& path) {
     const IndexKind kind = index_kind_from_path(path);
     if (kind == IndexKind::unknown) {
-        return {.ok = false, .error = index_probe_text("Vfp.IndexProbe.Error.PathExtensionUnknown")};
+        return {
+            .ok = false,
+            .probe = {},
+            .error = index_probe_text("Vfp.IndexProbe.Error.PathExtensionUnknown")
+        };
     }
 
     const std::filesystem::path native_path = copperfin::platform::path_from_utf8_string(path);
     std::ifstream input(native_path, std::ios::binary);
     if (!input) {
-        return {.ok = false, .error = index_probe_text("Vfp.IndexProbe.Error.OpenFileFailed")};
+        return {
+            .ok = false,
+            .probe = {},
+            .error = index_probe_text("Vfp.IndexProbe.Error.OpenFileFailed")
+        };
     }
 
     std::error_code file_size_error;
     const std::uint64_t file_size = static_cast<std::uint64_t>(
         std::filesystem::file_size(native_path, file_size_error));
     if (file_size_error) {
-        return {.ok = false, .error = index_probe_text("Vfp.IndexProbe.Error.OpenFileFailed")};
+        return {
+            .ok = false,
+            .probe = {},
+            .error = index_probe_text("Vfp.IndexProbe.Error.OpenFileFailed")
+        };
     }
     std::size_t probe_size = 512U;
     if (kind == IndexKind::cdx || kind == IndexKind::dcx || kind == IndexKind::mdx) {
@@ -707,7 +739,11 @@ IndexParseResult parse_index_probe_from_file(const std::string& path) {
     input.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
 
     if (input.gcount() <= 0) {
-        return {.ok = false, .error = index_probe_text("Vfp.IndexProbe.Error.ReadHeaderFailed")};
+        return {
+            .ok = false,
+            .probe = {},
+            .error = index_probe_text("Vfp.IndexProbe.Error.ReadHeaderFailed")
+        };
     }
 
     bytes.resize(static_cast<std::size_t>(input.gcount()));


### PR DESCRIPTION
## Summary
- explicitly initialize CDX and index-probe result aggregates
- remove one unused CDX helper
- preserve read-only inspection behavior and result layouts

## Validation
- GCC Release: `ctest --test-dir /tmp/copperfin-v1-asset-probe-warning-hygiene-build --output-on-failure -R "^test_vfp_assets$"`
- Clang Release: `ctest --test-dir /tmp/copperfin-v1-asset-probe-warning-hygiene-clang --output-on-failure -R "^test_vfp_assets$"`