### PR TITLE
CI: select Python for generated launcher validation

### DIFF
--- a/.github/workflows/generated-launcher-validation.yml
+++ b/.github/workflows/generated-launcher-validation.yml
@@ -86,6 +86,11 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Setup Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
       - name: Setup R 4.6.1
         uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2
         with:
@@ -125,6 +130,11 @@ jobs:
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
         with:
           dotnet-version: 10.0.x
+
+      - name: Setup Python 3.13
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
 
       - name: Setup R 4.6.1
         uses: r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6 # v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 2026-08-23: Provision an explicit Python 3.13 interpreter for generated-launcher
+  sidecar validation on Windows, Linux, and macOS instead of relying on each
+  hosted runner image's mutable default interpreter.
+
 - 2026-08-23: Continued #2564 test-module refactoring by moving report/label
   layout-object LEFT preview-bounds regressions into
   `test_studio_host_json_geometry_preview_object_lefts.cpp`. The existing

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,13 @@
 # Agent Handoff
 
+## Generated-launcher Python sidecar validation environment
+
+The generated-launcher validation workflow now uses a SHA-pinned setup action
+to provision Python 3.13 on Windows, Linux, and macOS. This removes
+dependence on a mutable runner-image Python default after a Windows-only Python
+sidecar failure; the source/protocol behavior stays unchanged. The next action
+is to inspect the hosted Windows result on the exact workflow head.
+
 ## V1 report layout-object LEFT preview-bounds test module
 
 The bounded #2564 structural slice moves the report/label layout-object LEFT

--- a/tests/run_github_actions_contract_check.cmake
+++ b/tests/run_github_actions_contract_check.cmake
@@ -167,6 +167,8 @@ foreach(required_text IN ITEMS
         "tests/test_prg_engine_file_io_functions.cpp"
         "tests/test_prg_engine_verified_dbf_security.cpp"
         "r-lib/actions/setup-r@d3c5be51b12e724e68f33216ca3c148b66d5f0b6"
+        "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405"
+        "python-version: \"3.13\""
         "r-version: \"4.6.1\""
         "rtools-version: \"none\""
         "use-public-rspm: \"false\""


### PR DESCRIPTION
## Summary

- provision Python 3.13 explicitly in the generated-launcher Windows and POSIX jobs
- retain SHA-pinned third-party action provenance and extend the workflow contract
- record that this is a hosted-environment correction, not a sidecar protocol change

## Evidence

- `test_github_actions_contract` passed
- `test_polyglot_python_sidecar` passed from a fresh Debug build
- the hosted Windows job on this exact head is the required regression confirmation

The prior failure was Windows-only and limited to the Python sidecar; Linux and macOS completed the same test successfully.