### PR TITLE
test: isolate basic DBF memo lifecycle regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
   lifetime, fault-containment, and owned-Windows-verification boundaries. No
    COM-event runtime behavior is implemented or claimed yet.
 
+- 2026-08-23: Continued #2564 test-module refactoring by moving the basic DBF
+  memo and G/P create/replace/append lifecycle regressions into
+  `test_dbf_table_memo_lifecycle.cpp`. The existing `test_dbf_table`
+   executable, invocation order, assertions, and DBF behavior remain unchanged.
+
 - 2026-08-23: Continued #2564 test-module refactoring by moving report/label
   layout-object LEFT preview-bounds regressions into
   `test_studio_host_json_geometry_preview_object_lefts.cpp`. The existing

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -46,6 +46,19 @@ source with lifecycle/fault verification (`#5164`). Do not treat native
 connected-COM evidence; no remote activation, network discovery, registry
 probing, or third-party COM server belongs in this lane.
 
+## V1 basic DBF memo lifecycle test module
+
+The bounded #5152/#2564 structural slice moves the basic M-field and G/P-field
+create/replace/append lifecycle regressions into
+`test_dbf_table_memo_lifecycle.cpp`. A minimal shared header owns only the
+existing failure reporter and the two declarations; the existing
+`test_dbf_table` executable, fixture ownership, invocation order, assertions,
+and DBF behavior remain unchanged. The raw-byte fixture, PACK MEMO,
+fail-closed, additive-replacement, and schema-rewrite memo regressions remain
+separate #5151 follow-up slices. The moved bodies match the former source range
+byte-for-byte. A fresh Debug build and focused `test_dbf_table` CTest pass 1/1;
+protected cross-platform validation remains required before merge.
+
 ## V1 report layout-object LEFT preview-bounds test module
 
 The bounded #2564 structural slice moves the report/label layout-object LEFT

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4523,6 +4523,7 @@ copperfin_apply_windows_stack_reserve(test_studio_host)
 
 copperfin_add_test(test_dbf_table cf_vfp_assets
     test_dbf_table.cpp
+    test_dbf_table_memo_lifecycle.cpp
 )
 
 copperfin_add_test(test_dbf_text_encoding cf_vfp_assets

--- a/tests/test_dbf_table.cpp
+++ b/tests/test_dbf_table.cpp
@@ -4,6 +4,7 @@
 
 #include "copperfin/localization/localization.h"
 #include "copperfin/vfp/dbf_table.h"
+#include "test_dbf_table_support.h"
 #include "test_environment_support.h"
 
 #include <algorithm>
@@ -23,9 +24,7 @@
 #include <string_view>
 #include <vector>
 
-namespace {
-
-using copperfin::test_support::ScopedEnvironmentValue;
+namespace copperfin::test_dbf_table {
 
 int failures = 0;
 
@@ -35,6 +34,14 @@ void expect(bool condition, const std::string& message) {
         ++failures;
     }
 }
+
+}  // namespace copperfin::test_dbf_table
+
+namespace {
+
+using copperfin::test_support::ScopedEnvironmentValue;
+using copperfin::test_dbf_table::expect;
+using copperfin::test_dbf_table::failures;
 
 class comma_decimal_numpunct final : public std::numpunct<char> {
 protected:
@@ -917,116 +924,6 @@ void test_dbf_table_default_catalog_refreshes_when_locale_changes() {
     expect(english_result.error != spanish_result.error &&
                spanish_result.error != pseudo_result.error,
            "#4360: locale refresh should not reuse the prior DBF-table diagnostic text");
-
-    fs::remove_all(temp_dir, ignored);
-}
-
-void test_memo_field_create_replace_and_append_round_trip() {
-    namespace fs = std::filesystem;
-    const fs::path temp_dir = fs::temp_directory_path() /
-        ("copperfin_dbf_table_memo_tests_" + std::to_string(_getpid()));
-    std::error_code ignored;
-    fs::remove_all(temp_dir, ignored);
-    fs::create_directories(temp_dir);
-
-    const fs::path table_path = temp_dir / "notes.dbf";
-    const fs::path memo_path = temp_dir / "notes.fpt";
-    const std::vector<copperfin::vfp::DbfFieldDescriptor> fields{
-        {.name = "TITLE", .type = 'C', .length = 12U},
-        {.name = "BODY", .type = 'M', .length = 4U}
-    };
-    const std::vector<std::vector<std::string>> records{
-        {"FIRST", "First memo body"},
-        {"SECOND", "Second memo body"}
-    };
-
-    const auto create_result = copperfin::vfp::create_dbf_table_file(table_path.string(), fields, records);
-    expect(create_result.ok, "create_dbf_table_file should support memo-backed schemas");
-    expect(fs::exists(memo_path), "memo-backed table creation should also create the FPT sidecar");
-
-    auto parse_result = copperfin::vfp::parse_dbf_table_from_file(table_path.string(), 5U);
-    expect(parse_result.ok, "memo-backed created tables should remain readable");
-    expect(parse_result.table.records.size() == 2U, "memo-backed created tables should persist record rows");
-    if (parse_result.table.records.size() == 2U) {
-        expect(parse_result.table.records[0].values[0].display_value == "FIRST", "memo-backed created character fields should persist");
-        expect(parse_result.table.records[0].values[1].display_value == "First memo body", "memo-backed created memo fields should round-trip through the sidecar");
-        expect(parse_result.table.records[0].values[1].memo_block_number != 0U,
-               "#711: created memo rows should retain non-zero memo block provenance");
-        expect(parse_result.table.records[1].values[1].display_value == "Second memo body", "later memo rows should also round-trip");
-        expect(parse_result.table.records[1].values[1].memo_block_number != 0U,
-               "#711: later created memo rows should retain non-zero memo block provenance");
-    }
-
-    const auto replace_result = copperfin::vfp::replace_record_field_value(table_path.string(), 0U, "BODY", "Updated first memo");
-    expect(replace_result.ok, "replace_record_field_value should support memo-backed fields");
-
-    const auto append_result = copperfin::vfp::append_blank_record_to_file(table_path.string());
-    expect(append_result.ok, "append_blank_record_to_file should support memo-backed tables");
-    expect(append_result.record_count == 3U, "memo-backed append_blank_record_to_file should grow the record count");
-
-    parse_result = copperfin::vfp::parse_dbf_table_from_file(table_path.string(), 5U);
-    expect(parse_result.ok, "memo-backed mutated tables should remain readable");
-    expect(parse_result.table.records.size() == 3U, "memo-backed tables should expose appended records");
-    if (parse_result.table.records.size() == 3U) {
-        expect(parse_result.table.records[0].values[1].display_value == "Updated first memo", "memo field replacements should persist through the shared DBF layer");
-        expect(parse_result.table.records[2].values[0].display_value.empty(), "blank appended character fields in memo-backed tables should start empty");
-        expect(parse_result.table.records[2].values[1].display_value.empty(), "blank appended memo fields should start with an empty pointer");
-        expect(parse_result.table.records[2].values[1].memo_block_number == 0U,
-               "#711: blank appended memo fields should expose memo block zero");
-    }
-
-    fs::remove_all(temp_dir, ignored);
-}
-
-void test_general_and_picture_memo_fields_round_trip() {
-    namespace fs = std::filesystem;
-    const fs::path temp_dir = fs::temp_directory_path() /
-        ("copperfin_dbf_table_gp_memo_tests_" + std::to_string(_getpid()));
-    std::error_code ignored;
-    fs::remove_all(temp_dir, ignored);
-    fs::create_directories(temp_dir);
-
-    const fs::path table_path = temp_dir / "assets.dbf";
-    const fs::path memo_path = temp_dir / "assets.fpt";
-    const std::vector<copperfin::vfp::DbfFieldDescriptor> fields{
-        {.name = "TITLE", .type = 'C', .length = 12U},
-        {.name = "GENERAL", .type = 'G', .length = 4U},
-        {.name = "PICTURE", .type = 'P', .length = 4U}
-    };
-    const std::vector<std::vector<std::string>> records{
-        {"FIRST", "General payload", "Picture payload"}
-    };
-
-    const auto create_result = copperfin::vfp::create_dbf_table_file(table_path.string(), fields, records);
-    expect(create_result.ok, "create_dbf_table_file should support G/P memo-pointer fields");
-    expect(fs::exists(memo_path), "G/P-backed table creation should also create the FPT sidecar");
-
-    auto parse_result = copperfin::vfp::parse_dbf_table_from_file(table_path.string(), 5U);
-    expect(parse_result.ok, "G/P-backed tables should remain readable after creation");
-    if (parse_result.ok && parse_result.table.records.size() == 1U && parse_result.table.records[0].values.size() >= 3U) {
-        expect(parse_result.table.records[0].values[1].display_value == "General payload", "created G fields should round-trip through memo sidecar storage");
-        expect(parse_result.table.records[0].values[2].display_value == "Picture payload", "created P fields should round-trip through memo sidecar storage");
-    }
-
-    const auto replace_general = copperfin::vfp::replace_record_field_value(table_path.string(), 0U, "GENERAL", "Updated general payload");
-    expect(replace_general.ok, "replace_record_field_value should support G fields");
-
-    const auto replace_picture = copperfin::vfp::replace_record_field_value(table_path.string(), 0U, "PICTURE", "Updated picture payload");
-    expect(replace_picture.ok, "replace_record_field_value should support P fields");
-
-    const auto append_result = copperfin::vfp::append_blank_record_to_file(table_path.string());
-    expect(append_result.ok, "append_blank_record_to_file should support G/P-backed tables");
-    expect(append_result.record_count == 2U, "G/P-backed append_blank_record_to_file should grow the record count");
-
-    parse_result = copperfin::vfp::parse_dbf_table_from_file(table_path.string(), 5U);
-    expect(parse_result.ok, "G/P-backed tables should remain readable after mutation");
-    expect(parse_result.table.records.size() == 2U, "G/P-backed tables should expose appended rows");
-    if (parse_result.table.records.size() == 2U) {
-        expect(parse_result.table.records[0].values[1].display_value == "Updated general payload", "G field replacements should persist");
-        expect(parse_result.table.records[0].values[2].display_value == "Updated picture payload", "P field replacements should persist");
-        expect(parse_result.table.records[1].values[1].display_value.empty(), "blank appended G fields should start with an empty pointer");
-        expect(parse_result.table.records[1].values[2].display_value.empty(), "blank appended P fields should start with an empty pointer");
-    }
 
     fs::remove_all(temp_dir, ignored);
 }
@@ -3129,8 +3026,8 @@ int main(int argc, char* argv[]) {
     test_create_dbf_table_file_rejects_duplicate_field_names();
     test_dbf_schema_writes_enforce_field_name_boundaries();
     test_record_field_updates_match_descriptor_names_case_insensitively();
-    test_memo_field_create_replace_and_append_round_trip();
-    test_general_and_picture_memo_fields_round_trip();
+    copperfin::test_dbf_table::test_memo_field_create_replace_and_append_round_trip();
+    copperfin::test_dbf_table::test_general_and_picture_memo_fields_round_trip();
     test_memo_payload_that_decodes_empty_stays_empty();
     test_pack_memo_preserves_payloads_that_decode_empty();
     test_pack_memo_preserves_binary_picture_payloads();

--- a/tests/test_dbf_table_memo_lifecycle.cpp
+++ b/tests/test_dbf_table_memo_lifecycle.cpp
@@ -1,0 +1,132 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "test_dbf_table_support.h"
+
+#include "copperfin/vfp/dbf_table.h"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#if defined(_WIN32)
+#include <process.h>
+#else
+#include <unistd.h>
+#define _getpid getpid
+#endif
+
+namespace copperfin::test_dbf_table {
+
+void test_memo_field_create_replace_and_append_round_trip() {
+    namespace fs = std::filesystem;
+    const fs::path temp_dir = fs::temp_directory_path() /
+        ("copperfin_dbf_table_memo_tests_" + std::to_string(_getpid()));
+    std::error_code ignored;
+    fs::remove_all(temp_dir, ignored);
+    fs::create_directories(temp_dir);
+
+    const fs::path table_path = temp_dir / "notes.dbf";
+    const fs::path memo_path = temp_dir / "notes.fpt";
+    const std::vector<copperfin::vfp::DbfFieldDescriptor> fields{
+        {.name = "TITLE", .type = 'C', .length = 12U},
+        {.name = "BODY", .type = 'M', .length = 4U}
+    };
+    const std::vector<std::vector<std::string>> records{
+        {"FIRST", "First memo body"},
+        {"SECOND", "Second memo body"}
+    };
+
+    const auto create_result = copperfin::vfp::create_dbf_table_file(table_path.string(), fields, records);
+    expect(create_result.ok, "create_dbf_table_file should support memo-backed schemas");
+    expect(fs::exists(memo_path), "memo-backed table creation should also create the FPT sidecar");
+
+    auto parse_result = copperfin::vfp::parse_dbf_table_from_file(table_path.string(), 5U);
+    expect(parse_result.ok, "memo-backed created tables should remain readable");
+    expect(parse_result.table.records.size() == 2U, "memo-backed created tables should persist record rows");
+    if (parse_result.table.records.size() == 2U) {
+        expect(parse_result.table.records[0].values[0].display_value == "FIRST", "memo-backed created character fields should persist");
+        expect(parse_result.table.records[0].values[1].display_value == "First memo body", "memo-backed created memo fields should round-trip through the sidecar");
+        expect(parse_result.table.records[0].values[1].memo_block_number != 0U,
+               "#711: created memo rows should retain non-zero memo block provenance");
+        expect(parse_result.table.records[1].values[1].display_value == "Second memo body", "later memo rows should also round-trip");
+        expect(parse_result.table.records[1].values[1].memo_block_number != 0U,
+               "#711: later created memo rows should retain non-zero memo block provenance");
+    }
+
+    const auto replace_result = copperfin::vfp::replace_record_field_value(table_path.string(), 0U, "BODY", "Updated first memo");
+    expect(replace_result.ok, "replace_record_field_value should support memo-backed fields");
+
+    const auto append_result = copperfin::vfp::append_blank_record_to_file(table_path.string());
+    expect(append_result.ok, "append_blank_record_to_file should support memo-backed tables");
+    expect(append_result.record_count == 3U, "memo-backed append_blank_record_to_file should grow the record count");
+
+    parse_result = copperfin::vfp::parse_dbf_table_from_file(table_path.string(), 5U);
+    expect(parse_result.ok, "memo-backed mutated tables should remain readable");
+    expect(parse_result.table.records.size() == 3U, "memo-backed tables should expose appended records");
+    if (parse_result.table.records.size() == 3U) {
+        expect(parse_result.table.records[0].values[1].display_value == "Updated first memo", "memo field replacements should persist through the shared DBF layer");
+        expect(parse_result.table.records[2].values[0].display_value.empty(), "blank appended character fields in memo-backed tables should start empty");
+        expect(parse_result.table.records[2].values[1].display_value.empty(), "blank appended memo fields should start with an empty pointer");
+        expect(parse_result.table.records[2].values[1].memo_block_number == 0U,
+               "#711: blank appended memo fields should expose memo block zero");
+    }
+
+    fs::remove_all(temp_dir, ignored);
+}
+
+void test_general_and_picture_memo_fields_round_trip() {
+    namespace fs = std::filesystem;
+    const fs::path temp_dir = fs::temp_directory_path() /
+        ("copperfin_dbf_table_gp_memo_tests_" + std::to_string(_getpid()));
+    std::error_code ignored;
+    fs::remove_all(temp_dir, ignored);
+    fs::create_directories(temp_dir);
+
+    const fs::path table_path = temp_dir / "assets.dbf";
+    const fs::path memo_path = temp_dir / "assets.fpt";
+    const std::vector<copperfin::vfp::DbfFieldDescriptor> fields{
+        {.name = "TITLE", .type = 'C', .length = 12U},
+        {.name = "GENERAL", .type = 'G', .length = 4U},
+        {.name = "PICTURE", .type = 'P', .length = 4U}
+    };
+    const std::vector<std::vector<std::string>> records{
+        {"FIRST", "General payload", "Picture payload"}
+    };
+
+    const auto create_result = copperfin::vfp::create_dbf_table_file(table_path.string(), fields, records);
+    expect(create_result.ok, "create_dbf_table_file should support G/P memo-pointer fields");
+    expect(fs::exists(memo_path), "G/P-backed table creation should also create the FPT sidecar");
+
+    auto parse_result = copperfin::vfp::parse_dbf_table_from_file(table_path.string(), 5U);
+    expect(parse_result.ok, "G/P-backed tables should remain readable after creation");
+    if (parse_result.ok && parse_result.table.records.size() == 1U && parse_result.table.records[0].values.size() >= 3U) {
+        expect(parse_result.table.records[0].values[1].display_value == "General payload", "created G fields should round-trip through memo sidecar storage");
+        expect(parse_result.table.records[0].values[2].display_value == "Picture payload", "created P fields should round-trip through memo sidecar storage");
+    }
+
+    const auto replace_general = copperfin::vfp::replace_record_field_value(table_path.string(), 0U, "GENERAL", "Updated general payload");
+    expect(replace_general.ok, "replace_record_field_value should support G fields");
+
+    const auto replace_picture = copperfin::vfp::replace_record_field_value(table_path.string(), 0U, "PICTURE", "Updated picture payload");
+    expect(replace_picture.ok, "replace_record_field_value should support P fields");
+
+    const auto append_result = copperfin::vfp::append_blank_record_to_file(table_path.string());
+    expect(append_result.ok, "append_blank_record_to_file should support G/P-backed tables");
+    expect(append_result.record_count == 2U, "G/P-backed append_blank_record_to_file should grow the record count");
+
+    parse_result = copperfin::vfp::parse_dbf_table_from_file(table_path.string(), 5U);
+    expect(parse_result.ok, "G/P-backed tables should remain readable after mutation");
+    expect(parse_result.table.records.size() == 2U, "G/P-backed tables should expose appended rows");
+    if (parse_result.table.records.size() == 2U) {
+        expect(parse_result.table.records[0].values[1].display_value == "Updated general payload", "G field replacements should persist");
+        expect(parse_result.table.records[0].values[2].display_value == "Updated picture payload", "P field replacements should persist");
+        expect(parse_result.table.records[1].values[1].display_value.empty(), "blank appended G fields should start with an empty pointer");
+        expect(parse_result.table.records[1].values[2].display_value.empty(), "blank appended P fields should start with an empty pointer");
+    }
+
+    fs::remove_all(temp_dir, ignored);
+}
+
+}  // namespace copperfin::test_dbf_table

--- a/tests/test_dbf_table_support.h
+++ b/tests/test_dbf_table_support.h
@@ -1,0 +1,18 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#pragma once
+
+#include <string>
+
+namespace copperfin::test_dbf_table {
+
+extern int failures;
+
+void expect(bool condition, const std::string& message);
+
+void test_memo_field_create_replace_and_append_round_trip();
+void test_general_and_picture_memo_fields_round_trip();
+
+}  // namespace copperfin::test_dbf_table


### PR DESCRIPTION
Resolves #5152.\n\nTest-only #2564 slice. Moves only the basic M-field and G/P-field create, replace, and append regressions into test_dbf_table_memo_lifecycle.cpp, retaining the existing test_dbf_table executable and invocation order. A minimal support header exposes the existing failure reporter and the two moved declarations.\n\nThe moved bodies match the prior source range byte-for-byte. Raw-payload, PACK MEMO, corrupt-sidecar, additive replacement, and schema-rewrite regressions remain separately scoped under #5151.\n\nValidation:\n- Debug build: test_dbf_table\n- CTest: test_dbf_table 1/1 passed\n- git diff --check passed