### PR TITLE
fix(test): clean up replacement file left by supporting-artifact rename test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+- 2026-09-01: Fixed a test-hygiene gap found while investigating a Windows
+  CI failure in a docs-only PR (#5439) that unexpectedly touched an
+  already-merged code path: `test_supporting_artifact_admission_rejects_rename_during_read()`
+  (issue #5427's regression test, in `test_polyglot_python_sidecar.cpp`)
+  cleaned up its moved-aside temp file but not the replacement file its
+  hook writes back at the original path, leaving a stray file in `root` --
+  which the rest of that test file's tests also use. Confirmed via
+  `inspect_and_open_physically_contained_path()`'s Windows
+  `CreateFileW(..., FILE_SHARE_DELETE, ...)` call that the rename actually
+  succeeds on Windows (not just POSIX), so this cleanup gap was real
+  there too, not merely theoretical. The specific CI failure investigated
+  turned out to be an unrelated, already-documented flake in this same
+  test file (an intermittent Python subprocess round-trip timing issue on
+  Windows CI, previously seen and cleared by rerun during #5420's own
+  review) -- confirmed by a clean rerun -- but the cleanup gap was real
+  regardless and is fixed here as good hygiene, not as the flake's root
+  cause.
+
 - 2026-09-01: A second adversarial review pass on PR #5436/issue #5427
   found the round-1 post-read re-walk fix (below) reused
   `PolyglotSupportingArtifactAdmissionError::containment_denied` for the

--- a/tests/test_polyglot_python_sidecar.cpp
+++ b/tests/test_polyglot_python_sidecar.cpp
@@ -334,8 +334,17 @@ void test_supporting_artifact_admission_rejects_rename_during_read(
             "#5427 regression test");
     }
 
+    // Clean up both the moved-aside original and the replacement the hook
+    // wrote back at g_supporting_artifact_rename_hook_original -- root is
+    // shared with the rest of this file's tests, which must not see a
+    // stray leftover file here (found while investigating an unrelated
+    // Windows CI failure in a downstream test after this one; the rename
+    // succeeds on Windows since inspect_and_open_physically_contained_path()
+    // opens with FILE_SHARE_DELETE, so this cleanup gap was real there, not
+    // just on POSIX).
     std::error_code cleanup_error;
     fs::remove(g_supporting_artifact_rename_hook_moved_aside, cleanup_error);
+    fs::remove(g_supporting_artifact_rename_hook_original, cleanup_error);
 }
 }  // namespace
 

--- a/tests/test_polyglot_python_sidecar.cpp
+++ b/tests/test_polyglot_python_sidecar.cpp
@@ -342,9 +342,23 @@ void test_supporting_artifact_admission_rejects_rename_during_read(
     // succeeds on Windows since inspect_and_open_physically_contained_path()
     // opens with FILE_SHARE_DELETE, so this cleanup gap was real there, not
     // just on POSIX).
+    // fs::remove(path, ec) clears ec (no error) when the path simply
+    // doesn't exist -- e.g. the moved-aside file when the rename itself
+    // was never permitted -- so checking cleanup_error after each call
+    // distinguishes that from an actual removal failure, without a false
+    // positive when there was nothing to clean up.
     std::error_code cleanup_error;
     fs::remove(g_supporting_artifact_rename_hook_moved_aside, cleanup_error);
+    expect_local(
+        !cleanup_error,
+        "cleanup of the moved-aside rename-race file should not fail, or "
+        "root may leak a stray file into later tests in this file");
+    cleanup_error.clear();
     fs::remove(g_supporting_artifact_rename_hook_original, cleanup_error);
+    expect_local(
+        !cleanup_error,
+        "cleanup of the replacement rename-race file should not fail, or "
+        "root may leak a stray file into later tests in this file");
 }
 }  // namespace
 


### PR DESCRIPTION
Found while investigating a Windows CI failure in an unrelated docs-only PR (#5439) that unexpectedly touched an already-merged code path.

## Summary

- `test_supporting_artifact_admission_rejects_rename_during_read()` (issue #5427's regression test) cleaned up its moved-aside temp file but not the replacement file its hook writes back at the original path, leaving a stray file in `root` -- which the rest of `test_polyglot_python_sidecar.cpp`'s tests also share.
- Confirmed via `inspect_and_open_physically_contained_path()`'s Windows `CreateFileW(..., FILE_SHARE_DELETE, ...)` call that the rename actually succeeds on Windows (not just POSIX), so this cleanup gap was real there too, not merely theoretical.
- The specific CI failure that prompted this investigation turned out to be an unrelated, already-documented flake in this same test file (an intermittent Python subprocess round-trip timing issue on Windows CI, previously seen and cleared by rerun during #5420's own review) -- confirmed by a clean rerun. This fix is good hygiene, not a root-cause fix for that flake.

## Test plan

- [x] `cmake --build build --target test_polyglot_python_sidecar` builds clean
- [x] `./build/tests/test_polyglot_python_sidecar` -- passes
- [ ] Windows Native Validation (dispatching after this PR opens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg