### PR TITLE
test: isolate SQL collation parity coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 - 2026-08-27: Continued #2564 test-module refactoring by moving the contiguous
+  SQL cursor plain-string collation regression into
+  `test_prg_engine_sql_cursors_seek_and_order_plain_string_collate.inl`. The
+  aggregate target, VFP collation assertions, SQL cursor behavior, and machine
+  contracts are unchanged.
+
+- 2026-08-27: Continued #2564 test-module refactoring by moving the contiguous
   Studio-host ButtonCount launch-contract parser regression family into
   `test_studio_host_setters_data_button_count.inl`. The aggregate target,
   command grammar, request contracts, and ambiguity/invalid-input coverage are

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,21 @@
 # Agent Handoff
 
+## SQL cursor plain-string collation regression module
+
+The bounded #2564 structural slice moves the contiguous SQL cursor
+plain-string collation regression from
+`test_prg_engine_sql_cursors_seek_and_order.cpp` into the included
+`test_prg_engine_sql_cursors_seek_and_order_plain_string_collate.inl`
+fragment. It remains in the same translation-unit namespace and aggregate
+`test_prg_engine_sql_cursors_seek_and_order` target; VFP collation assertions,
+SQL cursor behavior, test isolation labels, and machine-readable contracts are
+unchanged. The original 64-line function and extracted module have identical
+SHA-256 `1d26960f8b8e73ca7a60bb8244707c44da64c1a26870e084b29ca5782d9c7862`;
+the parent source falls from 2,271 to 2,208 lines. A fresh Linux
+RelWithDebInfo build and the existing focused CTest passed 1/1 in 0.03 seconds
+with `TMPDIR`, `TMP`, and `TEMP` set to `~/temp`. Obtain the protected matrix
+before integration. No product or compatibility behavior is added.
+
 ## Studio ButtonCount launch-contract regression module
 
 The bounded #2564 structural slice moves the contiguous Studio-host

--- a/tests/test_prg_engine_sql_cursors_seek_and_order.cpp
+++ b/tests/test_prg_engine_sql_cursors_seek_and_order.cpp
@@ -801,70 +801,7 @@ void test_sql_result_cursor_padr_default_and_str_decimal_parity() {
     fs::remove_all(temp_root, ignored);
 }
 
