### PR TITLE
Fix out-of-tree Studio locale discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 2026-08-24: Made out-of-tree locale staging remove its generated locale tree
+  before copying. A deleted or renamed source catalog can no longer remain
+  accidentally discoverable from an earlier configure.
+
 - 2026-08-24: Localization slice `#2348` made out-of-tree developer builds carry
   a refreshed locale-resource snapshot beside their executables. Catalog
   discovery now recognizes that executable-relative layout, so Studio's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+- 2026-08-24: Localization slice `#2348` made out-of-tree developer builds carry
+  a refreshed locale-resource snapshot beside their executables. Catalog
+  discovery now recognizes that executable-relative layout, so Studio's
+  internal visual-editor diagnostics retain the selected locale when invoked
+  from an arbitrary working directory; explicit `COPPERFIN_LOCALE_DIR`
+  overrides and installed layouts remain authoritative.
+
 - 2026-08-24: Continued #2564 test-module refactoring by moving the paired
   FRX/LBX `BOTMARGIN` memo round-trip regression into
   `test_visual_asset_editor_report_settings_bottom_margin.cpp`. The existing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -845,6 +845,17 @@ install(DIRECTORY resources/locales/
     DESTINATION share/copperfin/locales
 )
 
+# Make an out-of-tree developer build runnable from an arbitrary working
+# directory, matching the executable-relative resource layout used by the
+# installed hosts. Catalog inputs participate in CMake's reconfigure check so
+# edits are reflected by the next normal build.
+file(GLOB_RECURSE COPPERFIN_BUILD_TREE_LOCALE_CATALOGS CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/resources/locales/*")
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+    ${COPPERFIN_BUILD_TREE_LOCALE_CATALOGS})
+file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/resources/locales"
+    DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/resources")
+
 # Traceability: RQ-CF-REL-002; DQ-windows-installer-lifecycle-scope;
 # DV-windows-installer-lifecycle-contract; HZ-system-failure-01;
 # HZ-data-corruption-01; HZ-doc-command-01.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -853,6 +853,10 @@ file(GLOB_RECURSE COPPERFIN_BUILD_TREE_LOCALE_CATALOGS CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/resources/locales/*")
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
     ${COPPERFIN_BUILD_TREE_LOCALE_CATALOGS})
+# COPY is additive, so clear only this generated staging subtree before each
+# configure-time copy. This prevents a deleted or renamed source catalog from
+# remaining discoverable beside the out-of-tree executables.
+file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/resources/locales")
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/resources/locales"
     DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/resources")
 

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,13 @@
 # Agent Handoff
 
+## V1 out-of-tree locale staging cleanup
+
+The developer-build locale staging rule now removes only its generated
+`resources/locales` subtree before copying source catalogs. This keeps the
+executable-relative catalog lookup from seeing a catalog that was deleted or
+renamed in the source tree. Verify with an out-of-tree configure after placing
+a stale file below that generated subtree; the file must be absent afterward.
+
 ## V1 out-of-tree Studio locale discovery
 
 The #2348 localization slice stages `resources/locales` under an out-of-tree

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,16 @@
 # Agent Handoff
 
+## V1 out-of-tree Studio locale discovery
+
+The #2348 localization slice stages `resources/locales` under an out-of-tree
+build's `resources/` directory and recognizes that directory beside a host
+executable. This keeps default visual-editor diagnostics localized when Studio
+is invoked from an arbitrary working directory without a locale-root override.
+Explicit `COPPERFIN_LOCALE_DIR` overrides and installed layouts retain their
+existing precedence; JSON keys, command tokens, statuses, and exit codes remain
+invariant. Fresh Debug `test_localization` and `test_studio_host_json` pass;
+cross-platform hosted validation remains required before merge.
+
 ## V1 visual-asset BOTMARGIN memo test module
 
 The bounded #2564 structural slice moves the paired FRX/LBX `BOTMARGIN` memo

--- a/src/localization/localization.cpp
+++ b/src/localization/localization.cpp
@@ -559,6 +559,7 @@ std::filesystem::path resolve_catalog_root(const std::filesystem::path& executab
         const std::vector<std::filesystem::path> candidates{
             executable_root / ".." / "share" / "copperfin" / "locales",
             executable_root / "share" / "copperfin" / "locales",
+            executable_root / "resources" / "locales",
             executable_root / ".." / "resources" / "locales",
             executable_root / ".." / ".." / "resources" / "locales"
         };

--- a/tests/test_localization_catalog.cpp
+++ b/tests/test_localization_catalog.cpp
@@ -636,6 +636,36 @@ void test_catalog_root_resolution_finds_repo_build_output_layout_from_executable
     fs::remove_all(temp_root, ignored);
 }
 
+void test_catalog_root_resolution_finds_bundled_build_tree_layout_from_executable_path() {
+    namespace fs = std::filesystem;
+    ScopedEnvironmentValue locale_dir("COPPERFIN_LOCALE_DIR");
+    const fs::path temp_root =
+        fs::temp_directory_path() / "copperfin_localization_bundled_build_tree_catalog_tests";
+    std::error_code ignored;
+    fs::remove_all(temp_root, ignored);
+
+    const fs::path executable_path = temp_root / "build" / "copperfin_studio_host";
+    fs::create_directories(executable_path.parent_path());
+    write_text(executable_path, "");
+    seed_test_catalogs(executable_path.parent_path() / "resources" / "locales");
+
+    const fs::path working_directory = temp_root / "independent-working-directory";
+    fs::create_directories(working_directory);
+    fs::path resolved_root;
+    {
+        ScopedCurrentPath current_path(working_directory);
+        resolved_root = copperfin::localization::resolve_catalog_root(executable_path);
+    }
+    const auto catalog = copperfin::localization::load_catalogs(resolved_root, "en-US");
+
+    expect(
+        fs::equivalent(resolved_root, executable_path.parent_path() / "resources" / "locales") &&
+            catalog.translate("Command.Inspect") == "Inspect",
+        "#2348: catalog root resolution should find bundled locales beside an out-of-tree build executable");
+
+    fs::remove_all(temp_root, ignored);
+}
+
 void test_catalog_root_resolution_finds_repo_build_output_layout_from_path_launched_basename() {
     namespace fs = std::filesystem;
     ScopedEnvironmentValue locale_dir("COPPERFIN_LOCALE_DIR");

--- a/tests/test_localization_main.cpp
+++ b/tests/test_localization_main.cpp
@@ -20,6 +20,7 @@ void test_catalog_root_auto_discovery_preserves_executable_candidate_precedence(
 void test_catalog_root_explicit_override_remains_authoritative();
 void test_catalog_root_resolution_searches_parent_directories();
 void test_catalog_root_resolution_finds_repo_build_output_layout_from_executable_path();
+void test_catalog_root_resolution_finds_bundled_build_tree_layout_from_executable_path();
 void test_catalog_root_resolution_finds_repo_build_output_layout_from_path_launched_basename();
 void test_parser_behavior_remains_locale_invariant();
 void test_runtime_session_diagnostics_route_through_catalog();
@@ -85,6 +86,7 @@ int main(int argc, char** argv) {
     test_catalog_root_explicit_override_remains_authoritative();
     test_catalog_root_resolution_searches_parent_directories();
     test_catalog_root_resolution_finds_repo_build_output_layout_from_executable_path();
+    test_catalog_root_resolution_finds_bundled_build_tree_layout_from_executable_path();
     test_catalog_root_resolution_finds_repo_build_output_layout_from_path_launched_basename();
     test_parser_behavior_remains_locale_invariant();
     test_runtime_session_diagnostics_route_through_catalog();


### PR DESCRIPTION
## Summary
- stage source locale catalogs under an out-of-tree build's executable directory
- discover that executable-relative layout before working-directory fallbacks
- cover the layout directly and restore Studio host pseudo-localization from arbitrary working directories

## Verification
- `cmake -S . -B /tmp/copperfin-v1-studio-internal-locale-build -DCMAKE_BUILD_TYPE=Debug`
- `ctest --test-dir /tmp/copperfin-v1-studio-internal-locale-build -R "^test_localization$" --output-on-failure -j1`
- `ctest --test-dir /tmp/copperfin-v1-studio-internal-locale-build -R "^test_studio_host_json$" --output-on-failure -j1`
- direct qps-ploc Studio-host smoke from `/tmp` with `COPPERFIN_LOCALE_DIR` absent

## Traceability
- #2348; preserves machine-readable JSON keys, statuses, command tokens, and exit codes.