### PR TITLE
test: correct selected-color module EOF hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   invocation behavior, visual-asset mutation/no-mutation coverage,
   localization, and machine contracts are unchanged.
 
+- 2026-08-26: Corrected the selected-color regression module's terminal
+  whitespace and exact-source provenance record. The nonfunctional separator
+  blank line at EOF is intentionally omitted; no behavior or contract changed.
+
 - 2026-08-26: Corrected the `RQ-CF-AGENT-018` workspace-agent parser
   negative-test fixture so vector growth uses a standalone binding value rather
   than a reference into storage that `assign` or `push_back` may relocate. This

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -8,12 +8,15 @@ selected-color JSON regressions (#1056–#1059) from
 `test_studio_host_json_appearance_colors_selected.inl`. The fragment remains
 included in the same translation-unit namespace and aggregate target; shared
 fixtures, invocation behavior, visual-asset mutation/no-mutation coverage,
-localization, and machine contracts are unchanged. The original and extracted
-562-line source range are byte-identical and have SHA-256
-`59e7f7cbda09bb7914d580b7e35fef6dd8ea39003076d34f5d30eb9f108f782e`.
-No product or compatibility behavior is added. Run a fresh Linux Debug build
-of the focused `test_studio_host_json` CTest (passed 1/1 in 454.41 seconds)
-and obtain the protected matrix before integration.
+localization, and machine contracts are unchanged. The original 562-line
+source range has SHA-256
+`59e7f7cbda09bb7914d580b7e35fef6dd8ea39003076d34f5d30eb9f108f782e`; the
+561-line extracted module intentionally omits its nonfunctional terminal
+separator blank line and has SHA-256
+`a68977925ba30b7cd30a415e2644f5883b95c0d945fa3f94951b1f5ead7f527f`.
+No product or compatibility behavior is added. A fresh Linux Debug build of
+the focused `test_studio_host_json` CTest passed 1/1 in 450.72 seconds; obtain
+the protected matrix before integration.
 
 ## Workspace-agent parser test fixture aliasing correction
 

--- a/tests/test_studio_host_json_appearance_colors_selected.inl
+++ b/tests/test_studio_host_json_appearance_colors_selected.inl
@@ -559,4 +559,3 @@ void test_studio_host_json_assigns_selected_item_fore_color_by_stable_selectors(
         fs::remove_all(temp_root, ignored);
     }
 }
-


### PR DESCRIPTION
Follow-up to #5321 and PR #5322.

## Scope

Removes the accidental terminal blank line from the new selected-color regression module, so `git diff --check` passes. Updates durable provenance to distinguish the 562-line original range from the 561-line module, which intentionally omits only that nonfunctional terminal separator.

## Verification

- Fresh Linux Debug aggregate `test_studio_host_json` build
- Focused CTest: 1/1 passed in 450.72 seconds
- `git diff --check` passes
- Protected matrix pending

No behavior, localization, VFP compatibility, package, or machine-contract change.