### PR TITLE
test: split visual property comment regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 2026-08-24: Continued #2564 test-module refactoring by moving the report-settings
+  comment-line preservation regression into
+  `test_visual_asset_editor_property_comment_lines.cpp`. The existing
+  `test_visual_asset_editor` executable, fixture bytes, assertions, invocation
+  order, and visual-asset behavior remain unchanged.
+
 - 2026-08-24: Continued #2564 test-module refactoring by moving the visual
   asset blank-property-value preservation regression into
   `test_visual_asset_editor_property_blank_value.cpp`. The existing

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,13 @@
 # Agent Handoff
 
+## V1 visual-asset property comment-line test module
+
+The bounded #2564 structural slice moves the report-settings comment-line
+preservation regression into `test_visual_asset_editor_property_comment_lines.cpp`.
+The existing `test_visual_asset_editor` executable retains the same fixture
+bytes, assertions, invocation order, and visual-asset behavior. A fresh Debug
+build and focused CTest must pass before protected cross-platform validation.
+
 ## V1 visual-asset blank-property test module
 
 The bounded #2564 structural slice moves the blank-property-value preservation

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4644,6 +4644,7 @@ copperfin_add_test(test_visual_asset_editor cf_vfp_assets
     test_visual_asset_editor_object_lifecycle_identity_02.cpp
     test_visual_asset_editor_method_listing.cpp
     test_visual_asset_editor_property_blank_value.cpp
+    test_visual_asset_editor_property_comment_lines.cpp
     test_visual_asset_editor_methods.cpp
     test_visual_asset_editor_properties.cpp
     test_visual_asset_editor_report_printer_settings.cpp

--- a/tests/test_visual_asset_editor_properties.cpp
+++ b/tests/test_visual_asset_editor_properties.cpp
@@ -5,56 +5,6 @@
 #include "test_visual_asset_editor_support.h"
 
 namespace cf_test_visual_asset_editor {
-void test_update_visual_object_report_settings_property_preserves_comment_lines() {
-    namespace fs = std::filesystem;
-    const fs::path temp_dir = fs::temp_directory_path() /
-        ("copperfin_visual_editor_settings_comment_tests_" + std::to_string(_getpid()));
-    std::error_code ignored;
-    fs::remove_all(temp_dir, ignored);
-    fs::create_directories(temp_dir);
-
-    const fs::path report_path = temp_dir / "settings_comment.frx";
-    const std::vector<copperfin::vfp::DbfFieldDescriptor> fields{
-        {.name = "OBJTYPE", .type = 'N', .length = 8U},
-        {.name = "OBJCODE", .type = 'N', .length = 8U},
-        {.name = "EXPR", .type = 'M', .length = 4U},
-        {.name = "UNIQUEID", .type = 'C', .length = 40U}
-    };
-    const std::vector<std::vector<std::string>> records{
-        {"1", "53", "* Header = comment text\r\nORIENTATION=1", ""}
-    };
-    const auto create_result = copperfin::vfp::create_dbf_table_file(report_path.string(), fields, records);
-    expect(create_result.ok, "report-settings comment-line fixture should be writable");
-
-    const auto update_result = copperfin::vfp::update_visual_object_property({
-        .path = report_path.string(),
-        .record_index = 0U,
-        .object_name = {},
-        .unique_id = {},
-        .property_name = "ORIENTATION",
-        .property_value = "2"
-    });
-    expect(update_result.ok, "updating the real ORIENTATION setting should succeed");
-
-    const auto parse_result = copperfin::vfp::parse_dbf_table_from_file(report_path.string(), 1U);
-    expect(parse_result.ok && parse_result.table.records.size() == 1U,
-        "updated report-settings comment-line fixture should remain readable");
-    if (parse_result.ok && parse_result.table.records.size() == 1U) {
-        const auto* expr = find_record_field(parse_result.table.records[0], "EXPR");
-        expect(expr != nullptr, "updated record should retain the EXPR field");
-        if (expr != nullptr) {
-            expect(expr->display_value.find("* Header = comment text") != std::string::npos,
-                "a settings comment line containing '=' with non-empty trailing text must survive re-serialization "
-                "verbatim, not be misclassified as a real property assignment (its name starts with '*', the VFP "
-                "comment marker) and reformatted as \"* Header=comment text\"");
-            expect(expr->display_value.find("ORIENTATION=2") != std::string::npos,
-                "the real ORIENTATION assignment should be updated to the new value");
-        }
-    }
-
-    fs::remove_all(temp_dir, ignored);
-}
-
 void test_report_settings_bottom_margin_memo_round_trips() {
     namespace fs = std::filesystem;
     const fs::path temp_dir = fs::temp_directory_path() /

--- a/tests/test_visual_asset_editor_property_comment_lines.cpp
+++ b/tests/test_visual_asset_editor_property_comment_lines.cpp
@@ -1,0 +1,53 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "test_visual_asset_editor_support.h"
+
+namespace cf_test_visual_asset_editor {
+void test_update_visual_object_report_settings_property_preserves_comment_lines() {
+    namespace fs = std::filesystem;
+    const fs::path temp_dir = fs::temp_directory_path() /
+        ("copperfin_visual_editor_settings_comment_tests_" + std::to_string(_getpid()));
+    std::error_code ignored;
+    fs::remove_all(temp_dir, ignored);
+    fs::create_directories(temp_dir);
+
+    const fs::path report_path = temp_dir / "settings_comment.frx";
+    const std::vector<copperfin::vfp::DbfFieldDescriptor> fields{
+        {.name = "OBJTYPE", .type = 'N', .length = 8U},
+        {.name = "OBJCODE", .type = 'N', .length = 8U},
+        {.name = "EXPR", .type = 'M', .length = 4U},
+        {.name = "UNIQUEID", .type = 'C', .length = 40U}
+    };
+    const std::vector<std::vector<std::string>> records{
+        {"1", "53", "* Header = comment text\r\nORIENTATION=1", ""}
+    };
+    const auto create_result = copperfin::vfp::create_dbf_table_file(report_path.string(), fields, records);
+    expect(create_result.ok, "report-settings comment-line fixture should be writable");
+
+    const auto update_result = copperfin::vfp::update_visual_object_property({
+        .path = report_path.string(), .record_index = 0U, .object_name = {}, .unique_id = {},
+        .property_name = "ORIENTATION", .property_value = "2"
+    });
+    expect(update_result.ok, "updating the real ORIENTATION setting should succeed");
+
+    const auto parse_result = copperfin::vfp::parse_dbf_table_from_file(report_path.string(), 1U);
+    expect(parse_result.ok && parse_result.table.records.size() == 1U,
+        "updated report-settings comment-line fixture should remain readable");
+    if (parse_result.ok && parse_result.table.records.size() == 1U) {
+        const auto* expr = find_record_field(parse_result.table.records[0], "EXPR");
+        expect(expr != nullptr, "updated record should retain the EXPR field");
+        if (expr != nullptr) {
+            expect(expr->display_value.find("* Header = comment text") != std::string::npos,
+                "a settings comment line containing '=' with non-empty trailing text must survive re-serialization "
+                "verbatim, not be misclassified as a real property assignment (its name starts with '*', the VFP "
+                "comment marker) and reformatted as \"* Header=comment text\"");
+            expect(expr->display_value.find("ORIENTATION=2") != std::string::npos,
+                "the real ORIENTATION assignment should be updated to the new value");
+        }
+    }
+
+    fs::remove_all(temp_dir, ignored);
+}
+}  // namespace cf_test_visual_asset_editor


### PR DESCRIPTION
## Summary\n- extract the report-settings comment-line preservation regression from the oversized visual-property test module\n- retain the existing test executable, fixture bytes, assertions, and invocation order\n- document the bounded #2564 structural slice\n\n## Validation\n- -- Configuring done (0.4s)
-- Generating done (0.6s)
-- Build files have been written to: /tmp/copperfin-v1-visual-property-comment-build\n- [ 40%] Built target cf_platform_support
[ 40%] Built target cf_localization
[ 60%] Built target cf_vfp_assets
[100%] Built target test_visual_asset_editor\n- Test project /tmp/copperfin-v1-visual-property-comment-build
    Start 265: test_visual_asset_editor
1/1 Test #265: test_visual_asset_editor .........   Passed   16.96 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
copperfin-isolation:audit=complete              =  16.96 sec*proc (1 test)
copperfin-isolation:child-processes=none        =  16.96 sec*proc (1 test)
copperfin-isolation:environment=none            =  16.96 sec*proc (1 test)
copperfin-isolation:filesystem=process-owned    =  16.96 sec*proc (1 test)
copperfin-isolation:network=none                =  16.96 sec*proc (1 test)
copperfin-isolation:platform=portable           =  16.96 sec*proc (1 test)
copperfin-isolation:resources=none              =  16.96 sec*proc (1 test)
copperfin-isolation:samples=none                =  16.96 sec*proc (1 test)
copperfin-isolation:schedule=parallel-safe      =  16.96 sec*proc (1 test)

Total Test time (real) =  16.97 sec\n- 