### PR TITLE
refactor(security): consolidate duplicated Windows path-safety predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+- 2026-08-31: Consolidated four Windows path-safety predicates
+  (`path_has_embedded_nul`, `path_has_dot_component`,
+  `path_has_windows_alias_prone_component`,
+  `path_has_reserved_windows_device_name_component`, issue #5405) that had
+  been hand-duplicated verbatim across `workspace_agent_target_containment.cpp`,
+  `workspace_agent_process_containment.cpp`, `workspace_agent_environment.cpp`,
+  and `workspace_agent_audit_sink.cpp` into a single canonical implementation
+  in `include/copperfin/platform/path.h` / `src/platform/path.cpp`, consumed
+  by all four via `using` declarations. This is the same class of risk that
+  produced the colon-suffixed device-name bypass fixed for issue #5404: a
+  fix or hardening applied to one copy silently leaving the other three
+  copies unpatched. `workspace_agent_audit_sink.cpp`'s inline dot-component
+  loop in `relative_log_path_is_safe()` was also folded into the shared
+  `path_has_dot_component()` call. No behavior change: the four consumer
+  test suites (`test_workspace_agent_target_containment`,
+  `test_workspace_agent_process_containment`, `test_workspace_agent_audit_sink`,
+  `test_workspace_agent_isolated_environment`) plus `test_security_controls`
+  pass unchanged, and the predicates now also have direct regression
+  coverage at their canonical home in `tests/test_platform_path.cpp`,
+  including the colon-suffixed legacy MS-DOS device syntax case
+  (`NUL:`, `NUL:hidden.txt`).
+
 - 2026-08-30: Fixed a heap buffer over-read in two Win32 version-resource
   string extractors (`RQ-CF-EXTERNAL-PROCESS-001`, issue #5402):
   `get_company_name()` (`external_process_policy.cpp`) and

--- a/include/copperfin/platform/path.h
+++ b/include/copperfin/platform/path.h
@@ -46,4 +46,37 @@ std::string path_dos_8dot3_filename(const std::filesystem::path& value);
 // facility report no label rather than manufacturing one.
 std::optional<std::string> path_volume_label(const std::filesystem::path& value);
 
+// Reports whether any component of path contains an embedded NUL character.
+// Used by strict path-spelling checks that must reject an untrusted path
+// before it ever reaches a filesystem call, since a NUL truncates most
+// native APIs' view of a string.
+bool path_has_embedded_nul(const std::filesystem::path& path);
+
+// Reports whether any component of path is exactly "." or "..". Used by
+// strict relative-path-spelling checks that must reject traversal or
+// self-reference components before a path is joined onto a trusted root.
+bool path_has_dot_component(const std::filesystem::path& path);
+
+// Reports whether any component of path ends in a trailing '.' or ' '.
+// Win32's CreateFileW/GetFullPathNameW silently strip a trailing '.' or ' '
+// from each path component before resolving it, so e.g. "tool." and "tool "
+// name the same object as "tool" -- a component-boundary check alone cannot
+// reject this, it must inspect each component's own last character. Always
+// returns false on non-Windows platforms, where this aliasing does not
+// occur.
+bool path_has_windows_alias_prone_component(const std::filesystem::path& path);
+
+// Reports whether any component of path is a reserved Windows device name
+// (CON, PRN, AUX, NUL, COM1-COM9, LPT1-LPT9), matched case-insensitively
+// against the portion of the component before its first '.' or ':' --
+// Windows recognizes these names as device objects even when followed by an
+// extension ("NUL.txt") or by legacy MS-DOS colon-terminated device syntax
+// ("NUL:", "NUL:hidden.txt"), both still honored by Win32 path resolution
+// for backward compatibility. CreateFileW on such a component opens the
+// device object rather than a regular file or directory with that name.
+// Always returns false on non-Windows platforms, where these names have no
+// special meaning.
+bool path_has_reserved_windows_device_name_component(
+    const std::filesystem::path& path);
+
 }  // namespace copperfin::platform

--- a/src/platform/path.cpp
+++ b/src/platform/path.cpp
@@ -252,4 +252,83 @@ bool path_equal_case_insensitive(
 #endif
 }
 
+bool path_has_embedded_nul(const std::filesystem::path& path) {
+    const auto& native = path.native();
+    return native.find(typename std::filesystem::path::value_type{}) !=
+        std::filesystem::path::string_type::npos;
+}
+
+bool path_has_dot_component(const std::filesystem::path& path) {
+    for (const auto& component : path) {
+        if (component == "." || component == "..") {
+            return true;
+        }
+    }
+    return false;
+}
+
+#if defined(_WIN32)
+bool path_has_windows_alias_prone_component(const std::filesystem::path& path) {
+    for (const auto& component : path) {
+        const auto& native = component.native();
+        if (!native.empty() &&
+            (native.back() == L'.' || native.back() == L' ')) {
+            return true;
+        }
+    }
+    return false;
+}
+
+namespace {
+
+bool path_component_is_reserved_windows_device_name(
+    const std::filesystem::path::string_type& component) {
+    const auto stop = component.find_first_of(L".:");
+    const std::filesystem::path::string_type stem =
+        (stop == std::filesystem::path::string_type::npos)
+            ? component
+            : component.substr(0U, stop);
+    if (stem.empty() || stem.size() > 4U) {
+        return false;
+    }
+    std::filesystem::path::string_type upper;
+    upper.reserve(stem.size());
+    for (const wchar_t ch : stem) {
+        upper.push_back(
+            (ch >= L'a' && ch <= L'z') ? static_cast<wchar_t>(ch - (L'a' - L'A')) : ch);
+    }
+    static constexpr std::wstring_view reserved_names[] = {
+        L"CON", L"PRN", L"AUX", L"NUL",
+        L"COM1", L"COM2", L"COM3", L"COM4", L"COM5", L"COM6", L"COM7", L"COM8", L"COM9",
+        L"LPT1", L"LPT2", L"LPT3", L"LPT4", L"LPT5", L"LPT6", L"LPT7", L"LPT8", L"LPT9"
+    };
+    for (const std::wstring_view name : reserved_names) {
+        if (upper == name) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}  // namespace
+
+bool path_has_reserved_windows_device_name_component(
+    const std::filesystem::path& path) {
+    for (const auto& component : path) {
+        if (path_component_is_reserved_windows_device_name(component.native())) {
+            return true;
+        }
+    }
+    return false;
+}
+#else
+bool path_has_windows_alias_prone_component(const std::filesystem::path&) {
+    return false;
+}
+
+bool path_has_reserved_windows_device_name_component(const std::filesystem::path&) {
+    return false;
+}
+#endif
+
 }  // namespace copperfin::platform

--- a/src/security/workspace_agent_audit_sink.cpp
+++ b/src/security/workspace_agent_audit_sink.cpp
@@ -24,101 +24,19 @@ constexpr std::string_view workspace_agent_process_audit_event_name =
 constexpr std::string_view workspace_agent_file_read_audit_event_name =
     "workspace_agent.file_read.v3";
 
-bool path_has_embedded_nul(const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        if (component.native().find(std::filesystem::path::value_type{}) !=
-            std::filesystem::path::string_type::npos) {
-            return true;
-        }
-    }
-    return false;
-}
-
-#if defined(_WIN32)
-// Win32's CreateFileW/GetFullPathNameW silently strip a trailing '.' or ' '
-// from each path component before resolving it, so "log." and "log " name
-// the same object as "log". A component-boundary check alone cannot reject
-// this: it must inspect each component's own last character.
-bool path_has_windows_alias_prone_component(const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        const auto& native = component.native();
-        if (!native.empty() &&
-            (native.back() == L'.' || native.back() == L' ')) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool path_component_is_reserved_windows_device_name(
-    const std::filesystem::path::string_type& component) {
-    // Legacy MS-DOS device syntax ("NUL:", "COM1:") is still honored by
-    // Win32 path resolution for backward compatibility, so a reserved name
-    // can be terminated by ':' as well as by '.' -- stopping at '.' alone is
-    // a well-known bypass for naive reserved-name checks.
-    const auto stop = component.find_first_of(L".:");
-    const std::filesystem::path::string_type stem =
-        (stop == std::filesystem::path::string_type::npos)
-            ? component
-            : component.substr(0U, stop);
-    if (stem.empty() || stem.size() > 4U) {
-        return false;
-    }
-    std::filesystem::path::string_type upper;
-    upper.reserve(stem.size());
-    for (const wchar_t ch : stem) {
-        upper.push_back(
-            (ch >= L'a' && ch <= L'z') ? static_cast<wchar_t>(ch - (L'a' - L'A')) : ch);
-    }
-    static constexpr std::wstring_view reserved_names[] = {
-        L"CON", L"PRN", L"AUX", L"NUL",
-        L"COM1", L"COM2", L"COM3", L"COM4", L"COM5", L"COM6", L"COM7", L"COM8", L"COM9",
-        L"LPT1", L"LPT2", L"LPT3", L"LPT4", L"LPT5", L"LPT6", L"LPT7", L"LPT8", L"LPT9"
-    };
-    for (const std::wstring_view name : reserved_names) {
-        if (upper == name) {
-            return true;
-        }
-    }
-    return false;
-}
-
-// Windows reserves these names as device objects at every path component,
-// not just the final one, and regardless of any extension: CreateFileW on
-// "NUL.txt" opens the NUL device rather than creating a file with that
-// name. Matching is case-insensitive against the portion of the component
-// before its first '.', mirroring how Windows itself resolves the name.
-bool path_has_reserved_windows_device_name_component(
-    const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        if (path_component_is_reserved_windows_device_name(component.native())) {
-            return true;
-        }
-    }
-    return false;
-}
-#else
-bool path_has_windows_alias_prone_component(const std::filesystem::path&) {
-    return false;
-}
-
-bool path_has_reserved_windows_device_name_component(const std::filesystem::path&) {
-    return false;
-}
-#endif
+using copperfin::platform::path_has_dot_component;
+using copperfin::platform::path_has_embedded_nul;
+using copperfin::platform::path_has_reserved_windows_device_name_component;
+using copperfin::platform::path_has_windows_alias_prone_component;
 
 bool relative_log_path_is_safe(const std::filesystem::path& path) {
     if (path.empty() || path.is_absolute() || path.has_root_name() ||
         path.has_root_directory() || path.filename().empty() ||
         path_has_embedded_nul(path) ||
         path_has_windows_alias_prone_component(path) ||
-        path_has_reserved_windows_device_name_component(path)) {
+        path_has_reserved_windows_device_name_component(path) ||
+        path_has_dot_component(path)) {
         return false;
-    }
-    for (const auto& component : path) {
-        if (component == "." || component == "..") {
-            return false;
-        }
     }
     return true;
 }

--- a/src/security/workspace_agent_environment.cpp
+++ b/src/security/workspace_agent_environment.cpp
@@ -24,93 +24,10 @@ constexpr std::array<std::string_view,
 
 using CapturedDirectory = PhysicalPathContainmentResult;
 
-bool path_has_embedded_nul(const std::filesystem::path& path) {
-    const auto& native = path.native();
-    return native.find(typename std::filesystem::path::value_type{}) !=
-        std::filesystem::path::string_type::npos;
-}
-
-bool path_has_dot_component(const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        if (component == "." || component == "..") {
-            return true;
-        }
-    }
-    return false;
-}
-
-#if defined(_WIN32)
-// Win32's CreateFileW/GetFullPathNameW silently strip a trailing '.' or ' '
-// from each path component before resolving it, so "tool." and "tool " name
-// the same object as "tool". A component-boundary check alone cannot reject
-// this: it must inspect each component's own last character.
-bool path_has_windows_alias_prone_component(const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        const auto& native = component.native();
-        if (!native.empty() &&
-            (native.back() == L'.' || native.back() == L' ')) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool path_component_is_reserved_windows_device_name(
-    const std::filesystem::path::string_type& component) {
-    // Legacy MS-DOS device syntax ("NUL:", "COM1:") is still honored by
-    // Win32 path resolution for backward compatibility, so a reserved name
-    // can be terminated by ':' as well as by '.' -- stopping at '.' alone is
-    // a well-known bypass for naive reserved-name checks.
-    const auto stop = component.find_first_of(L".:");
-    const std::filesystem::path::string_type stem =
-        (stop == std::filesystem::path::string_type::npos)
-            ? component
-            : component.substr(0U, stop);
-    if (stem.empty() || stem.size() > 4U) {
-        return false;
-    }
-    std::filesystem::path::string_type upper;
-    upper.reserve(stem.size());
-    for (const wchar_t ch : stem) {
-        upper.push_back(
-            (ch >= L'a' && ch <= L'z') ? static_cast<wchar_t>(ch - (L'a' - L'A')) : ch);
-    }
-    static constexpr std::wstring_view reserved_names[] = {
-        L"CON", L"PRN", L"AUX", L"NUL",
-        L"COM1", L"COM2", L"COM3", L"COM4", L"COM5", L"COM6", L"COM7", L"COM8", L"COM9",
-        L"LPT1", L"LPT2", L"LPT3", L"LPT4", L"LPT5", L"LPT6", L"LPT7", L"LPT8", L"LPT9"
-    };
-    for (const std::wstring_view name : reserved_names) {
-        if (upper == name) {
-            return true;
-        }
-    }
-    return false;
-}
-
-// Windows reserves these names as device objects at every path component,
-// not just the final one, and regardless of any extension: CreateFileW on
-// "NUL.txt" opens the NUL device rather than creating a file with that
-// name. Matching is case-insensitive against the portion of the component
-// before its first '.', mirroring how Windows itself resolves the name.
-bool path_has_reserved_windows_device_name_component(
-    const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        if (path_component_is_reserved_windows_device_name(component.native())) {
-            return true;
-        }
-    }
-    return false;
-}
-#else
-bool path_has_windows_alias_prone_component(const std::filesystem::path&) {
-    return false;
-}
-
-bool path_has_reserved_windows_device_name_component(const std::filesystem::path&) {
-    return false;
-}
-#endif
+using copperfin::platform::path_has_dot_component;
+using copperfin::platform::path_has_embedded_nul;
+using copperfin::platform::path_has_reserved_windows_device_name_component;
+using copperfin::platform::path_has_windows_alias_prone_component;
 
 #if defined(_WIN32)
 bool path_has_remote_or_device_root(const std::filesystem::path& path) {

--- a/src/security/workspace_agent_process_containment.cpp
+++ b/src/security/workspace_agent_process_containment.cpp
@@ -4,6 +4,7 @@
 
 #include "copperfin/security/workspace_agent_process_containment.h"
 
+#include "copperfin/platform/path.h"
 #include "copperfin/platform/windows_pe_image.h"
 
 #include "sha256_native.h"
@@ -219,101 +220,16 @@ WorkspaceAgentProcessTargetPins::executable_snapshot_for_materialization()
 
 namespace {
 
+using copperfin::platform::path_has_dot_component;
+using copperfin::platform::path_has_embedded_nul;
+using copperfin::platform::path_has_reserved_windows_device_name_component;
+using copperfin::platform::path_has_windows_alias_prone_component;
+
 WorkspaceAgentProcessTargetInspection denied(std::string diagnostic_code) {
     WorkspaceAgentProcessTargetInspection result;
     result.diagnostic_code = std::move(diagnostic_code);
     return result;
 }
-
-bool path_has_embedded_nul(const std::filesystem::path& path) {
-    const auto& native = path.native();
-    return native.find(typename std::filesystem::path::value_type{}) !=
-        std::filesystem::path::string_type::npos;
-}
-
-bool path_has_dot_component(const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        if (component == "." || component == "..") {
-            return true;
-        }
-    }
-    return false;
-}
-
-#if defined(_WIN32)
-// Win32's CreateFileW/GetFullPathNameW silently strip a trailing '.' or ' '
-// from each path component before resolving it, so "tool." and "tool " name
-// the same object as "tool". A component-boundary check alone cannot reject
-// this: it must inspect each component's own last character.
-bool path_has_windows_alias_prone_component(const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        const auto& native = component.native();
-        if (!native.empty() &&
-            (native.back() == L'.' || native.back() == L' ')) {
-            return true;
-        }
-    }
-    return false;
-}
-bool path_component_is_reserved_windows_device_name(
-    const std::filesystem::path::string_type& component) {
-    // Legacy MS-DOS device syntax ("NUL:", "COM1:") is still honored by
-    // Win32 path resolution for backward compatibility, so a reserved name
-    // can be terminated by ':' as well as by '.' -- stopping at '.' alone is
-    // a well-known bypass for naive reserved-name checks. This file also has
-    // its own independent path_has_windows_device_or_stream_syntax() check
-    // that already rejects any ':' in a relative component, so this fix is
-    // defense-in-depth here rather than closing a live gap.
-    const auto stop = component.find_first_of(L".:");
-    const std::filesystem::path::string_type stem =
-        (stop == std::filesystem::path::string_type::npos)
-            ? component
-            : component.substr(0U, stop);
-    if (stem.empty() || stem.size() > 4U) {
-        return false;
-    }
-    std::filesystem::path::string_type upper;
-    upper.reserve(stem.size());
-    for (const wchar_t ch : stem) {
-        upper.push_back(
-            (ch >= L'a' && ch <= L'z') ? static_cast<wchar_t>(ch - (L'a' - L'A')) : ch);
-    }
-    static constexpr std::wstring_view reserved_names[] = {
-        L"CON", L"PRN", L"AUX", L"NUL",
-        L"COM1", L"COM2", L"COM3", L"COM4", L"COM5", L"COM6", L"COM7", L"COM8", L"COM9",
-        L"LPT1", L"LPT2", L"LPT3", L"LPT4", L"LPT5", L"LPT6", L"LPT7", L"LPT8", L"LPT9"
-    };
-    for (const std::wstring_view name : reserved_names) {
-        if (upper == name) {
-            return true;
-        }
-    }
-    return false;
-}
-
-// Windows reserves these names as device objects at every path component,
-// not just the final one, and regardless of any extension: CreateFileW on
-// "NUL.txt" opens the NUL device rather than creating a file with that
-// name. Matching is case-insensitive against the portion of the component
-// before its first '.', mirroring how Windows itself resolves the name.
-bool path_has_reserved_windows_device_name_component(
-    const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        if (path_component_is_reserved_windows_device_name(component.native())) {
-            return true;
-        }
-    }
-    return false;
-}
-#else
-bool path_has_windows_alias_prone_component(const std::filesystem::path&) {
-    return false;
-}
-
-bool path_has_reserved_windows_device_name_component(const std::filesystem::path&) {
-    return false;
-}
-#endif
 
 #if defined(_WIN32)
 bool path_has_windows_device_or_stream_syntax(const std::filesystem::path& path) {

--- a/src/security/workspace_agent_target_containment.cpp
+++ b/src/security/workspace_agent_target_containment.cpp
@@ -4,7 +4,8 @@
 
 #include "copperfin/security/workspace_agent_target_containment.h"
 
-#include <string_view>
+#include "copperfin/platform/path.h"
+
 #include <system_error>
 #include <utility>
 
@@ -18,6 +19,11 @@
 namespace copperfin::security {
 namespace {
 
+using copperfin::platform::path_has_dot_component;
+using copperfin::platform::path_has_embedded_nul;
+using copperfin::platform::path_has_reserved_windows_device_name_component;
+using copperfin::platform::path_has_windows_alias_prone_component;
+
 WorkspaceAgentFileTargetInspection denied(std::string diagnostic_code) {
     return {
         .allowed = false,
@@ -26,94 +32,6 @@ WorkspaceAgentFileTargetInspection denied(std::string diagnostic_code) {
         .diagnostic_code = std::move(diagnostic_code)
     };
 }
-
-bool path_has_embedded_nul(const std::filesystem::path& path) {
-    const auto& native = path.native();
-    return native.find(typename std::filesystem::path::value_type{}) !=
-        std::filesystem::path::string_type::npos;
-}
-
-bool path_has_dot_component(const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        if (component == "." || component == "..") {
-            return true;
-        }
-    }
-    return false;
-}
-
-#if defined(_WIN32)
-// Win32's CreateFileW/GetFullPathNameW silently strip a trailing '.' or ' '
-// from each path component before resolving it, so "tool." and "tool " name
-// the same object as "tool". A component-boundary check alone cannot reject
-// this: it must inspect each component's own last character.
-bool path_has_windows_alias_prone_component(const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        const auto& native = component.native();
-        if (!native.empty() &&
-            (native.back() == L'.' || native.back() == L' ')) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool path_component_is_reserved_windows_device_name(
-    const std::filesystem::path::string_type& component) {
-    // Legacy MS-DOS device syntax ("NUL:", "COM1:") is still honored by
-    // Win32 path resolution for backward compatibility, so a reserved name
-    // can be terminated by ':' as well as by '.' -- stopping at '.' alone is
-    // a well-known bypass for naive reserved-name checks.
-    const auto stop = component.find_first_of(L".:");
-    const std::filesystem::path::string_type stem =
-        (stop == std::filesystem::path::string_type::npos)
-            ? component
-            : component.substr(0U, stop);
-    if (stem.empty() || stem.size() > 4U) {
-        return false;
-    }
-    std::filesystem::path::string_type upper;
-    upper.reserve(stem.size());
-    for (const wchar_t ch : stem) {
-        upper.push_back(
-            (ch >= L'a' && ch <= L'z') ? static_cast<wchar_t>(ch - (L'a' - L'A')) : ch);
-    }
-    static constexpr std::wstring_view reserved_names[] = {
-        L"CON", L"PRN", L"AUX", L"NUL",
-        L"COM1", L"COM2", L"COM3", L"COM4", L"COM5", L"COM6", L"COM7", L"COM8", L"COM9",
-        L"LPT1", L"LPT2", L"LPT3", L"LPT4", L"LPT5", L"LPT6", L"LPT7", L"LPT8", L"LPT9"
-    };
-    for (const std::wstring_view name : reserved_names) {
-        if (upper == name) {
-            return true;
-        }
-    }
-    return false;
-}
-
-// Windows reserves these names as device objects at every path component,
-// not just the final one, and regardless of any extension: CreateFileW on
-// "NUL.txt" opens the NUL device rather than creating a file with that
-// name. Matching is case-insensitive against the portion of the component
-// before its first '.', mirroring how Windows itself resolves the name.
-bool path_has_reserved_windows_device_name_component(
-    const std::filesystem::path& path) {
-    for (const auto& component : path) {
-        if (path_component_is_reserved_windows_device_name(component.native())) {
-            return true;
-        }
-    }
-    return false;
-}
-#else
-bool path_has_windows_alias_prone_component(const std::filesystem::path&) {
-    return false;
-}
-
-bool path_has_reserved_windows_device_name_component(const std::filesystem::path&) {
-    return false;
-}
-#endif
 
 bool strict_relative_file_path(const std::filesystem::path& path) {
     return !path.empty() && !path_has_embedded_nul(path) &&

--- a/tests/test_platform_path.cpp
+++ b/tests/test_platform_path.cpp
@@ -71,6 +71,76 @@ void test_case_insensitive_normalized_path_comparison() {
            "#35: VFP path identity should reject a different normalized path");
 }
 
+// #5405: path_has_embedded_nul, path_has_dot_component,
+// path_has_windows_alias_prone_component, and
+// path_has_reserved_windows_device_name_component were duplicated verbatim
+// across four workspace-agent security files; this is now their single
+// shared definition. Direct coverage here is in addition to (not instead
+// of) each of those four files' own existing regression coverage, which
+// already exercises these predicates through their real strict-spelling
+// call sites and continues to pass unchanged.
+void test_embedded_nul_detection() {
+    expect(!copperfin::platform::path_has_embedded_nul("ordinary/path.prg"),
+           "#5405: an ordinary path should not report an embedded NUL");
+    const std::filesystem::path::string_type embedded{
+        std::filesystem::path::value_type{'a'},
+        std::filesystem::path::value_type{},
+        std::filesystem::path::value_type{'b'}};
+    expect(copperfin::platform::path_has_embedded_nul(std::filesystem::path(embedded)),
+           "#5405: a component containing a NUL byte must be detected");
+}
+
+void test_dot_component_detection() {
+    expect(!copperfin::platform::path_has_dot_component("nested/child.prg"),
+           "#5405: an ordinary relative path should have no dot component");
+    expect(copperfin::platform::path_has_dot_component("nested/./child.prg"),
+           "#5405: a literal '.' component must be detected");
+    expect(copperfin::platform::path_has_dot_component("../outside/outside.prg"),
+           "#5405: a literal '..' component must be detected");
+}
+
+void test_windows_alias_prone_component_detection() {
+#if defined(_WIN32)
+    expect(copperfin::platform::path_has_windows_alias_prone_component(
+               std::filesystem::path(L"tool.")),
+           "#5405: a trailing-dot component must be detected on Windows");
+    expect(copperfin::platform::path_has_windows_alias_prone_component(
+               std::filesystem::path(L"tool ")),
+           "#5405: a trailing-space component must be detected on Windows");
+    expect(!copperfin::platform::path_has_windows_alias_prone_component(
+               std::filesystem::path(L"tool")),
+           "#5405: an unambiguous component must not be flagged on Windows");
+#else
+    expect(!copperfin::platform::path_has_windows_alias_prone_component("tool."),
+           "#5405: this check is always false on non-Windows platforms");
+#endif
+}
+
+void test_reserved_windows_device_name_detection() {
+#if defined(_WIN32)
+    for (const wchar_t* device_name : {L"NUL", L"con", L"COM1", L"lpt1.txt"}) {
+        expect(copperfin::platform::path_has_reserved_windows_device_name_component(
+                   std::filesystem::path(device_name)),
+               "#5405: a reserved device name component must be detected");
+    }
+    // Legacy MS-DOS device syntax ("NUL:") is still honored by Win32 path
+    // resolution, so a colon-suffixed form must also be detected -- this is
+    // the exact bypass an adversarial review found in the first, per-file
+    // duplicated version of this check (issue #5404's follow-up fix).
+    for (const wchar_t* device_name : {L"NUL:", L"NUL:hidden.txt", L"com1:stream"}) {
+        expect(copperfin::platform::path_has_reserved_windows_device_name_component(
+                   std::filesystem::path(device_name)),
+               "#5405: a colon-suffixed reserved device name must be detected");
+    }
+    expect(!copperfin::platform::path_has_reserved_windows_device_name_component(
+               std::filesystem::path(L"normal.txt")),
+           "#5405: an ordinary filename must not be flagged as a reserved device name");
+#else
+    expect(!copperfin::platform::path_has_reserved_windows_device_name_component("NUL"),
+           "#5405: this check is always false on non-Windows platforms");
+#endif
+}
+
 }  // namespace
 
 int main() {
@@ -79,6 +149,10 @@ int main() {
     test_invalid_utf8_contract();
     test_platform_component_comparison();
     test_case_insensitive_normalized_path_comparison();
+    test_embedded_nul_detection();
+    test_dot_component_detection();
+    test_windows_alias_prone_component_detection();
+    test_reserved_windows_device_name_detection();
 
     if (failures == 0) {
         std::cout << "Platform path tests passed\n";


### PR DESCRIPTION
## Summary

- `path_has_embedded_nul`, `path_has_dot_component`, `path_has_windows_alias_prone_component`, and `path_has_reserved_windows_device_name_component` were hand-duplicated verbatim across `workspace_agent_target_containment.cpp`, `workspace_agent_process_containment.cpp`, `workspace_agent_environment.cpp`, and `workspace_agent_audit_sink.cpp`.
- This is the same class of risk that produced the colon-suffixed device-name bypass fixed for issue #5404: a fix or hardening applied to one copy could silently leave the other three unpatched.
- Moves all four into a single canonical implementation in `copperfin::platform` (`include/copperfin/platform/path.h`, `src/platform/path.cpp`), consumed by all four call sites via `using` declarations.
- Also folds `workspace_agent_audit_sink.cpp`'s inline dot-component loop in `relative_log_path_is_safe()` into the shared `path_has_dot_component()` call.
- No behavior change intended — pure consolidation.

Fixes #5405

## Test plan

- [x] `test_platform_path` — new direct regression coverage for all four predicates, including the colon-suffixed legacy MS-DOS device syntax case (`NUL:`, `NUL:hidden.txt`)
- [x] `test_workspace_agent_target_containment` — pass, unchanged
- [x] `test_workspace_agent_process_containment` — pass, unchanged
- [x] `test_workspace_agent_audit_sink` — pass, unchanged
- [x] `test_workspace_agent_isolated_environment` — pass, unchanged
- [x] `test_security_controls` — pass, unchanged
- [ ] Full "Windows Native Validation" workflow dispatch against this exact head commit (in progress)
- [ ] Adversarial `/code-review` pass (in progress)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg