### PR TITLE
Add bounded runtime external-event token queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+- 2026-08-24: Added the internal bounded external-event token queue required
+  by the Windows `EVENTHANDLER()` COM adapter. Host callbacks can now hand off
+  only normalized event tokens for later runtime-thread consumption; this does
+  not add COM dispatch or a PRG-visible interface.
+
 - 2026-08-24: Continued #2564 source-modularity work by extracting the
   platform-specific native-wrapper configure/build process runner into
   `runtime_pipeline_native_wrapper_process.cpp`. Wrapper command-line,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -540,6 +540,7 @@ add_library(cf_runtime_text
 )
 
 add_library(cf_xbase_runtime
+    src/runtime/runtime_external_event_queue.cpp
     src/runtime/prg_engine_command_helpers.cpp
     src/runtime/prg_engine_date_time_functions.cpp
     src/runtime/prg_engine_file_io_functions.cpp

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,15 @@
 # Agent Handoff
 
+## V1 external event-token queue
+
+Issue #5186 adds `runtime_external_event_queue.{h,cpp}`, an internal,
+thread-safe FIFO for normalized, bounded host event tokens. It rejects empty,
+malformed, overlong, and over-capacity input without partial mutation and
+exposes no mutable runtime session state. This is only the portable handoff
+primitive for the Windows `EVENTHANDLER()` adapter in #5185; it does not
+subscribe to COM, dispatch a handler, or change any PRG/JSON contract. Fresh
+Debug CTest `test_runtime_external_event_queue` passes 1/1.
+
 ## V1 native-wrapper process module
 
 The bounded #2564 source-modularity slice moves the platform-specific native

--- a/src/runtime/runtime_external_event_queue.cpp
+++ b/src/runtime/runtime_external_event_queue.cpp
@@ -1,0 +1,59 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "runtime_external_event_queue.h"
+
+#include <cctype>
+#include <utility>
+
+namespace copperfin::runtime::detail {
+
+bool ExternalEventTokenQueue::try_push(std::string token) {
+    if (!is_valid_token(token)) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (tokens_.size() >= kMaximumTokenCount) {
+        return false;
+    }
+    tokens_.push_back(std::move(token));
+    return true;
+}
+
+std::vector<std::string> ExternalEventTokenQueue::drain() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::string> drained;
+    drained.reserve(tokens_.size());
+    while (!tokens_.empty()) {
+        drained.push_back(std::move(tokens_.front()));
+        tokens_.pop_front();
+    }
+    return drained;
+}
+
+void ExternalEventTokenQueue::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    tokens_.clear();
+}
+
+std::size_t ExternalEventTokenQueue::size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return tokens_.size();
+}
+
+bool ExternalEventTokenQueue::is_valid_token(const std::string& token) {
+    if (token.empty() || token.size() > kMaximumTokenLength) {
+        return false;
+    }
+    for (const unsigned char character : token) {
+        if (!(std::isalnum(character) != 0 || character == '_' || character == '.' ||
+              character == ':' || character == '-')) {
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace copperfin::runtime::detail

--- a/src/runtime/runtime_external_event_queue.h
+++ b/src/runtime/runtime_external_event_queue.h
@@ -1,0 +1,35 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace copperfin::runtime::detail {
+
+// A host callback may place only a normalized event name in this queue.  The
+// runtime later consumes the names on its own execution thread; no callback is
+// granted access to mutable session state.
+class ExternalEventTokenQueue {
+public:
+    static constexpr std::size_t kMaximumTokenCount = 64U;
+    static constexpr std::size_t kMaximumTokenLength = 128U;
+
+    [[nodiscard]] bool try_push(std::string token);
+    [[nodiscard]] std::vector<std::string> drain();
+    void clear();
+    [[nodiscard]] std::size_t size() const;
+
+private:
+    static bool is_valid_token(const std::string& token);
+
+    mutable std::mutex mutex_;
+    std::deque<std::string> tokens_;
+};
+
+}  // namespace copperfin::runtime::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4893,6 +4893,10 @@ copperfin_add_test(test_bounded_process cf_platform_profile
     test_bounded_process.cpp
 )
 
+copperfin_add_test(test_runtime_external_event_queue cf_xbase_runtime
+    test_runtime_external_event_queue.cpp
+)
+
 copperfin_add_test(test_polyglot_parity_comparator cf_platform_profile
     test_polyglot_parity_comparator.cpp
 )

--- a/tests/test_runtime_external_event_queue.cpp
+++ b/tests/test_runtime_external_event_queue.cpp
@@ -1,0 +1,49 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "../src/runtime/runtime_external_event_queue.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace {
+
+void expect(const bool condition, const char* const message) {
+    if (!condition) {
+        std::cerr << "FAIL: " << message << '\n';
+        std::exit(1);
+    }
+}
+
+}  // namespace
+
+int main() {
+    using copperfin::runtime::detail::ExternalEventTokenQueue;
+
+    ExternalEventTokenQueue queue;
+    expect(!queue.try_push(""), "empty tokens must fail closed");
+    expect(!queue.try_push("event name"), "un-normalized tokens must fail closed");
+    expect(!queue.try_push("event\nname"), "control characters must fail closed");
+    expect(queue.size() == 0U, "rejected tokens must not mutate the queue");
+
+    expect(queue.try_push("Source.Interface.EventA"), "first normalized token should enqueue");
+    expect(queue.try_push("Source.Interface.EventB"), "second normalized token should enqueue");
+    const auto drained = queue.drain();
+    expect(drained.size() == 2U, "drain should preserve accepted token count");
+    expect(drained[0] == "Source.Interface.EventA" &&
+               drained[1] == "Source.Interface.EventB",
+           "drain must preserve FIFO order");
+    expect(queue.size() == 0U, "drain must empty the queue");
+
+    for (std::size_t index = 0U; index < ExternalEventTokenQueue::kMaximumTokenCount; ++index) {
+        expect(queue.try_push("Event" + std::to_string(index)), "capacity boundary token should enqueue");
+    }
+    expect(!queue.try_push("Overflow"), "over-capacity tokens must fail closed");
+    expect(queue.size() == ExternalEventTokenQueue::kMaximumTokenCount,
+           "over-capacity rejection must not mutate the queue");
+    queue.clear();
+    expect(queue.size() == 0U, "clear should discard queued tokens");
+    return 0;
+}


### PR DESCRIPTION
Implements #5186, the portable internal handoff prerequisite for the Windows-owned EVENTHANDLER adapter (#5185).

- Bounded, synchronized FIFO for normalized event tokens only.
- Fail-closed rejection for empty, malformed, overlong, and over-capacity tokens.
- Focused regression covers rejection non-mutation, FIFO drain, capacity, and clear behavior.

No COM pointer, subscription, handler dispatch, payload marshaling, or PRG/JSON contract is added.

Evidence: direct GCC C++20 compile/run passed; fresh Debug CMake CTest test_runtime_external_event_queue passed 1/1; git diff --check passed.