### PR TITLE
test: split visual blank property regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 - 2026-08-24: Continued #2564 test-module refactoring by moving the visual
-  asset method-list regression into `test_visual_asset_editor_method_listing.cpp`.
-  The existing `test_visual_asset_editor` executable, fixture bytes,
-  assertions, and invocation order remain unchanged.
+  asset blank-property-value preservation regression into
+  `test_visual_asset_editor_property_blank_value.cpp`. The existing
+  `test_visual_asset_editor` executable, fixture bytes, assertions, and
+  invocation order remain unchanged.
 
 - 2026-08-24: Continued #2564 test-module refactoring by extracting the shared
   VFP-asset test support (locale guard, localized validation lookup, and

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,12 +1,12 @@
 # Agent Handoff
 
-## V1 visual-asset method-list test module
+## V1 visual-asset blank-property test module
 
-The bounded #2564 structural slice moves the selected-object method-list
-regression into `test_visual_asset_editor_method_listing.cpp`. The existing
-`test_visual_asset_editor` executable retains its fixture bytes, assertions,
-and invocation order. A fresh Debug build and focused CTest pass 1/1; protected
-cross-platform validation remains required before merge.
+The bounded #2564 structural slice moves the blank-property-value preservation
+regression into `test_visual_asset_editor_property_blank_value.cpp`. The
+existing `test_visual_asset_editor` executable retains its fixture bytes,
+ assertions, and invocation order. A fresh Debug build and focused CTest pass
+ 1/1; protected cross-platform validation remains required before merge.
 
 ## V1 VFP-asset test support
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4643,6 +4643,7 @@ copperfin_add_test(test_visual_asset_editor cf_vfp_assets
     test_visual_asset_editor_object_lifecycle_identity_01.cpp
     test_visual_asset_editor_object_lifecycle_identity_02.cpp
     test_visual_asset_editor_method_listing.cpp
+    test_visual_asset_editor_property_blank_value.cpp
     test_visual_asset_editor_methods.cpp
     test_visual_asset_editor_properties.cpp
     test_visual_asset_editor_report_printer_settings.cpp

--- a/tests/test_visual_asset_editor_properties.cpp
+++ b/tests/test_visual_asset_editor_properties.cpp
@@ -5,52 +5,6 @@
 #include "test_visual_asset_editor_support.h"
 
 namespace cf_test_visual_asset_editor {
-void test_update_visual_object_property_preserves_equals_for_blank_property_values() {
-    namespace fs = std::filesystem;
-    const fs::path temp_dir = fs::temp_directory_path() /
-        ("copperfin_visual_editor_blank_equals_tests_" + std::to_string(_getpid()));
-    std::error_code ignored;
-    fs::remove_all(temp_dir, ignored);
-    fs::create_directories(temp_dir);
-
-    const fs::path table_path = temp_dir / "blank_equals.scx";
-    const std::vector<copperfin::vfp::DbfFieldDescriptor> fields{
-        {.name = "OBJNAME", .type = 'C', .length = 20U},
-        {.name = "UNIQUEID", .type = 'C', .length = 20U},
-        {.name = "PROPERTIES", .type = 'M', .length = 4U}
-    };
-    const std::vector<std::vector<std::string>> records{
-        {"txtBox", "blank-guid", "Caption = \"Hello\"\r\nFormat = \r\n"}
-    };
-    const auto create_result = copperfin::vfp::create_dbf_table_file(table_path.string(), fields, records);
-    expect(create_result.ok, "blank-value property fixture should be writable");
-
-    const auto update_result = copperfin::vfp::update_visual_object_property({
-        .path = table_path.string(),
-        .record_index = 0U,
-        .object_name = {},
-        .unique_id = "blank-guid",
-        .property_name = "Caption",
-        .property_value = "\"World\""
-    });
-    expect(update_result.ok, "updating an unrelated property should succeed");
-
-    const auto parse_result = copperfin::vfp::parse_dbf_table_from_file(table_path.string(), 1U);
-    expect(parse_result.ok && parse_result.table.records.size() == 1U,
-        "updated blank-equals fixture should remain readable");
-    if (parse_result.ok && parse_result.table.records.size() == 1U) {
-        const auto* properties = find_record_field(parse_result.table.records[0], "PROPERTIES");
-        expect(properties != nullptr, "updated record should retain the PROPERTIES field");
-        if (properties != nullptr) {
-            expect(properties->display_value.find("Format =") != std::string::npos,
-                "re-serializing the PROPERTIES blob should not drop the '=' for properties with a blank value "
-                "(matching the sibling report-settings serializer, which always preserves it)");
-        }
-    }
-
-    fs::remove_all(temp_dir, ignored);
-}
-
 void test_update_visual_object_report_settings_property_preserves_comment_lines() {
     namespace fs = std::filesystem;
     const fs::path temp_dir = fs::temp_directory_path() /

--- a/tests/test_visual_asset_editor_property_blank_value.cpp
+++ b/tests/test_visual_asset_editor_property_blank_value.cpp
@@ -1,0 +1,51 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "test_visual_asset_editor_support.h"
+
+namespace cf_test_visual_asset_editor {
+
+void test_update_visual_object_property_preserves_equals_for_blank_property_values() {
+    namespace fs = std::filesystem;
+    const fs::path temp_dir = fs::temp_directory_path() /
+        ("copperfin_visual_editor_blank_equals_tests_" + std::to_string(_getpid()));
+    std::error_code ignored;
+    fs::remove_all(temp_dir, ignored);
+    fs::create_directories(temp_dir);
+
+    const fs::path table_path = temp_dir / "blank_equals.scx";
+    const std::vector<copperfin::vfp::DbfFieldDescriptor> fields{
+        {.name = "OBJNAME", .type = 'C', .length = 20U},
+        {.name = "UNIQUEID", .type = 'C', .length = 20U},
+        {.name = "PROPERTIES", .type = 'M', .length = 4U}
+    };
+    const std::vector<std::vector<std::string>> records{
+        {"txtBox", "blank-guid", "Caption = \"Hello\"\r\nFormat = \r\n"}
+    };
+    const auto create_result = copperfin::vfp::create_dbf_table_file(table_path.string(), fields, records);
+    expect(create_result.ok, "blank-value property fixture should be writable");
+
+    const auto update_result = copperfin::vfp::update_visual_object_property({
+        .path = table_path.string(), .record_index = 0U, .object_name = {}, .unique_id = "blank-guid",
+        .property_name = "Caption", .property_value = "\"World\""
+    });
+    expect(update_result.ok, "updating an unrelated property should succeed");
+
+    const auto parse_result = copperfin::vfp::parse_dbf_table_from_file(table_path.string(), 1U);
+    expect(parse_result.ok && parse_result.table.records.size() == 1U,
+        "updated blank-equals fixture should remain readable");
+    if (parse_result.ok && parse_result.table.records.size() == 1U) {
+        const auto* properties = find_record_field(parse_result.table.records[0], "PROPERTIES");
+        expect(properties != nullptr, "updated record should retain the PROPERTIES field");
+        if (properties != nullptr) {
+            expect(properties->display_value.find("Format =") != std::string::npos,
+                "re-serializing the PROPERTIES blob should not drop the '=' for properties with a blank value "
+                "(matching the sibling report-settings serializer, which always preserves it)");
+        }
+    }
+
+    fs::remove_all(temp_dir, ignored);
+}
+
+}  // namespace cf_test_visual_asset_editor


### PR DESCRIPTION
## Summary\n- move the blank-property-value preservation regression into its own test module\n- retain the existing test executable, fixture bytes, assertions, and invocation order\n- record the #2564 structural-slice evidence\n\n## Verification\n- -- Configuring done (0.4s)
-- Generating done (0.6s)
-- Build files have been written to: /tmp/copperfin-v1-visual-property-blank-build\n- [ 40%] Built target cf_platform_support
[ 40%] Built target cf_localization
[ 60%] Built target cf_vfp_assets
[100%] Built target test_visual_asset_editor\n- Test project /tmp/copperfin-v1-visual-property-blank-build
    Start 265: test_visual_asset_editor
1/1 Test #265: test_visual_asset_editor .........   Passed   17.13 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
copperfin-isolation:audit=complete              =  17.13 sec*proc (1 test)
copperfin-isolation:child-processes=none        =  17.13 sec*proc (1 test)
copperfin-isolation:environment=none            =  17.13 sec*proc (1 test)
copperfin-isolation:filesystem=process-owned    =  17.13 sec*proc (1 test)
copperfin-isolation:network=none                =  17.13 sec*proc (1 test)
copperfin-isolation:platform=portable           =  17.13 sec*proc (1 test)
copperfin-isolation:resources=none              =  17.13 sec*proc (1 test)
copperfin-isolation:samples=none                =  17.13 sec*proc (1 test)
copperfin-isolation:schedule=parallel-safe      =  17.13 sec*proc (1 test)

Total Test time (real) =  17.14 sec