### PR TITLE
fix(security): fail closed on empty allowed_path_roots on Windows

### DIFF
--- a/resources/locales/en-US/strings.json
+++ b/resources/locales/en-US/strings.json
@@ -1256,6 +1256,7 @@
   "Security.Audit.Error.OpenLogForAppendFailed": "Unable to open audit log for append.",
   "Security.Audit.Error.ReadExistingLogFailed": "Unable to read existing audit log.",
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "Executable path is outside allowed roots.",
+  "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "No allowed path roots are configured; the policy denies all paths.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "The authorized executable changed before launch.",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "Executable publisher is not in the allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "Unable to resolve executable on PATH: {executableName}",

--- a/resources/locales/es-419/strings.json
+++ b/resources/locales/es-419/strings.json
@@ -483,6 +483,7 @@
   "Security.Audit.Error.OpenLogForAppendFailed": "No se pudo abrir el log de auditoria para anexar.",
   "Security.Audit.Error.ReadExistingLogFailed": "No se pudo leer el log de auditoria existente.",
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "La ruta del ejecutable esta fuera de las raices permitidas.",
+  "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "No hay raices de rutas permitidas configuradas; la politica deniega todas las rutas.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "El ejecutable autorizado cambio antes del inicio.",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "El publisher del ejecutable no esta en la allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "No se pudo resolver el ejecutable en PATH: {executableName}",

--- a/resources/locales/pt-BR/strings.json
+++ b/resources/locales/pt-BR/strings.json
@@ -483,6 +483,7 @@
   "Security.Audit.Error.OpenLogForAppendFailed": "Nao foi possivel abrir o log de auditoria para anexar.",
   "Security.Audit.Error.ReadExistingLogFailed": "Nao foi possivel ler o log de auditoria existente.",
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "O caminho do executavel esta fora das raizes permitidas.",
+  "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "Nenhuma raiz de caminho permitida esta configurada; a politica nega todos os caminhos.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "O executavel autorizado mudou antes da inicializacao.",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "O publisher do executavel nao esta na allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "Nao foi possivel resolver o executavel no PATH: {executableName}",

--- a/resources/locales/qps-ploc/strings.json
+++ b/resources/locales/qps-ploc/strings.json
@@ -483,6 +483,7 @@
   "Security.Audit.Error.OpenLogForAppendFailed": "Unable to open audit log for append.",
   "Security.Audit.Error.ReadExistingLogFailed": "Unable to read existing audit log.",
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "Executable path is outside allowed roots.",
+  "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "No allowed path roots are configured; the policy denies all paths.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "The authorized executable changed before launch.",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "Executable publisher is not in the allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "Unable to resolve executable on PATH: {executableName}",

