### PR TITLE
docs(handoff): record bottom-margin validation

### DIFF
--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,20 @@
 # Agent Handoff
 
+## V1 Studio bottom-margin test module
+
+The bounded #2564 structural slice moved the four focused report/label
+stable-selection bottom-margin regressions into
+`test_studio_host_json_settings_bottom_margin.cpp`, retaining the existing
+report-page-setup executable, fixtures, declarations, invocation order, and
+Studio behavior. PR #5135 merged as `97cb833f1249b97bfff1b350f653d63d2e9c8d59`
+after the exact rebased head `92a0a61e8eeaace18aa5808df0ee2b5af7753bee`
+passed DCO, Socket, GCC/Clang, Windows Win32/x64 DECLARE, Windows environment
+and generated-launcher, and GitHub-hosted macOS/Ubuntu validation. An initial
+Windows parser crash was not reproduced: the exact-head environment-path rerun
+passed. The next #2564 candidate is the cohesive detail-header/footer object
+distribution regression group; preserve the existing focused layout-actions
+executable and its report/label, live/deleted coverage.
+
 ## V1 table-buffer negative RECNO identity
 
 The bounded #5125 runtime slice recovers the installed VFP9 table-buffer


### PR DESCRIPTION
## Scope

Records the merged #5135 Studio bottom-margin test-module split and its exact-head protected validation evidence in agent-handoff.md.

No production code, test behavior, machine-readable contract, release-candidate artifact, or licensing change.

## Verification

- git diff --check
- Exact merged #5135 head 92a0a61e8eeaace18aa5808df0ee2b5af7753bee passed DCO, Socket, GCC/Clang, hosted macOS/Ubuntu, Windows Win32/x64 DECLARE, Windows launcher, and the rerun Windows environment-path suite.