### PR TITLE
Refactor generated wrapper compilation preamble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+- 2026-08-25: Continued #2564 source-modularity work by extracting the
+  generated native-wrapper compilation preamble into
+  `runtime_pipeline_library_export_preamble.cpp`. The platform include order,
+  platform export macros, generated wrapper text, public helper contract, and
+  runtime-package behavior are unchanged.
+
 - 2026-08-25: Recorded protected Windows evidence for the owned local
   `EVENTHANDLER()` COM connection-point lane. Run `32794260256` passed the
   adapter fixture's delivery, rejection, explicit-unbind, release-cleanup, and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,6 +509,7 @@ set(COPPERFIN_RUNTIME_PIPELINE_SOURCES
     src/runtime/runtime_pipeline_file_io_and_classification.cpp
     src/runtime/runtime_pipeline_library_export_metadata.cpp
     src/runtime/runtime_pipeline_library_export_artifacts.cpp
+    src/runtime/runtime_pipeline_library_export_preamble.cpp
     src/runtime/runtime_pipeline_library_export_manifest.cpp
     src/runtime/runtime_pipeline_native_wrapper_process.cpp
     src/runtime/runtime_pipeline_fxp_and_archive_manifest.cpp

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,18 @@
 # Agent Handoff
 
+## V1 library-export compilation-preamble module
+
+The bounded #2564 structural slice in #5194 moves the platform-specific
+include and export-macro preamble emitted into generated native wrappers from
+`runtime_pipeline_library_export_manifest.cpp` into
+`runtime_pipeline_library_export_preamble.cpp`. Preserve the exact emitted
+include order, Windows/POSIX branches, export definitions, blank-line
+termination, and the existing public runtime-pipeline helper contract. A fresh
+Debug build in a relocated `/home/rich` build directory plus focused
+`test_runtime_pipeline` CTest passed 1/1 in 71.82 seconds; the local `/tmp`
+build failure was an environmental quota limit and not product evidence.
+Protected cross-platform validation remains required before merge.
+
 ## V1 owned-COM adapter hosted evidence
 
 Protected Windows run `32794260256` passed at merged adapter head `e68056ad0`.

--- a/src/runtime/runtime_pipeline_library_export_manifest.cpp
+++ b/src/runtime/runtime_pipeline_library_export_manifest.cpp
@@ -15,34 +15,7 @@ std::string build_native_wrapper_source(const RuntimePackagePlan& plan) {
     stream.imbue(std::locale::classic());
     stream << "// Generated Copperfin native wrapper scaffold\n";
     stream << "// This is an honest bridge scaffold, not a finished FoxPro/VFP-compatible runtime wrapper.\n";
-    stream << "#include <algorithm>\n";
-    stream << "#include <array>\n";
-    stream << "#include <atomic>\n";
-    stream << "#include <cerrno>\n";
-    stream << "#include <cstdint>\n";
-    stream << "#include <cstring>\n";
-    stream << "#include <cwchar>\n";
-    stream << "#include <filesystem>\n";
-    stream << "#include <fstream>\n";
-    stream << "#include <iterator>\n";
-    stream << "#include <mutex>\n";
-    stream << "#include <sstream>\n";
-    stream << "#include <string>\n";
-    stream << "#include <utility>\n";
-    stream << "#include <vector>\n";
-    stream << "#if defined(_WIN32)\n";
-    stream << "#include <windows.h>\n";
-    stream << "#define COPPERFIN_EXPORT extern \"C\" __declspec(dllexport)\n";
-    stream << "#else\n";
-    stream << "#include <dlfcn.h>\n";
-    stream << "#include <fcntl.h>\n";
-    stream << "#include <sys/stat.h>\n";
-    stream << "#include <sys/types.h>\n";
-    stream << "#include <sys/wait.h>\n";
-    stream << "#include <unistd.h>\n";
-    stream << "extern char** environ;\n";
-    stream << "#define COPPERFIN_EXPORT extern \"C\" __attribute__((visibility(\"default\")))\n";
-    stream << "#endif\n\n";
+    append_native_wrapper_compilation_preamble(stream);
     stream << R"CF(
 static std::uint32_t copperfin_runtime_bridge_rotr(
     const std::uint32_t value,

--- a/src/runtime/runtime_pipeline_library_export_preamble.cpp
+++ b/src/runtime/runtime_pipeline_library_export_preamble.cpp
@@ -1,0 +1,45 @@
+// Copyright © 2026 Richard M. Hamilton.
+// SPDX-License-Identifier: GPL-3.0-only
+// Additional permission: Copperfin Application, Runtime, and Toolchain Exception 1.0; see LICENSE.
+
+#include "runtime_pipeline_support.h"
+
+namespace copperfin::runtime {
+
+namespace runtime_pipeline_detail {
+
+void append_native_wrapper_compilation_preamble(std::ostringstream& stream)
+{
+    stream << "#include <algorithm>\n";
+    stream << "#include <array>\n";
+    stream << "#include <atomic>\n";
+    stream << "#include <cerrno>\n";
+    stream << "#include <cstdint>\n";
+    stream << "#include <cstring>\n";
+    stream << "#include <cwchar>\n";
+    stream << "#include <filesystem>\n";
+    stream << "#include <fstream>\n";
+    stream << "#include <iterator>\n";
+    stream << "#include <mutex>\n";
+    stream << "#include <sstream>\n";
+    stream << "#include <string>\n";
+    stream << "#include <utility>\n";
+    stream << "#include <vector>\n";
+    stream << "#if defined(_WIN32)\n";
+    stream << "#include <windows.h>\n";
+    stream << "#define COPPERFIN_EXPORT extern \"C\" __declspec(dllexport)\n";
+    stream << "#else\n";
+    stream << "#include <dlfcn.h>\n";
+    stream << "#include <fcntl.h>\n";
+    stream << "#include <sys/stat.h>\n";
+    stream << "#include <sys/types.h>\n";
+    stream << "#include <sys/wait.h>\n";
+    stream << "#include <unistd.h>\n";
+    stream << "extern char** environ;\n";
+    stream << "#define COPPERFIN_EXPORT extern \"C\" __attribute__((visibility(\"default\")))\n";
+    stream << "#endif\n\n";
+}
+
+} // namespace runtime_pipeline_detail
+
+} // namespace copperfin::runtime

--- a/src/runtime/runtime_pipeline_support.h
+++ b/src/runtime/runtime_pipeline_support.h
@@ -201,6 +201,7 @@ std::map<std::string, SourceLocation> collect_library_export_routine_locations(c
 std::string build_placeholder_int_parameter_list(const std::vector<std::string>& parameter_names);
 std::string build_manifest_parameter_names(const std::vector<std::string>& parameter_names);
 std::string build_manifest_source_location(const SourceLocation& location);
+void append_native_wrapper_compilation_preamble(std::ostringstream& stream);
 std::string build_module_definition_source(const RuntimePackagePlan& plan);
 std::string build_native_wrapper_source(const RuntimePackagePlan& plan);
 std::string build_native_wrapper_cmake_source(const RuntimePackagePlan& plan);


### PR DESCRIPTION
Closes #5194

Extracts the platform-specific generated native-wrapper compilation preamble into its own runtime-pipeline module. Generated wrapper text and package/API contracts are unchanged.

Focused evidence:
- Fresh relocated Linux Debug build of test_runtime_pipeline completed.
- Focused CTest test_runtime_pipeline passed 1/1 in 71.82 seconds.
- git diff --check passed.

The initial in-worktree build stopped only because the shared /tmp filesystem quota was exhausted; the identical relocated /home/rich build is the retained local evidence.