### PR TITLE
Test concurrent external event queue delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@
   fault cleanup. Hosted Windows execution remains required before the
   recovered requirement can be marked complete.
 
+- 2026-08-24: Added a deterministic concurrent-producer/runtime-consumer
+  regression for the internal `EVENTHANDLER()` external-event token queue.
+  It verifies that bounded accepted tokens are retained exactly once while the
+  runtime drains concurrently; no PRG or JSON contract changed.
+
 - 2026-08-24: Added controlled runtime-thread delivery for admitted
   `EVENTHANDLER()` method tokens. A host-owned subscription can enqueue only
   an already-declared handler method through a weak, bounded queue sink; the

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -45,6 +45,16 @@ binding rules. It does not activate, discover, probe, or contact a third-party
 or remote COM server. Issue #5190 requires the focused Windows workflow
 evidence before this becomes a recovered-complete claim.
 
+## V1 external event-token queue concurrent delivery coverage
+
+The internal `ExternalEventTokenQueue` now has a focused four-producer and
+one-runtime-consumer regression. It remains deliberately below its fixed
+capacity so every normalized token must be accepted; concurrent draining must
+retain every accepted token exactly once and leave the queue empty. This
+extends the existing validation/FIFO/boundary coverage without adding a public
+PRG, JSON, or COM contract. Direct Linux compilation with strict warnings and
+execution of the queue test pass.
+
 ## V1 controlled EVENTHANDLER token delivery
 
 Issue #5188 connects an optional host-owned admitted-source subscription to

--- a/tests/test_runtime_external_event_queue.cpp
+++ b/tests/test_runtime_external_event_queue.cpp
@@ -4,9 +4,13 @@
 
 #include "../src/runtime/runtime_external_event_queue.h"
 
+#include <algorithm>
+#include <atomic>
 #include <cstdlib>
 #include <iostream>
 #include <string>
+#include <thread>
+#include <vector>
 
 namespace {
 
@@ -45,5 +49,62 @@ int main() {
            "over-capacity rejection must not mutate the queue");
     queue.clear();
     expect(queue.size() == 0U, "clear should discard queued tokens");
+
+    // The queue is an internal boundary between one runtime consumer and
+    // host-owned callback producers.  Keep the test below deliberately below
+    // the bounded capacity so every producer result is deterministic while a
+    // consumer drains concurrently.
+    constexpr std::size_t producer_count = 4U;
+    constexpr std::size_t tokens_per_producer = 4U;
+    std::atomic<bool> start_producing{false};
+    std::atomic<std::size_t> finished_producer_count{0U};
+    std::atomic<std::size_t> accepted_token_count{0U};
+    std::vector<std::thread> producers;
+    producers.reserve(producer_count);
+    for (std::size_t producer = 0U; producer < producer_count; ++producer) {
+        producers.emplace_back([&queue, &start_producing, &accepted_token_count, &finished_producer_count, producer]() {
+            while (!start_producing.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            for (std::size_t token = 0U; token < tokens_per_producer; ++token) {
+                if (queue.try_push("Producer" + std::to_string(producer) + "Token" + std::to_string(token))) {
+                    accepted_token_count.fetch_add(1U, std::memory_order_relaxed);
+                }
+            }
+            finished_producer_count.fetch_add(1U, std::memory_order_release);
+        });
+    }
+
+    start_producing.store(true, std::memory_order_release);
+    std::vector<std::string> concurrently_drained;
+    while (finished_producer_count.load(std::memory_order_acquire) != producer_count || queue.size() != 0U) {
+        const auto batch = queue.drain();
+        concurrently_drained.insert(concurrently_drained.end(), batch.begin(), batch.end());
+        std::this_thread::yield();
+    }
+    for (std::thread& producer : producers) {
+        if (producer.joinable()) {
+            producer.join();
+        }
+    }
+
+    expect(accepted_token_count.load(std::memory_order_relaxed) == producer_count * tokens_per_producer,
+           "concurrent producer tokens below capacity must all enqueue");
+    expect(concurrently_drained.size() == accepted_token_count.load(std::memory_order_relaxed),
+           "concurrent drain must retain every accepted token exactly once");
+    std::sort(concurrently_drained.begin(), concurrently_drained.end());
+    expect(std::adjacent_find(concurrently_drained.begin(), concurrently_drained.end()) == concurrently_drained.end(),
+           "concurrent drain must not duplicate accepted tokens");
+    std::vector<std::string> expected_tokens;
+    expected_tokens.reserve(producer_count * tokens_per_producer);
+    for (std::size_t producer = 0U; producer < producer_count; ++producer) {
+        for (std::size_t token = 0U; token < tokens_per_producer; ++token) {
+            expected_tokens.push_back(
+                "Producer" + std::to_string(producer) + "Token" + std::to_string(token));
+        }
+    }
+    expect(concurrently_drained == expected_tokens,
+           "concurrent drain must retain the exact accepted token set");
+    expect(queue.size() == 0U, "concurrent consumer must leave the queue empty");
     return 0;
 }


### PR DESCRIPTION
## Summary
- exercise the internal bounded event-token queue with four concurrent host producers and one runtime consumer
- verify every accepted token is retained exactly once while draining concurrently
- retain changelog and handoff evidence without changing PRG, JSON, or COM contracts

## Verification
- `g++ -std=c++20 -Wall -Wextra -Werror -pthread tests/test_runtime_external_event_queue.cpp src/runtime/runtime_external_event_queue.cpp -o /tmp/copperfin-runtime-external-event-queue-test && /tmp/copperfin-runtime-external-event-queue-test`
- `git diff --check`

Maps the internal queue evidence to #5186 and the existing `LLR-VFP-COM-002` / `HZ-runtime-crash-01` / `HZ-system-failure-01` boundary.