### PR TITLE
test: isolate toolbox palette query-filter coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 - 2026-08-27: Continued #2564 test-module refactoring by moving the contiguous
+  Studio-host toolbox-palette query-filter regression into
+  `test_studio_host_json_dispatch_toolbox_palette_query_filters.inl`. The
+  aggregate target, query JSON behavior, localization, and machine-readable
+  contracts are unchanged.
+
+- 2026-08-27: Continued #2564 test-module refactoring by moving the contiguous
   Studio editor-action dispatch localization-refresh regression into
   `test_context_editor_actions_default_dispatch_locales.inl`. The aggregate
   target, locale behavior, invariant tokens, and machine-readable contracts

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,19 @@
 # Agent Handoff
 
+## Studio toolbox-palette query-filter regression module
+
+The bounded #2564 structural slice moves the contiguous Studio-host
+toolbox-palette query-filter regression from
+`test_studio_host_json_dispatch_toolbox_palette.cpp` into the included
+`test_studio_host_json_dispatch_toolbox_palette_query_filters.inl` fragment.
+It remains in the same translation-unit namespace and aggregate
+`test_studio_host_json` target; query invocation, exit statuses, JSON and
+localization assertions, cleanup behavior, and machine-readable contracts are
+unchanged. Verify the original and extracted function hashes before committing,
+then run a fresh Linux RelWithDebInfo build and the focused CTest with `TMPDIR`,
+`TMP`, and `TEMP` set to `~/temp`; obtain the protected matrix before
+integration. No product or compatibility behavior is added.
+
 ## Studio editor-action dispatch localization-refresh regression module
 
 The bounded #2564 structural slice moves the contiguous Studio editor-action

--- a/tests/test_studio_host_json_dispatch_toolbox_palette.cpp
+++ b/tests/test_studio_host_json_dispatch_toolbox_palette.cpp
@@ -6,6 +6,7 @@
 
 namespace cf_test_studio_host_json {
 #include "test_studio_host_json_dispatch_toolbox_palette_launch_plan.inl"
+#include "test_studio_host_json_dispatch_toolbox_palette_query_filters.inl"
 
 void test_studio_host_json_exposes_toolbox_palette_launch_catalog(const std::string& studio_host_path) {
     namespace fs = std::filesystem;
@@ -103,89 +104,6 @@ void test_studio_host_json_exposes_toolbox_palette_launch_catalog(const std::str
     expect_contains(unknown_option_process.stdout_text,
         "Unknown toolbox-palette-launch-catalog option: --selection-context",
         "#1317: unknown toolbox palette launch catalog options should report parser errors");
-
-    if (failures == 0) {
-        fs::remove_all(temp_root, ignored);
-    }
-}
-
-void test_studio_host_json_exposes_toolbox_palette_query_filters(const std::string& studio_host_path) {
-    namespace fs = std::filesystem;
-
-    const fs::path temp_root =
-        fs::temp_directory_path() / "copperfin_studio_host_toolbox_palette_query_json_tests";
-    std::error_code ignored;
-    fs::remove_all(temp_root, ignored);
-    fs::create_directories(temp_root);
-    ScopedDefaultLocaleCatalogEnvironment default_locale_environment;
-
-    const auto filtered_process = run_process_capture(
-        studio_host_path,
-        {
-            "--toolbox-palette-query",
-            "--toolbox-context", "form",
-            "--toolbox-search", "textbox",
-            "--toolbox-category", "Standard Controls",
-            "--json"
-        },
-        temp_root);
-    expect(filtered_process.exit_code == 0,
-        "#1414: toolbox palette query JSON should exit successfully for matching filters");
-    expect_contains(filtered_process.stdout_text, "\"toolboxPaletteQuery\": {",
-        "#1414: toolbox palette query JSON should expose a query object");
-    expect_contains(filtered_process.stdout_text, "\"toolboxContext\": \"form\"",
-        "#1414: toolbox palette query JSON should expose toolbox contexts");
-    expect_contains(filtered_process.stdout_text, "\"searchText\": \"textbox\"",
-        "#1414: toolbox palette query JSON should expose search filters");
-    expect_contains(filtered_process.stdout_text, "\"category\": \"Standard Controls\"",
-        "#1414: toolbox palette query JSON should expose category filters");
-    expect_contains(filtered_process.stdout_text, "\"itemCount\": 1",
-        "#1414: toolbox palette query JSON should expose filtered item counts");
-    expect_contains(filtered_process.stdout_text, "\"dryRun\": true",
-        "#1414: toolbox palette query JSON should remain dry-run");
-    expect_contains(filtered_process.stdout_text, "\"mutatesAsset\": false",
-        "#1414: toolbox palette query JSON should remain non-mutating");
-    expect_contains(filtered_process.stdout_text, "\"id\": \"textbox\"",
-        "#1414: toolbox palette query JSON should include matching descriptors");
-    expect_not_contains(filtered_process.stdout_text, "\"id\": \"pageframe\"",
-        "#1414: toolbox palette query JSON should exclude non-matching descriptors");
-
-    const auto empty_process = run_process_capture(
-        studio_host_path,
-        {
-            "--toolbox-palette-query",
-            "--toolbox-context", "report",
-            "--toolbox-search", "textbox",
-            "--json"
-        },
-        temp_root);
-    expect(empty_process.exit_code == 0,
-        "#1414: toolbox palette query JSON should succeed for empty results");
-    expect_contains(empty_process.stdout_text, "\"toolboxContext\": \"report\"",
-        "#1414: empty toolbox palette query JSON should preserve requested context");
-    expect_contains(empty_process.stdout_text, "\"itemCount\": 0",
-        "#1414: empty toolbox palette query JSON should report zero matches");
-    expect_contains(empty_process.stdout_text, "\"items\": [\n    ]",
-        "#1414: empty toolbox palette query JSON should expose an empty item list");
-
-    const auto invalid_context_process = run_process_capture(
-        studio_host_path,
-        {
-            "--toolbox-palette-query",
-            "--toolbox-context", "menu_item",
-            "--json"
-        },
-        temp_root);
-    expect(invalid_context_process.exit_code == 2,
-        "#1414: toolbox palette query JSON should reject invalid toolbox contexts");
-    expect_contains(invalid_context_process.stdout_text, "\"toolboxPaletteQuery\": null",
-        "#1414: invalid toolbox palette query JSON should not expose a query object");
-    expect_contains(invalid_context_process.stdout_text, "Unknown toolbox context token: menu_item",
-        "#1414: invalid toolbox palette query JSON should report parser errors");
-
-    const auto usage_process = run_process_capture(studio_host_path, {}, temp_root);
-    expect_contains(usage_process.stdout_text, "--toolbox-palette-query --toolbox-context <token>",
-        "#1414: usage text should expose toolbox palette query commands");
 
     if (failures == 0) {
         fs::remove_all(temp_root, ignored);

--- a/tests/test_studio_host_json_dispatch_toolbox_palette_query_filters.inl
+++ b/tests/test_studio_host_json_dispatch_toolbox_palette_query_filters.inl
@@ -1,0 +1,82 @@
+void test_studio_host_json_exposes_toolbox_palette_query_filters(const std::string& studio_host_path) {
+    namespace fs = std::filesystem;
+
+    const fs::path temp_root =
+        fs::temp_directory_path() / "copperfin_studio_host_toolbox_palette_query_json_tests";
+    std::error_code ignored;
+    fs::remove_all(temp_root, ignored);
+    fs::create_directories(temp_root);
+    ScopedDefaultLocaleCatalogEnvironment default_locale_environment;
+
+    const auto filtered_process = run_process_capture(
+        studio_host_path,
+        {
+            "--toolbox-palette-query",
+            "--toolbox-context", "form",
+            "--toolbox-search", "textbox",
+            "--toolbox-category", "Standard Controls",
+            "--json"
+        },
+        temp_root);
+    expect(filtered_process.exit_code == 0,
+        "#1414: toolbox palette query JSON should exit successfully for matching filters");
+    expect_contains(filtered_process.stdout_text, "\"toolboxPaletteQuery\": {",
+        "#1414: toolbox palette query JSON should expose a query object");
+    expect_contains(filtered_process.stdout_text, "\"toolboxContext\": \"form\"",
+        "#1414: toolbox palette query JSON should expose toolbox contexts");
+    expect_contains(filtered_process.stdout_text, "\"searchText\": \"textbox\"",
+        "#1414: toolbox palette query JSON should expose search filters");
+    expect_contains(filtered_process.stdout_text, "\"category\": \"Standard Controls\"",
+        "#1414: toolbox palette query JSON should expose category filters");
+    expect_contains(filtered_process.stdout_text, "\"itemCount\": 1",
+        "#1414: toolbox palette query JSON should expose filtered item counts");
+    expect_contains(filtered_process.stdout_text, "\"dryRun\": true",
+        "#1414: toolbox palette query JSON should remain dry-run");
+    expect_contains(filtered_process.stdout_text, "\"mutatesAsset\": false",
+        "#1414: toolbox palette query JSON should remain non-mutating");
+    expect_contains(filtered_process.stdout_text, "\"id\": \"textbox\"",
+        "#1414: toolbox palette query JSON should include matching descriptors");
+    expect_not_contains(filtered_process.stdout_text, "\"id\": \"pageframe\"",
+        "#1414: toolbox palette query JSON should exclude non-matching descriptors");
+
+    const auto empty_process = run_process_capture(
+        studio_host_path,
+        {
+            "--toolbox-palette-query",
+            "--toolbox-context", "report",
+            "--toolbox-search", "textbox",
+            "--json"
+        },
+        temp_root);
+    expect(empty_process.exit_code == 0,
+        "#1414: toolbox palette query JSON should succeed for empty results");
+    expect_contains(empty_process.stdout_text, "\"toolboxContext\": \"report\"",
+        "#1414: empty toolbox palette query JSON should preserve requested context");
+    expect_contains(empty_process.stdout_text, "\"itemCount\": 0",
+        "#1414: empty toolbox palette query JSON should report zero matches");
+    expect_contains(empty_process.stdout_text, "\"items\": [\n    ]",
+        "#1414: empty toolbox palette query JSON should expose an empty item list");
+
+    const auto invalid_context_process = run_process_capture(
+        studio_host_path,
+        {
+            "--toolbox-palette-query",
+            "--toolbox-context", "menu_item",
+            "--json"
+        },
+        temp_root);
+    expect(invalid_context_process.exit_code == 2,
+        "#1414: toolbox palette query JSON should reject invalid toolbox contexts");
+    expect_contains(invalid_context_process.stdout_text, "\"toolboxPaletteQuery\": null",
+        "#1414: invalid toolbox palette query JSON should not expose a query object");
+    expect_contains(invalid_context_process.stdout_text, "Unknown toolbox context token: menu_item",
+        "#1414: invalid toolbox palette query JSON should report parser errors");
+
+    const auto usage_process = run_process_capture(studio_host_path, {}, temp_root);
+    expect_contains(usage_process.stdout_text, "--toolbox-palette-query --toolbox-context <token>",
+        "#1414: usage text should expose toolbox palette query commands");
+
+    if (failures == 0) {
+        fs::remove_all(temp_root, ignored);
+    }
+}


### PR DESCRIPTION
## Summary
- move the contiguous toolbox-palette query-filter regression into a focused included test module
- retain the existing aggregate translation unit, target, query JSON behavior, locale assertions, cleanup, and machine-readable contracts
- document the structural slice and focused verification evidence

## Verification
- fresh Linux RelWithDebInfo build: `test_studio_host_json`
- `ctest --test-dir /home/rich/temp/copperfin-v1-toolbox-query-filter-build --output-on-failure -R '^test_studio_host_json$'` (1/1 passed, 64.32 s)
- original/extracted SHA-256: `f4946d3de66b54b7866df287b56b0abdef0b787be6d0f2b6b4bc630f0cfcf615`

Relates to #2564.