### PR TITLE
test(runtime): isolate YIELD event regression

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5531,6 +5531,7 @@ copperfin_add_test(test_prg_engine_control_flow cf_xbase_runtime
     test_prg_engine_control_flow_aggregate_and_total_commands.cpp
     test_prg_engine_select_query_commands.cpp
     test_prg_engine_control_flow_concurrency_and_critical_sections.cpp
+    test_prg_engine_control_flow_yield_event.cpp
     test_prg_engine_control_flow_event_loop.cpp
     test_prg_engine_control_flow_error_handler_commands.cpp
     test_prg_engine_control_flow_bare_null.cpp

--- a/tests/test_prg_engine_control_flow_concurrency_and_critical_sections.cpp
+++ b/tests/test_prg_engine_control_flow_concurrency_and_critical_sections.cpp
@@ -1344,56 +1344,6 @@ void test_critical_sections_release_on_task_fault_without_deadlock() {
     fs::remove_all(temp_root, ignored);
 }
 
-void test_yield_command_emits_runtime_yield_event_and_preserves_state() {
-    namespace fs = std::filesystem;
-    const fs::path temp_root = fs::temp_directory_path() / "copperfin_prg_yield_cmd";
-    std::error_code ignored;
-    fs::remove_all(temp_root, ignored);
-    fs::create_directories(temp_root);
-
-    const fs::path main_path = temp_root / "yield_test.prg";
-    write_text(
-        main_path,
-        "PROCEDURE worker\n"
-        "    SLEEP 1\n"
-        "    RETURN\n"
-        "ENDPROC\n"
-        "nBefore = 1\n"
-        "SPAWN worker TO nTask\n"
-        "YIELD\n"
-        "nAfter = 42\n"
-        "AWAIT nTask TO lDone\n"
-        "RETURN\n");
-
-    copperfin::runtime::PrgRuntimeSession session =
-        copperfin::runtime::PrgRuntimeSession::create(make_runtime_session_options(main_path.string(), temp_root.string(), false));
-    const auto state = session.run(copperfin::runtime::DebugResumeAction::continue_run);
-    expect(state.completed, "YIELD test should complete");
-
-    const auto yield_event = std::find_if(
-        state.events.begin(), state.events.end(),
-        [](const auto& event) { return event.category == "runtime.yield"; });
-    expect(yield_event != state.events.end(), "YIELD should emit a runtime.yield event");
-
-    const auto before_it = state.globals.find("nbefore");
-    const auto after_it = state.globals.find("nafter");
-    const auto done_it = state.globals.find("ldone");
-    expect(before_it != state.globals.end(), "YIELD script should capture the pre-yield value");
-    expect(after_it != state.globals.end(), "YIELD script should continue after yielding");
-    expect(done_it != state.globals.end(), "YIELD script should wait for the spawned task");
-    if (before_it != state.globals.end()) {
-        expect(before_it->second.number_value == 1.0, "pre-yield state should remain intact");
-    }
-    if (after_it != state.globals.end()) {
-        expect(after_it->second.number_value == 42.0, "post-yield assignment should execute");
-    }
-    if (done_it != state.globals.end()) {
-        expect(done_it->second.boolean_value, "awaited worker should complete successfully");
-    }
-
-    fs::remove_all(temp_root, ignored);
-}
-
 void test_yield_is_allowed_while_holding_critical_section() {
     namespace fs = std::filesystem;
     const fs::path temp_root = fs::temp_directory_path() / "copperfin_prg_yield_critical_regression";

--- a/tests/test_prg_engine_control_flow_yield_event.cpp
+++ b/tests/test_prg_engine_control_flow_yield_event.cpp
@@ -1,0 +1,57 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "test_prg_engine_control_flow_support.h"
+
+namespace cf_test_prg_engine_control_flow {
+void test_yield_command_emits_runtime_yield_event_and_preserves_state() {
+    namespace fs = std::filesystem;
+    const fs::path temp_root = fs::temp_directory_path() / "copperfin_prg_yield_cmd";
+    std::error_code ignored;
+    fs::remove_all(temp_root, ignored);
+    fs::create_directories(temp_root);
+
+    const fs::path main_path = temp_root / "yield_test.prg";
+    write_text(
+        main_path,
+        "PROCEDURE worker\n"
+        "    SLEEP 1\n"
+        "    RETURN\n"
+        "ENDPROC\n"
+        "nBefore = 1\n"
+        "SPAWN worker TO nTask\n"
+        "YIELD\n"
+        "nAfter = 42\n"
+        "AWAIT nTask TO lDone\n"
+        "RETURN\n");
+
+    copperfin::runtime::PrgRuntimeSession session =
+        copperfin::runtime::PrgRuntimeSession::create(make_runtime_session_options(main_path.string(), temp_root.string(), false));
+    const auto state = session.run(copperfin::runtime::DebugResumeAction::continue_run);
+    expect(state.completed, "YIELD test should complete");
+
+    const auto yield_event = std::find_if(
+        state.events.begin(), state.events.end(),
+        [](const auto& event) { return event.category == "runtime.yield"; });
+    expect(yield_event != state.events.end(), "YIELD should emit a runtime.yield event");
+
+    const auto before_it = state.globals.find("nbefore");
+    const auto after_it = state.globals.find("nafter");
+    const auto done_it = state.globals.find("ldone");
+    expect(before_it != state.globals.end(), "YIELD script should capture the pre-yield value");
+    expect(after_it != state.globals.end(), "YIELD script should continue after yielding");
+    expect(done_it != state.globals.end(), "YIELD script should wait for the spawned task");
+    if (before_it != state.globals.end()) {
+        expect(before_it->second.number_value == 1.0, "pre-yield state should remain intact");
+    }
+    if (after_it != state.globals.end()) {
+        expect(after_it->second.number_value == 42.0, "post-yield assignment should execute");
+    }
+    if (done_it != state.globals.end()) {
+        expect(done_it->second.boolean_value, "awaited worker should complete successfully");
+    }
+
+    fs::remove_all(temp_root, ignored);
+}
+}  // namespace cf_test_prg_engine_control_flow


### PR DESCRIPTION
## Scope

- Moves the existing core YIELD event/state regression into its own control-flow translation unit under #2564.
- Retains the same executable, shared declaration, runner invocation order, assertions, and runtime behavior.

## Evidence

- Extracted test body is byte-identical to the current v1-development source.
- Fresh Release configure/build completed.
- The focused test_prg_engine_control_flow CTest passed 1/1.
- git diff --check passed.

No runtime, package, machine contract, RC tag, or artifact changes.