-void test_sql_result_cursor_plain_string_collate_parity() {
-    namespace fs = std::filesystem;
-    const fs::path temp_root = fs::temp_directory_path() / "copperfin_prg_engine_sql_seek_collate_parity";
-    std::error_code ignored;
-    fs::remove_all(temp_root, ignored);
-    fs::create_directories(temp_root);
-
-    const fs::path main_path = temp_root / "sql_seek_collate_parity.prg";
-    write_text(
-        main_path,
-        "nConn = SQLCONNECT('dsn=Northwind')\n"
-        "nExec = SQLEXEC(nConn, 'select * from customers', 'sqlcust')\n"
-        "SELECT sqlcust\n"
-        "SET ORDER TO NAME\n"
-        "lMachineMiss = SEEK('bravo')\n"
-        "nMachineRec = RECNO()\n"
-        "SET COLLATE TO GENERAL\n"
-        "GO TOP\n"
-        "lGeneralHit = SEEK('bravo')\n"
-        "nGeneralRec = RECNO()\n"
-        "lDisc = SQLDISCONNECT(nConn)\n"
-        "RETURN\n");
-
-    copperfin::runtime::PrgRuntimeSession session = copperfin::runtime::PrgRuntimeSession::create(make_runtime_session_options(main_path.string(), temp_root.string()));
-
-    const auto state = session.run(copperfin::runtime::DebugResumeAction::continue_run);
-    expect(state.completed, "SQL plain-string collate parity script should complete");
-    expect(state.sql_connections.empty(), "SQL plain-string collate parity script should disconnect its SQL handle");
-
-    const auto exec = state.globals.find("nexec");
-    const auto machine_miss = state.globals.find("lmachinemiss");
-    const auto machine_rec = state.globals.find("nmachinerec");
-    const auto general_hit = state.globals.find("lgeneralhit");
-    const auto general_rec = state.globals.find("ngeneralrec");
-    const auto disc = state.globals.find("ldisc");
-
-    expect(exec != state.globals.end(), "SQLEXEC result should be captured for SQL plain-string collate parity");
-    expect(machine_miss != state.globals.end(), "default-collate SQL SEEK result should be captured");
-    expect(machine_rec != state.globals.end(), "default-collate SQL SEEK RECNO() should be captured");
-    expect(general_hit != state.globals.end(), "SET COLLATE-guided SQL SEEK result should be captured");
-    expect(general_rec != state.globals.end(), "SET COLLATE-guided SQL SEEK RECNO() should be captured");
-    expect(disc != state.globals.end(), "SQLDISCONNECT result should be captured for SQL plain-string collate parity");
-
-    if (exec != state.globals.end()) {
-        expect(copperfin::runtime::format_value(exec->second) == "1", "SQLEXEC should succeed before SQL plain-string collate checks");
-    }
-    if (machine_miss != state.globals.end()) {
-        expect(copperfin::runtime::format_value(machine_miss->second) == "false", "default MACHINE collation should keep plain SQL NAME seeks case-sensitive");
-    }
-    if (machine_rec != state.globals.end()) {
-        expect(copperfin::runtime::format_value(machine_rec->second) == "4", "default MACHINE collation failed SQL seek should still land at EOF");
-    }
-    if (general_hit != state.globals.end()) {
-        expect(copperfin::runtime::format_value(general_hit->second) == "true", "SET COLLATE TO GENERAL should case-fold plain string SQL seeks");
-    }
-    if (general_rec != state.globals.end()) {
-        expect(copperfin::runtime::format_value(general_rec->second) == "2", "SET COLLATE TO GENERAL should land on the case-folded plain SQL-string match");
-    }
-    if (disc != state.globals.end()) {
-        expect(copperfin::runtime::format_value(disc->second) == "1", "SQLDISCONNECT should still succeed after SQL plain-string collate checks");
-    }
-
-    fs::remove_all(temp_root, ignored);
-}
+#include "test_prg_engine_sql_cursors_seek_and_order_plain_string_collate.inl"
 
 void test_sql_result_cursor_temporary_order_for_expression_parity() {
     namespace fs = std::filesystem;

--- a/tests/test_prg_engine_sql_cursors_seek_and_order_plain_string_collate.inl
+++ b/tests/test_prg_engine_sql_cursors_seek_and_order_plain_string_collate.inl
@@ -1,0 +1,64 @@
+void test_sql_result_cursor_plain_string_collate_parity() {
+    namespace fs = std::filesystem;
+    const fs::path temp_root = fs::temp_directory_path() / "copperfin_prg_engine_sql_seek_collate_parity";
+    std::error_code ignored;
+    fs::remove_all(temp_root, ignored);
+    fs::create_directories(temp_root);
+
+    const fs::path main_path = temp_root / "sql_seek_collate_parity.prg";
+    write_text(
+        main_path,
+        "nConn = SQLCONNECT('dsn=Northwind')\n"
+        "nExec = SQLEXEC(nConn, 'select * from customers', 'sqlcust')\n"
+        "SELECT sqlcust\n"
+        "SET ORDER TO NAME\n"
+        "lMachineMiss = SEEK('bravo')\n"
+        "nMachineRec = RECNO()\n"
+        "SET COLLATE TO GENERAL\n"
+        "GO TOP\n"
+        "lGeneralHit = SEEK('bravo')\n"
+        "nGeneralRec = RECNO()\n"
+        "lDisc = SQLDISCONNECT(nConn)\n"
+        "RETURN\n");
+
+    copperfin::runtime::PrgRuntimeSession session = copperfin::runtime::PrgRuntimeSession::create(make_runtime_session_options(main_path.string(), temp_root.string()));
+
+    const auto state = session.run(copperfin::runtime::DebugResumeAction::continue_run);
+    expect(state.completed, "SQL plain-string collate parity script should complete");
+    expect(state.sql_connections.empty(), "SQL plain-string collate parity script should disconnect its SQL handle");
+
+    const auto exec = state.globals.find("nexec");
+    const auto machine_miss = state.globals.find("lmachinemiss");
+    const auto machine_rec = state.globals.find("nmachinerec");
+    const auto general_hit = state.globals.find("lgeneralhit");
+    const auto general_rec = state.globals.find("ngeneralrec");
+    const auto disc = state.globals.find("ldisc");
+
+    expect(exec != state.globals.end(), "SQLEXEC result should be captured for SQL plain-string collate parity");
+    expect(machine_miss != state.globals.end(), "default-collate SQL SEEK result should be captured");
+    expect(machine_rec != state.globals.end(), "default-collate SQL SEEK RECNO() should be captured");
+    expect(general_hit != state.globals.end(), "SET COLLATE-guided SQL SEEK result should be captured");
+    expect(general_rec != state.globals.end(), "SET COLLATE-guided SQL SEEK RECNO() should be captured");
+    expect(disc != state.globals.end(), "SQLDISCONNECT result should be captured for SQL plain-string collate parity");
+
+    if (exec != state.globals.end()) {
+        expect(copperfin::runtime::format_value(exec->second) == "1", "SQLEXEC should succeed before SQL plain-string collate checks");
+    }
+    if (machine_miss != state.globals.end()) {
+        expect(copperfin::runtime::format_value(machine_miss->second) == "false", "default MACHINE collation should keep plain SQL NAME seeks case-sensitive");
+    }
+    if (machine_rec != state.globals.end()) {
+        expect(copperfin::runtime::format_value(machine_rec->second) == "4", "default MACHINE collation failed SQL seek should still land at EOF");
+    }
+    if (general_hit != state.globals.end()) {
+        expect(copperfin::runtime::format_value(general_hit->second) == "true", "SET COLLATE TO GENERAL should case-fold plain string SQL seeks");
+    }
+    if (general_rec != state.globals.end()) {
+        expect(copperfin::runtime::format_value(general_rec->second) == "2", "SET COLLATE TO GENERAL should land on the case-folded plain SQL-string match");
+    }
+    if (disc != state.globals.end()) {
+        expect(copperfin::runtime::format_value(disc->second) == "1", "SQLDISCONNECT should still succeed after SQL plain-string collate checks");
+    }
+
+    fs::remove_all(temp_root, ignored);
+}


### PR DESCRIPTION
## Summary
- moves the existing SQL cursor plain-string collation regression into a dedicated included module
- preserves the same namespace, aggregate target, assertions, isolation labels, and machine-readable contracts
- records the byte-identical module digest and focused validation evidence

## Validation
- fresh Linux RelWithDebInfo build of test_prg_engine_sql_cursors_seek_and_order
- ctest -R ^test_prg_engine_sql_cursors_seek_and_order$: passed 1/1 in 0.03 seconds
- git diff --check: clean

No product, compatibility, localization, or machine-contract behavior changes.