### PR TITLE
docs(gap-analysis): fix two stale claims in docs/31 and its diagrams

### DIFF
--- a/docs/31-specification-compliance-gap-analysis.md
+++ b/docs/31-specification-compliance-gap-analysis.md
@@ -70,7 +70,7 @@ flowchart TB
       RBAC["docs/18 Native Security And RBAC<br/>claims a current code baseline"]
       DOTNET["docs/11 .NET Bridge Spec<br/>full CLR host + marshaling +<br/>parity matrix spec'd"]
       POLYGLOT["docs/19 Polyglot And AI<br/>Subprojects - policy rules"]
-      FEDERATION["docs/21 Database Federation<br/>And Query Translation<br/>translator/planner shipped;<br/>no live connector execution"]
+      FEDERATION["docs/21 Database Federation<br/>And Query Translation<br/>translator/planner shipped;<br/>one live read-only SQLite<br/>connector (docs/49); no other<br/>backend connector execution"]
     end
 
     subgraph STUBS["Self-Reported Gaps"]
@@ -106,7 +106,7 @@ flowchart TB
     class RBAC seed;
     class DOTNET seed;
     class POLYGLOT seed;
-    class FEDERATION seed;
+    class FEDERATION partial;
     class STUBINV matrix;
     class FOUND,LANG,PIPE,SEC,STUBS lane;
 ```
@@ -240,7 +240,8 @@ the full migration pipeline remains one of the widest gaps in the review.
 
 This is a **coverage matrix**, not a pass/fail contract: it documents the full
 official VFP9 language surface — **429 commands, 413 functions, 323 properties,
-83 methods, 72 system variables, 69 events, 22 objects — 1,411 documented items
+83 methods, 72 system variables, 69 events, 22 objects, 4 preprocessor
+directives, 3 operators — 1,418 documented items
 total** — and tracks per-symbol Copperfin coverage against it, hundreds of entries
 deep, each phrased as "documented VFP9 behavior → current partial coverage claim
 → explicitly excluded remaining behavior."
@@ -605,7 +606,7 @@ excluded from the compliance map above:
 | 19 | Polyglot And AI Subprojects | Partial (portable artifact boundary, route executor, trusted host composition, PRG seam, Native AOT C# leaf, admitted Python/R sidecar leaves, advisory measured-route strategy, versioned benchmark evidence, bounded read-only MCP DBF-header host, and non-executing agent file/process target preflights) | No general CLR/Python/R runtime surface or broader model/provider and mutable MCP tooling |
 | 20 | Runtime Build And Debug Pipeline | Partial | Engine is PRG-first, not the full command surface |
 | 21 | Database Federation And Query Translation | Partial (real seed) | No live connector execution behind the translator/planner |
-| 22 | VFP Language Reference Coverage | Partial, measured | 1,411 documented items; official surface exceeds current runtime |
+| 22 | VFP Language Reference Coverage | Partial, measured | 1,418 documented items; official surface exceeds current runtime |
 | 25 | Engine Concurrency Policy | Met for current implementation | Shared blocking-policy helper and focused native coverage verify the four invariants; hosted cross-platform evidence remains a release gate |
 | 27 | Known VFP9 Bug Exceptions Registry | Scaffold-only | Zero entries |
 | 29 | Package Trust Contract | Partial | Unsigned fallback is still the default; POSIX/macOS unclaimed |
@@ -621,3 +622,17 @@ excluded from the compliance map above:
   and does not claim overall project completion percentages.
 - Refresh it when a cited document's own status language changes, or when a
   gap closes and should move to the historical record instead.
+- 2026-08-31 correction: the Database Federation node (both the inline map
+  and the detailed diagram) still read "no live connector execution" and
+  classified `FEDERATION` as `seed`, contradicting this file's own prose two
+  paragraphs later, which already documented a real, tested, read-only local
+  SQLite connector (`docs/49`) with a Windows/Linux/macOS hosted build lane.
+  Verified against `src/platform/sqlite_federation_connector.cpp` and its
+  test files directly (they exist and are wired into the build), not just
+  against the docs. Reclassified to `partial` and narrowed the stated gap to
+  the remaining non-SQLite backends. Separately, `docs/22`'s official VFP9
+  surface count grew from 1,411 to 1,418 documented items (it now also lists
+  4 preprocessor-directive and 3 operator entries); this file's two citations
+  of the stale 1,411 total (prose and summary table) are corrected to match.
+  Neither correction changes any other document's status language, so no
+  further rows moved.

--- a/docs/diagrams/gap-analysis-interop-federation-trust-security.md
+++ b/docs/diagrams/gap-analysis-interop-federation-trust-security.md
@@ -26,8 +26,8 @@ flowchart LR
 
     subgraph FED["Database Federation (docs/21) vs Reality"]
       direction TB
-      F_HAVE["HAVE: cf_platform_profile<br/>deterministic Fox-SQL to backend<br/>translator + execution-planning lane"]
-      F_GAP1["GAP: no live connector execution<br/>for sqlite/postgres/sqlserver/oracle"]
+      F_HAVE["HAVE: cf_platform_profile<br/>deterministic Fox-SQL to backend<br/>translator + execution-planning lane,<br/>PLUS one live read-only local<br/>SQLite connector (docs/49)"]
+      F_GAP1["GAP: no live connector execution<br/>for postgres/sqlserver/oracle/<br/>remote or non-SQLite backends"]
       F_GAP2["GAP: no provider/session/cursor<br/>capability contracts"]
       F_HAVE --> F_GAP1 --> F_GAP2
     end

--- a/docs/diagrams/gap-analysis-language-data-fidelity.md
+++ b/docs/diagrams/gap-analysis-language-data-fidelity.md
@@ -17,7 +17,7 @@ flowchart TB
     KBX_NEED["WHAT IT TAKES: an audit pass over\nknown Copperfin/VFP9 divergences,\neach evidenced against real VFP9 or\nshipped docs, classified and filed\nas KBX-NNN before it can be called\nan intentional exception"]
     KBX_SPEC --> KBX_REAL --> KBX_NEED
 
-    LANG_SPEC["docs/22 official VFP9 surface:\n429 commands + 413 functions +\n323 properties + 83 methods +\n72 system vars + 69 events +\n22 objects = 1,411 documented items"]
+    LANG_SPEC["docs/22 official VFP9 surface:\n429 commands + 413 functions +\n323 properties + 83 methods +\n72 system vars + 69 events +\n22 objects + 4 preprocessor directives +\n3 operators = 1,418 documented items"]
     LANG_REAL["REALITY: coverage is tracked per-symbol\nin hundreds of individual runtime-surface\nentries; doc's own backlog section states\nthe official inventory is much larger\nthan the current runtime"]
     LANG_NEED["WHAT IT TAKES: close the backlog\nagainst open issues #7/#8/#10/#11/#13/\n#14/#22/#24/#30/#31, expanding coverage\nsymbol-by-symbol with real-VFP9 or\nshipped-doc evidence per docs/07"]
     LANG_SPEC --> LANG_REAL --> LANG_NEED


### PR DESCRIPTION
Docs-only correction, no code change. Found while answering a status-check question about the project's overall completion state.

## What was checked

I verified specific claims in `docs/31-specification-compliance-gap-analysis.md` and its two split-out Mermaid diagrams directly against source (grep against actual files, CMakeLists.txt defaults, docs/22's live counts) rather than trusting the existing prose — this repo has a real precedent for status docs drifting from code truth (`RQ-CF-AGENT-009/010/012` were recorded `defined` while the underlying Windows path-alias vulnerability was still unfixed).

## What was wrong

1. **Database Federation**: the inline Specification Compliance Map and the detailed `gap-analysis-interop-federation-trust-security.md` diagram both said "no live connector execution" and classified `FEDERATION` as `seed`. This contradicted the file's *own* prose two paragraphs later ("Status: partial, with one live connector") — `src/platform/sqlite_federation_connector.cpp` and its tests exist and are wired into the build, implementing the read-only local SQLite connector documented in `docs/49`. Reclassified to `partial`; narrowed the stated gap to the remaining backends named in the still-open tracking issue #30 (PostgreSQL, SQL Server, Oracle).
2. **VFP Language Reference Coverage**: `docs/22`'s official surface count grew from 1,411 to 1,418 documented items (it now separately lists 4 preprocessor-directive and 3 operator entries). `docs/31`'s prose and summary table both still cited the stale 1,411 total; corrected in both places plus the language/data-fidelity diagram.

No other document's status language changed, so no other rows moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg