### PR TITLE
docs: align workspace-agent security overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+- 2026-08-25: Corrected the workspace-agent security overview to match the
+  implemented narrow Windows-only unrestricted-local executor and its mandatory
+  content-free intent/outcome audit boundary. The overview continues to state
+  that it is current-user authority rather than a sandbox or elevation, and
+  that the product consent dialog, provider adapters, real sandbox enforcement,
+  general mutable-tool surface, and POSIX/macOS executor remain unimplemented.
+
 - 2026-08-25: Continued #2564 test-module refactoring by moving the contiguous
   Studio designer-dispatch JSON regression family from
   `test_studio_host_json_dispatch_designer.cpp` into

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,17 @@
 # Agent Handoff
 
+## V1 workspace-agent security-overview accuracy
+
+The bounded #5244 documentation correction aligns `docs/04-security-model.md`
+with the detailed workspace-agent policy. Copperfin implements a deliberately
+narrow Windows-only executor for an admitted, warned `unrestricted_local`
+session, with an authenticated private image, bounded transport, and mandatory
+content-free intent/outcome audit commits. It remains current-user authority,
+not a sandbox or privilege elevation. Do not claim a product consent dialog,
+provider adapter, real sandbox enforcement, general mutable-tool surface, or
+POSIX/macOS executor: those remain unimplemented. This documentation-only
+slice changes no policy, executable behavior, public API, or machine contract.
+
 ## V1 Studio designer-dispatch JSON regression module
 
 The bounded #5242/#2564 structural slice moves the contiguous Studio

--- a/docs/04-security-model.md
+++ b/docs/04-security-model.md
@@ -69,8 +69,13 @@ activation additionally requires trusted Copperfin UI, an available audit
 sink, the exact current localized warning contract, and affirmative consent.
 It allows the current user's file, process, and network authority but never
 administrator/root elevation. Provider sign-in is authentication only and
-cannot satisfy any local-authority gate. The host dialog, mutable executor,
-sandbox, audit commits, and provider adapters are not implemented yet; see
+cannot satisfy any local-authority gate. The native policy includes a narrow
+Windows-only executor for an admitted, warned `unrestricted_local` session: it
+launches an authenticated private executable image with bounded transport and
+mandatory content-free intent/outcome audit commits. That is current-user
+authority, not a workspace sandbox or privilege elevation. The host consent
+dialog, provider adapters, real sandbox enforcement, general mutable-tool
+surface, and POSIX/macOS executor are not implemented; see
 [`64-workspace-agent-access-policy.md`](64-workspace-agent-access-policy.md).
 
 Current federation baseline: live execution is explicit, limited to one local


### PR DESCRIPTION
Closes #5244.

## Scope

Corrects the overview’s stale claim that audit commits and a mutable executor are unimplemented. The detailed policy already documents the shipped narrow Windows-only executor for warned `unrestricted_local` sessions.

## Preserved limits

- Current-user authority only; no elevation and no sandbox claim.
- No product consent dialog, provider adapter, real sandbox, general mutable-tool surface, or POSIX/macOS executor.
- No code, public API, policy, or machine-contract change.

## Verification

- `git diff --check`
- Focused documentation consistency assertions verify that the stale wording is absent and the Windows-only executor, mandatory content-free intent/outcome audit, no-sandbox boundary, and remaining POSIX/macOS limitation are all present.