### PR TITLE
test: isolate SQL right str temporary order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10301,3 +10301,6 @@ passes `1/1`.
   `test_studio_host_json_object_lifecycle_stable_selector_ungroup.inl`. The
   aggregate target, #1029 behavior, localization, and machine-readable
   contracts are unchanged.
+- 2026-08-27: Continued #2564 test-module refactoring by moving the contiguous
+  SQL cursor `RIGHT`/`STR` temporary-order regression into a dedicated included
+  module. The aggregate target and VFP SQL cursor contracts are unchanged.

--- a/agent-handoff.md
+++ b/agent-handoff.md
@@ -1,5 +1,16 @@
 # Agent Handoff
 
+## SQL cursor RIGHT/STR temporary-order regression module
+
+The bounded #2564 structural slice moves the contiguous SQL cursor RIGHT/STR
+temporary-order regression into
+`test_prg_engine_sql_cursors_seek_and_order_right_str_temporary_order.inl`.
+It remains in the aggregate `test_prg_engine_sql_cursors_seek_and_order`
+target; VFP RIGHT/STR temporary-order SEEK/RECNO assertions, cleanup, and
+machine-readable contracts are unchanged. The original and extracted 62-line
+function SHA-256 is `06dff09b1a2c66cb1a5c6983e0a3150bcbf4fdbae134485419824417fd334a68`.
+A fresh Linux RelWithDebInfo focused CTest passed 1/1 in 0.04 seconds.
+
 ## SQL cursor derived-string temporary-order regression module
 
 The bounded #2564 structural slice moves the contiguous SQL cursor

--- a/tests/test_prg_engine_sql_cursors_seek_and_order.cpp
+++ b/tests/test_prg_engine_sql_cursors_seek_and_order.cpp
@@ -316,68 +316,7 @@ void test_sql_result_cursor_seek_respects_set_deleted() {
 
 #include "test_prg_engine_sql_cursors_seek_and_order_derived_string_temporary_order.inl"
 
-void test_sql_result_cursor_right_and_str_temporary_order_parity() {
-    namespace fs = std::filesystem;
-    const fs::path temp_root = fs::temp_directory_path() / "copperfin_prg_engine_sql_seek_right_str_orders";
-    std::error_code ignored;
-    fs::remove_all(temp_root, ignored);
-    fs::create_directories(temp_root);
-
-    const fs::path main_path = temp_root / "sql_seek_right_str_orders.prg";
-    write_text(
-        main_path,
-        "nConn = SQLCONNECT('dsn=Northwind')\n"
-        "nExec = SQLEXEC(nConn, 'select * from customers', 'sqlcust')\n"
-        "lSeekRight = SEEK('LIE', 'sqlcust', 'UPPER(RIGHT(NAME, 3))')\n"
-        "nRecRight = RECNO()\n"
-        "GO TOP IN sqlcust\n"
-        "lSeekStr = SEEK(' 30', 'sqlcust', 'UPPER(STR(AMOUNT, 3))')\n"
-        "nRecStr = RECNO()\n"
-        "lDisc = SQLDISCONNECT(nConn)\n"
-        "RETURN\n");
-
-    copperfin::runtime::PrgRuntimeSession session =
-        copperfin::runtime::PrgRuntimeSession::create(make_runtime_session_options(main_path.string(), temp_root.string()));
-
-    const auto state = session.run(copperfin::runtime::DebugResumeAction::continue_run);
-    expect(state.completed, "SQL RIGHT/STR temporary-order parity script should complete");
-    expect(state.sql_connections.empty(), "SQL RIGHT/STR temporary-order parity script should disconnect its SQL handle");
-
-    const auto exec = state.globals.find("nexec");
-    const auto seek_right = state.globals.find("lseekright");
-    const auto rec_right = state.globals.find("nrecright");
-    const auto seek_str = state.globals.find("lseekstr");
-    const auto rec_str = state.globals.find("nrecstr");
-    const auto disc = state.globals.find("ldisc");
-
-    expect(exec != state.globals.end(), "SQLEXEC result should be captured for SQL RIGHT/STR temporary-order parity");
-    expect(seek_right != state.globals.end(), "RIGHT()-derived SQL SEEK() result should be captured");
-    expect(rec_right != state.globals.end(), "RIGHT()-derived SQL SEEK() RECNO() should be captured");
-    expect(seek_str != state.globals.end(), "STR()-derived SQL SEEK() result should be captured");
-    expect(rec_str != state.globals.end(), "STR()-derived SQL SEEK() RECNO() should be captured");
-    expect(disc != state.globals.end(), "SQLDISCONNECT result should be captured for SQL RIGHT/STR temporary-order parity");
-
-    if (exec != state.globals.end()) {
-        expect(copperfin::runtime::format_value(exec->second) == "1", "SQLEXEC should succeed before RIGHT/STR SQL seek checks");
-    }
-    if (seek_right != state.globals.end()) {
-        expect(copperfin::runtime::format_value(seek_right->second) == "true", "SEEK() should match RIGHT()-derived temporary SQL order keys");
-    }
-    if (rec_right != state.globals.end()) {
-        expect(copperfin::runtime::format_value(rec_right->second) == "3", "RIGHT()-derived SQL SEEK() should land on the expected exact match");
-    }
-    if (seek_str != state.globals.end()) {
-        expect(copperfin::runtime::format_value(seek_str->second) == "true", "SEEK() should match STR()-derived temporary SQL order keys");
-    }
-    if (rec_str != state.globals.end()) {
-        expect(copperfin::runtime::format_value(rec_str->second) == "3", "STR()-derived SQL SEEK() should land on the expected exact match");
-    }
-    if (disc != state.globals.end()) {
-        expect(copperfin::runtime::format_value(disc->second) == "1", "SQLDISCONNECT should succeed after RIGHT/STR SQL seek checks");
-    }
-
-    fs::remove_all(temp_root, ignored);
-}
+#include "test_prg_engine_sql_cursors_seek_and_order_right_str_temporary_order.inl"
 
 void test_sql_result_cursor_default_padding_and_str_variant_parity() {
     namespace fs = std::filesystem;

--- a/tests/test_prg_engine_sql_cursors_seek_and_order_right_str_temporary_order.inl
+++ b/tests/test_prg_engine_sql_cursors_seek_and_order_right_str_temporary_order.inl
@@ -1,0 +1,62 @@
+void test_sql_result_cursor_right_and_str_temporary_order_parity() {
+    namespace fs = std::filesystem;
+    const fs::path temp_root = fs::temp_directory_path() / "copperfin_prg_engine_sql_seek_right_str_orders";
+    std::error_code ignored;
+    fs::remove_all(temp_root, ignored);
+    fs::create_directories(temp_root);
+
+    const fs::path main_path = temp_root / "sql_seek_right_str_orders.prg";
+    write_text(
+        main_path,
+        "nConn = SQLCONNECT('dsn=Northwind')\n"
+        "nExec = SQLEXEC(nConn, 'select * from customers', 'sqlcust')\n"
+        "lSeekRight = SEEK('LIE', 'sqlcust', 'UPPER(RIGHT(NAME, 3))')\n"
+        "nRecRight = RECNO()\n"
+        "GO TOP IN sqlcust\n"
+        "lSeekStr = SEEK(' 30', 'sqlcust', 'UPPER(STR(AMOUNT, 3))')\n"
+        "nRecStr = RECNO()\n"
+        "lDisc = SQLDISCONNECT(nConn)\n"
+        "RETURN\n");
+
+    copperfin::runtime::PrgRuntimeSession session =
+        copperfin::runtime::PrgRuntimeSession::create(make_runtime_session_options(main_path.string(), temp_root.string()));
+
+    const auto state = session.run(copperfin::runtime::DebugResumeAction::continue_run);
+    expect(state.completed, "SQL RIGHT/STR temporary-order parity script should complete");
+    expect(state.sql_connections.empty(), "SQL RIGHT/STR temporary-order parity script should disconnect its SQL handle");
+
+    const auto exec = state.globals.find("nexec");
+    const auto seek_right = state.globals.find("lseekright");
+    const auto rec_right = state.globals.find("nrecright");
+    const auto seek_str = state.globals.find("lseekstr");
+    const auto rec_str = state.globals.find("nrecstr");
+    const auto disc = state.globals.find("ldisc");
+
+    expect(exec != state.globals.end(), "SQLEXEC result should be captured for SQL RIGHT/STR temporary-order parity");
+    expect(seek_right != state.globals.end(), "RIGHT()-derived SQL SEEK() result should be captured");
+    expect(rec_right != state.globals.end(), "RIGHT()-derived SQL SEEK() RECNO() should be captured");
+    expect(seek_str != state.globals.end(), "STR()-derived SQL SEEK() result should be captured");
+    expect(rec_str != state.globals.end(), "STR()-derived SQL SEEK() RECNO() should be captured");
+    expect(disc != state.globals.end(), "SQLDISCONNECT result should be captured for SQL RIGHT/STR temporary-order parity");
+
+    if (exec != state.globals.end()) {
+        expect(copperfin::runtime::format_value(exec->second) == "1", "SQLEXEC should succeed before RIGHT/STR SQL seek checks");
+    }
+    if (seek_right != state.globals.end()) {
+        expect(copperfin::runtime::format_value(seek_right->second) == "true", "SEEK() should match RIGHT()-derived temporary SQL order keys");
+    }
+    if (rec_right != state.globals.end()) {
+        expect(copperfin::runtime::format_value(rec_right->second) == "3", "RIGHT()-derived SQL SEEK() should land on the expected exact match");
+    }
+    if (seek_str != state.globals.end()) {
+        expect(copperfin::runtime::format_value(seek_str->second) == "true", "SEEK() should match STR()-derived temporary SQL order keys");
+    }
+    if (rec_str != state.globals.end()) {
+        expect(copperfin::runtime::format_value(rec_str->second) == "3", "STR()-derived SQL SEEK() should land on the expected exact match");
+    }
+    if (disc != state.globals.end()) {
+        expect(copperfin::runtime::format_value(disc->second) == "1", "SQLDISCONNECT should succeed after RIGHT/STR SQL seek checks");
+    }
+
+    fs::remove_all(temp_root, ignored);
+}


### PR DESCRIPTION
## Summary

- Extracts the SQL `RIGHT`/`STR` temporary-order regression into its own included module without changing the aggregate target or runtime behavior.

## Structural proof

- Original/extracted SHA-256: `06dff09b1a2c66cb1a5c6983e0a3150bcbf4fdbae134485419824417fd334a68`.
- Parent test source: 1,912 to 1,850 lines.

## Verification

Fresh Linux RelWithDebInfo target build and focused `test_prg_engine_sql_cursors_seek_and_order` CTest: 1/1 passed in 0.04 seconds.