--- a/src/security/external_process_policy.cpp
+++ b/src/security/external_process_policy.cpp
@@ -344,7 +344,13 @@ ExternalProcessAuthorizationResult authorize_external_process(const ExternalProc
 
     const std::filesystem::path executable_path =
         copperfin::platform::path_from_utf8_string(resolved_path);
-    bool root_match = policy.allowed_path_roots.empty();
+    if (policy.allowed_path_roots.empty()) {
+        return {.allowed = false,
+                .resolved_path = resolved_path,
+                .error = security_text("Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots"),
+                .file_identity = {}};
+    }
+    bool root_match = false;
     for (const auto& root : policy.allowed_path_roots) {
         if (path_under_root(
                 executable_path,

--- a/src/security/external_process_policy.cpp
+++ b/src/security/external_process_policy.cpp
@@ -347,7 +347,7 @@ ExternalProcessAuthorizationResult authorize_external_process(const ExternalProc
     if (policy.allowed_path_roots.empty()) {
         return {.allowed = false,
                 .resolved_path = resolved_path,
-                .error = security_text("Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots"),
+                .error = security_text("Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots"),
                 .file_identity = {}};
     }
     bool root_match = false;
@@ -422,7 +422,7 @@ ExternalProcessAuthorizationResult authorize_external_process(const ExternalProc
     if (policy.allowed_path_roots.empty()) {
         return {.allowed = false,
                 .resolved_path = resolved_path,
-                .error = security_text("Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots"),
+                .error = security_text("Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots"),
                 .file_identity = {}};
     }
     const bool root_match = std::any_of(

--- a/tests/test_security_controls.cpp
+++ b/tests/test_security_controls.cpp
@@ -897,10 +897,18 @@ void test_external_process_authorization_rejects_empty_allowed_path_roots() {
         .allowed_publishers = {},
         .require_trusted_signature = false
     };
+    const auto authorization = copperfin::security::authorize_external_process(policy);
     expect(
-        !copperfin::security::authorize_external_process(policy).allowed,
+        !authorization.allowed,
         "#5431: POSIX external-process policy should deny an empty allowed_path_roots "
         "(fail closed), matching the Windows path fixed for the same scenario");
+    expect(
+        authorization.error ==
+            "No allowed path roots are configured; the policy denies all paths.",
+        "#5431/copilot-review: the empty-allowed_path_roots denial should carry its own "
+        "diagnostic (not one that could also mean 'resolved but outside the configured "
+        "roots'), and this assertion should fail if a future change makes the denial "
+        "happen for an unrelated reason (e.g. 'sh' no longer resolvable on PATH)");
 }
 #endif
 
@@ -1033,6 +1041,13 @@ void test_external_process_policy_rejects_empty_allowed_path_roots() {
     expect(!authorization.allowed,
            "#5431: Windows external-process policy should deny an empty allowed_path_roots "
            "(fail closed) rather than treating it as unrestricted, matching POSIX behavior");
+    expect(
+        authorization.error ==
+            "No allowed path roots are configured; the policy denies all paths.",
+        "#5431/copilot-review: the empty-allowed_path_roots denial should carry its own "
+        "diagnostic distinct from PathOutsideAllowedRoots, and this assertion should fail "
+        "if a future change makes the denial happen for an unrelated reason (e.g. "
+        "cmd.exe no longer resolvable on PATH)");
 }
 
 void test_external_process_policy_handles_long_paths() {

--- a/tests/test_security_controls.cpp
+++ b/tests/test_security_controls.cpp
@@ -889,6 +889,19 @@ void test_external_process_authorization_follows_posix_volume_case_semantics() {
 
     fs::remove_all(temp_root, ignored);
 }
+
+void test_external_process_authorization_rejects_empty_allowed_path_roots() {
+    const copperfin::security::ExternalProcessPolicy policy{
+        .executable_name = "sh",
+        .allowed_path_roots = {},
+        .allowed_publishers = {},
+        .require_trusted_signature = false
+    };
+    expect(
+        !copperfin::security::authorize_external_process(policy).allowed,
+        "#5431: POSIX external-process policy should deny an empty allowed_path_roots "
+        "(fail closed), matching the Windows path fixed for the same scenario");
+}
 #endif
 
 #ifdef _WIN32
@@ -1007,6 +1020,19 @@ void test_external_process_policy_preserves_unicode_paths() {
         SetEnvironmentVariableW(L"PATH", original_path.c_str());
     }
     fs::remove_all(temp_root, ignored);
+}
+
+void test_external_process_policy_rejects_empty_allowed_path_roots() {
+    const copperfin::security::ExternalProcessPolicy policy{
+        .executable_name = "cmd.exe",
+        .allowed_path_roots = {},
+        .allowed_publishers = {},
+        .require_trusted_signature = false
+    };
+    const auto authorization = copperfin::security::authorize_external_process(policy);
+    expect(!authorization.allowed,
+           "#5431: Windows external-process policy should deny an empty allowed_path_roots "
+           "(fail closed) rather than treating it as unrestricted, matching POSIX behavior");
 }
 
 void test_external_process_policy_handles_long_paths() {
@@ -1626,9 +1652,11 @@ int main() {
 #ifndef _WIN32
     test_external_process_authorization_rejects_replacement();
     test_external_process_authorization_follows_posix_volume_case_semantics();
+    test_external_process_authorization_rejects_empty_allowed_path_roots();
 #endif
 #ifdef _WIN32
     test_external_process_policy_preserves_unicode_paths();
+    test_external_process_policy_rejects_empty_allowed_path_roots();
     test_external_process_policy_handles_long_paths();
 #endif
     test_physical_path_containment_rejects_indirection();


### PR DESCRIPTION
## Summary
- `authorize_external_process()`'s Windows path silently allowed any resolved executable path when `policy.allowed_path_roots` was empty, while the POSIX path already denied for the identical configuration.
- Fixes #5431.

## Details
The only current caller (`polyglot_artifact_admission.cpp`) already denies independently before reaching `authorize_external_process()` when `allowed_path_roots` is empty, so this was latent, not exploitable today -- but a footgun for any future/direct Windows caller, with no evidence of a deliberate reason for the divergence.

Fixed by denying immediately on an empty `allowed_path_roots` on Windows, matching POSIX. Added a Windows regression test (compiles/runs only under Windows CI -- this dev box is Linux) and a POSIX parity test.

## Test plan
- [x] `test_security_controls` builds and passes locally (POSIX side)
- [ ] Windows Native Validation dispatched against this branch's head commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg