### PR TITLE
physical_path_containment.cpp: extract shared read-and-revalidate-path helper (#5434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+- 2026-09-02: Extracted the identical hand-rolled "handle-based read, then
+  independent post-read path re-walk" pattern from
+  `runtime_pipeline_launcher_artifact_inventory.cpp`'s
+  `admit_launcher_artifact()` (issue #5426) and
+  `polyglot_supporting_artifact_admission.cpp`'s
+  `admit_polyglot_supporting_artifact()` (issue #5427) into one shared
+  primitive,
+  `read_physically_contained_file_snapshot_from_handle_and_revalidate_path()`
+  in `physical_path_containment.{h,cpp}` (issue #5434), so a name-keyed
+  caller (one whose read result is stored/compared by name rather than
+  reused immediately via the same still-open handle) gets the guarantee by
+  construction instead of by convention -- the failure mode issue #5434
+  was filed to prevent, matching how issue #5421 round 1 once dropped an
+  analogous link_count re-check by hand at a different call site. Each
+  caller's own single-shot test hook is preserved via an optional
+  `post_read_hook` function-pointer parameter, fired at the same point
+  between the read and the re-walk their hand-rolled versions used, so
+  this shared primitive doesn't depend on either caller's own test-hook
+  build flag. A minor, deliberate behavior change: the polyglot caller's
+  post-read re-walk now runs before its SHA-256 comparison (matching the
+  launcher caller's existing order, which the shared implementation had
+  to pick one of), so in the theoretical case of both a hash mismatch and
+  a mid-read rename occurring together, it now reports the rename
+  (`artifact_changed`) rather than the hash mismatch -- arguably more
+  informative, and no existing regression test exercises that
+  combination. Left the directory-walk syscall count unchanged (per the
+  issue's own lower-priority, performance-not-correctness framing): the
+  re-walk's independence from the initial check is what makes it a
+  meaningful TOCTOU guard, so folding it back into the same walk would
+  undermine the property this whole migration series exists to provide.
+  Verified via revert (neutering the shared helper's re-walk check) that
+  both callers' existing rename-during-read regression tests still catch
+  the regression; restored and re-verified green.
+
 - 2026-09-02: A Codex/Copilot review pass on PR #5445 (issue #5432) found
   `EnsureSafeForCmdExeCommandLine()`'s round-2 `%`-unconditional fix
   (below) still gated CR/LF rejection behind `insideQuotes`, the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,34 +3,53 @@
   `runtime_pipeline_launcher_artifact_inventory.cpp`'s
   `admit_launcher_artifact()` (issue #5426) and
   `polyglot_supporting_artifact_admission.cpp`'s
-  `admit_polyglot_supporting_artifact()` (issue #5427) into one shared
-  primitive,
-  `read_physically_contained_file_snapshot_from_handle_and_revalidate_path()`
-  in `physical_path_containment.{h,cpp}` (issue #5434), so a name-keyed
-  caller (one whose read result is stored/compared by name rather than
-  reused immediately via the same still-open handle) gets the guarantee by
-  construction instead of by convention -- the failure mode issue #5434
-  was filed to prevent, matching how issue #5421 round 1 once dropped an
-  analogous link_count re-check by hand at a different call site. Each
-  caller's own single-shot test hook is preserved via an optional
-  `post_read_hook` function-pointer parameter, fired at the same point
-  between the read and the re-walk their hand-rolled versions used, so
+  `admit_polyglot_supporting_artifact()` (issue #5427) into two shared
+  primitives in `physical_path_containment.{h,cpp}` (issue #5434):
+  `revalidate_physical_path_containment_after_read()`, the re-walk itself
+  (callable standalone after a caller's own checks on the read bytes), and
+  `read_physically_contained_file_snapshot_from_handle_and_revalidate_path()`,
+  a read-then-revalidate convenience for callers with no ordering
+  constraint of their own. A name-keyed caller (one whose read result is
+  stored/compared by name rather than reused immediately via the same
+  still-open handle) now gets this guarantee by construction instead of
+  by convention -- the failure mode issue #5434 was filed to prevent,
+  matching how issue #5421 round 1 once dropped an analogous link_count
+  re-check by hand at a different call site. Each caller's own single-shot
+  test hook is preserved via an optional `post_read_hook` function-pointer
+  parameter, fired at the same point their hand-rolled versions used, so
   this shared primitive doesn't depend on either caller's own test-hook
-  build flag. A minor, deliberate behavior change: the polyglot caller's
-  post-read re-walk now runs before its SHA-256 comparison (matching the
-  launcher caller's existing order, which the shared implementation had
-  to pick one of), so in the theoretical case of both a hash mismatch and
-  a mid-read rename occurring together, it now reports the rename
-  (`artifact_changed`) rather than the hash mismatch -- arguably more
-  informative, and no existing regression test exercises that
-  combination. Left the directory-walk syscall count unchanged (per the
-  issue's own lower-priority, performance-not-correctness framing): the
-  re-walk's independence from the initial check is what makes it a
-  meaningful TOCTOU guard, so folding it back into the same walk would
-  undermine the property this whole migration series exists to provide.
-  Verified via revert (neutering the shared helper's re-walk check) that
+  build flag.
+  A Codex/Copilot review pass found two real gaps in the first version of
+  this extraction: (1) the combined helper forwarded
+  `read_physically_contained_file_snapshot_from_handle()`'s own
+  `identity_changed` failure (a mid-read content-change race, detected by
+  the read itself) indistinguishably from the re-walk's own failure,
+  so a launcher artifact modified during the read -- no rename involved --
+  was misreported as `LauncherArtifactRenamedDuringRead`; fixed by adding
+  a new `path_changed_after_read` failure value used only by the re-walk,
+  keeping the two distinguishable (and updated three other
+  `PhysicalPathContainmentFailure` switch statements elsewhere, in
+  `workspace_agent_target_containment.cpp` and
+  `workspace_agent_process_containment.cpp`, to stay exhaustive over the
+  new value, even though those call sites can never actually produce it).
+  (2) The polyglot caller's post-read re-walk had moved to run before its
+  SHA-256 comparison, contradicting issue #5427's own "no observable
+  behavior change" acceptance criterion; fixed by having
+  `admit_polyglot_supporting_artifact()` call the plain read, then its own
+  hash check, then `revalidate_physical_path_containment_after_read()`
+  explicitly -- restoring its exact original diagnostic precedence while
+  still sharing the re-walk's actual logic. `admit_launcher_artifact()`
+  keeps using the combined convenience function, since it had no such
+  ordering constraint to preserve. Left the directory-walk syscall count
+  unchanged (per the issue's own lower-priority, performance-not-correctness
+  framing): the re-walk's independence from the initial check is what
+  makes it a meaningful TOCTOU guard, so folding it back into the same
+  walk would undermine the property this whole migration series exists to
+  provide. Verified via revert (neutering the shared re-walk check) that
   both callers' existing rename-during-read regression tests still catch
-  the regression; restored and re-verified green.
+  the regression; restored and re-verified green, plus a full local build
+  and the broader security/workspace-agent/polyglot/runtime-pipeline test
+  sweep.
 
 - 2026-09-02: A Codex/Copilot review pass on PR #5445 (issue #5432) found
   `EnsureSafeForCmdExeCommandLine()`'s round-2 `%`-unconditional fix

--- a/include/copperfin/security/physical_path_containment.h
+++ b/include/copperfin/security/physical_path_containment.h
@@ -146,4 +146,42 @@ private:
 [[nodiscard]] PhysicalFileSnapshotResult read_physically_contained_file_snapshot_from_handle(
     const PhysicalPathContainmentHandle& handle);
 
+// Reads via handle (as read_physically_contained_file_snapshot_from_handle()
+// above), then performs an independent post-read re-walk of root to confirm
+// the path still resolves to the same object. The handle-bound read alone
+// guarantees the bytes read are exactly what the check verified, but makes
+// no claim about whether the path still resolves to that same object once
+// this call returns -- a caller whose result is stored or compared *by
+// name* later (rather than reused immediately via the same still-open
+// handle) needs that extra guarantee, or a rename/replace during the read
+// can leave it holding a digest/identity for an object the path no longer
+// actually names. Fails with identity_changed (never read_failed) when the
+// re-walk finds a different object, so this is identifiable in logs
+// distinctly from an ordinary read failure (issue #5434, consolidating the
+// identical hand-rolled re-walk pair from issues #5426 and #5427).
+//
+// post_read_hook, if non-null, runs once after a successful read and
+// before the re-walk -- the same injection point issues #5426/#5427's own
+// hand-rolled versions used for their single-shot test hooks (see e.g.
+// runtime_pipeline_test_hooks.h), preserved here so callers keep that
+// capability without this shared primitive depending on any caller's own
+// test-hook machinery or build flag.
+//
+// Prefer plain read_physically_contained_file_snapshot_from_handle() for
+// callers that revalidate independently at use time instead (e.g. an
+// #5421-style migration that re-verifies immediately before every use) and
+// don't need the extra walk.
+[[nodiscard]] PhysicalFileSnapshotResult
+read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+    const PhysicalPathContainmentHandle& handle,
+    const std::filesystem::path& root,
+    std::uint64_t maximum_bytes,
+    void (*post_read_hook)() = nullptr);
+
+[[nodiscard]] PhysicalFileSnapshotResult
+read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+    const PhysicalPathContainmentHandle& handle,
+    const std::filesystem::path& root,
+    void (*post_read_hook)() = nullptr);
+
 }  // namespace copperfin::security

--- a/include/copperfin/security/physical_path_containment.h
+++ b/include/copperfin/security/physical_path_containment.h
@@ -21,7 +21,17 @@ enum class PhysicalPathContainmentFailure {
     identity_changed,
     not_regular_file,
     size_limit_exceeded,
-    read_failed
+    read_failed,
+    // Distinct from identity_changed: identity_changed can come from a read
+    // itself detecting a mid-read content change (see
+    // read_physically_contained_file_snapshot[_from_handle]()'s own before/
+    // after identity checks), while this value comes only from
+    // revalidate_physical_path_containment_after_read()'s independent
+    // post-read path re-walk finding a different object -- a caller
+    // classifying "was this specifically a rename/replace observed after
+    // the read completed" must not conflate the two (issue #5434 review
+    // finding).
+    path_changed_after_read
 };
 
 struct PhysicalPathIdentity {
@@ -146,31 +156,48 @@ private:
 [[nodiscard]] PhysicalFileSnapshotResult read_physically_contained_file_snapshot_from_handle(
     const PhysicalPathContainmentHandle& handle);
 
-// Reads via handle (as read_physically_contained_file_snapshot_from_handle()
-// above), then performs an independent post-read re-walk of root to confirm
-// the path still resolves to the same object. The handle-bound read alone
-// guarantees the bytes read are exactly what the check verified, but makes
-// no claim about whether the path still resolves to that same object once
-// this call returns -- a caller whose result is stored or compared *by
-// name* later (rather than reused immediately via the same still-open
-// handle) needs that extra guarantee, or a rename/replace during the read
-// can leave it holding a digest/identity for an object the path no longer
-// actually names. Fails with identity_changed (never read_failed) when the
-// re-walk finds a different object, so this is identifiable in logs
-// distinctly from an ordinary read failure (issue #5434, consolidating the
-// identical hand-rolled re-walk pair from issues #5426 and #5427).
+// Performs an independent post-read re-walk of root to confirm
+// snapshot.containment.canonical_path (from a prior successful read --
+// snapshot.ok must be true) still resolves to the same object. A caller
+// whose result is stored or compared *by name* later (rather than reused
+// immediately via the same still-open handle that produced the read) needs
+// this extra guarantee, or a rename/replace during the read can leave it
+// holding a digest/identity for an object the path no longer actually
+// names. Fails with path_changed_after_read (never identity_changed, and
+// never any failure the read itself could produce) when the re-walk finds
+// a different object, so this specific outcome is identifiable distinctly
+// from an ordinary read failure (issue #5434, consolidating the identical
+// hand-rolled re-walk pair from issues #5426 and #5427). Returns snapshot
+// unchanged on success.
 //
-// post_read_hook, if non-null, runs once after a successful read and
-// before the re-walk -- the same injection point issues #5426/#5427's own
-// hand-rolled versions used for their single-shot test hooks (see e.g.
-// runtime_pipeline_test_hooks.h), preserved here so callers keep that
-// capability without this shared primitive depending on any caller's own
-// test-hook machinery or build flag.
+// post_read_hook, if non-null, runs once before the re-walk -- the same
+// injection point issues #5426/#5427's own hand-rolled versions used for
+// their single-shot test hooks (see e.g. runtime_pipeline_test_hooks.h),
+// preserved here so callers keep that capability without this shared
+// primitive depending on any caller's own test-hook machinery or build
+// flag.
+//
+// Call this directly, after your own caller-specific checks on snapshot's
+// bytes (e.g. a hash comparison), if their relative order matters to your
+// diagnostics -- see admit_polyglot_supporting_artifact()'s use of this
+// split form to preserve its pre-existing hash-mismatch-before-rename
+// precedence. Otherwise, prefer the combined convenience function below.
+[[nodiscard]] PhysicalFileSnapshotResult
+revalidate_physical_path_containment_after_read(
+    const PhysicalFileSnapshotResult& snapshot,
+    const std::filesystem::path& root,
+    void (*post_read_hook)() = nullptr);
+
+// Reads via handle (as read_physically_contained_file_snapshot_from_handle()
+// above), then revalidate_physical_path_containment_after_read() in one
+// call, for a caller with no caller-specific check that needs to run
+// between the two (see that function's own doc comment for callers that
+// do, and for what path_changed_after_read means).
 //
 // Prefer plain read_physically_contained_file_snapshot_from_handle() for
 // callers that revalidate independently at use time instead (e.g. an
 // #5421-style migration that re-verifies immediately before every use) and
-// don't need the extra walk.
+// don't need the extra walk at all.
 [[nodiscard]] PhysicalFileSnapshotResult
 read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
     const PhysicalPathContainmentHandle& handle,

--- a/src/platform/polyglot_supporting_artifact_admission.cpp
+++ b/src/platform/polyglot_supporting_artifact_admission.cpp
@@ -128,12 +128,15 @@ PolyglotSupportingArtifactAdmissionResult admit_polyglot_supporting_artifact(
     // unchanged object), while resolved_path_ now points at a different
     // one. This function's own returned admission (resolved_path_,
     // artifact_sha256_, containment_) must be self-consistent regardless of
-    // whether a given caller later revalidates before use, so the
-    // _and_revalidate_path() variant's independent post-read path re-walk
-    // is required here (issue #5434, consolidating what used to be a
-    // hand-rolled re-walk here and in
-    // runtime_pipeline_launcher_artifact_inventory.cpp; originally found by
-    // adversarial review on this PR).
+    // whether a given caller later revalidates before use, so an
+    // independent post-read path re-walk is required here -- via
+    // revalidate_physical_path_containment_after_read(), called explicitly
+    // below (not the combined _and_revalidate_path() convenience function)
+    // so the hash comparison keeps running first, preserving this
+    // function's pre-existing hash-mismatch-before-rename diagnostic
+    // precedence (issue #5434, consolidating what used to be a hand-rolled
+    // re-walk here and in runtime_pipeline_launcher_artifact_inventory.cpp;
+    // originally found by adversarial review on this PR).
     auto handle = security::inspect_and_open_physically_contained_path(
         path_from_utf8_string(request.artifact_path),
         path_from_utf8_string(request.allowed_root));
@@ -148,37 +151,12 @@ PolyglotSupportingArtifactAdmissionResult admit_polyglot_supporting_artifact(
             PolyglotSupportingArtifactAdmissionError::artifact_too_large,
             "polyglot.supporting_artifact.size_limit_exceeded");
     }
-    void (*post_read_hook)() = nullptr;
-#if defined(COPPERFIN_ENABLE_POLYGLOT_SUPPORTING_ARTIFACT_ADMISSION_TEST_HOOKS)
-    post_read_hook = post_read_test_hook.exchange(nullptr, std::memory_order_relaxed);
-#endif
-    const auto snapshot =
-        security::read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
-            handle,
-            path_from_utf8_string(request.allowed_root),
-            result.maximum_bytes_,
-            post_read_hook);
+    const auto snapshot = security::read_physically_contained_file_snapshot_from_handle(
+        handle, result.maximum_bytes_);
     if (!snapshot.ok) {
-        // Denied with artifact_changed, not containment_denied/read_failed,
-        // when the failure is specifically a rename/replace observed
-        // mid-read: a materially different security event from "the path
-        // was never allowed" (containment_denied's meaning at the top of
-        // this function) or an ordinary I/O failure, and reusing either
-        // code would mask a genuine TOCTOU-attack signal from security
-        // audit logs. Mirrors the established
-        // polyglot.artifact.changed_during_admission convention in the
-        // sibling polyglot_artifact_admission.cpp, and reuses the same
-        // PolyglotSupportingArtifactAdmissionError::artifact_changed value
-        // this file's own revalidate_polyglot_supporting_artifact_admission()
-        // already uses for its analogous checks -- found by a second
-        // adversarial review pass on PR #5428/issue #5427.
         return deny(
-            snapshot.failure == security::PhysicalPathContainmentFailure::identity_changed
-                ? PolyglotSupportingArtifactAdmissionError::artifact_changed
-                : PolyglotSupportingArtifactAdmissionError::read_failed,
-            snapshot.failure == security::PhysicalPathContainmentFailure::identity_changed
-                ? "polyglot.supporting_artifact.changed_during_admission"
-                : "polyglot.supporting_artifact.read_failed");
+            PolyglotSupportingArtifactAdmissionError::read_failed,
+            "polyglot.supporting_artifact.read_failed");
     }
     const auto digest = security::sha256_hex_for_text(snapshot.bytes);
     if (!digest.ok) {
@@ -191,8 +169,30 @@ PolyglotSupportingArtifactAdmissionResult admit_polyglot_supporting_artifact(
             PolyglotSupportingArtifactAdmissionError::hash_mismatch,
             "polyglot.supporting_artifact.sha256_mismatch");
     }
+    void (*post_read_hook)() = nullptr;
+#if defined(COPPERFIN_ENABLE_POLYGLOT_SUPPORTING_ARTIFACT_ADMISSION_TEST_HOOKS)
+    post_read_hook = post_read_test_hook.exchange(nullptr, std::memory_order_relaxed);
+#endif
+    const auto revalidated = security::revalidate_physical_path_containment_after_read(
+        snapshot, path_from_utf8_string(request.allowed_root), post_read_hook);
+    if (!revalidated.ok) {
+        // Denied with artifact_changed, not containment_denied: a rename/
+        // replace caught here is a materially different security event
+        // from "the path was never allowed" (containment_denied's meaning
+        // at the top of this function) and reusing that code would mask a
+        // genuine TOCTOU-attack signal from security audit logs. Mirrors
+        // the established polyglot.artifact.changed_during_admission
+        // convention in the sibling polyglot_artifact_admission.cpp, and
+        // reuses the same PolyglotSupportingArtifactAdmissionError::artifact_changed
+        // value this file's own revalidate_polyglot_supporting_artifact_admission()
+        // already uses for its analogous checks -- found by a second
+        // adversarial review pass on PR #5428/issue #5427.
+        return deny(
+            PolyglotSupportingArtifactAdmissionError::artifact_changed,
+            "polyglot.supporting_artifact.changed_during_admission");
+    }
 
-    result.containment_ = snapshot.containment;
+    result.containment_ = revalidated.containment;
     result.resolved_path_ = path_to_utf8_string(
         result.containment_.canonical_path);
     result.artifact_sha256_ = digest.hex_digest;

--- a/src/platform/polyglot_supporting_artifact_admission.cpp
+++ b/src/platform/polyglot_supporting_artifact_admission.cpp
@@ -120,17 +120,19 @@ PolyglotSupportingArtifactAdmissionResult admit_polyglot_supporting_artifact(
 
     // Atomic check-and-open primitive (issue #5409/#5420/#5427): the read
     // below is bound to the exact object this walk verified, never reopened
-    // by path string. The inline expected_sha256 comparison below protects
-    // the bytes read via the handle, but -- as issue #5426's identical
-    // post-read re-walk fix established -- it does not by itself guarantee
+    // by path string. The inline expected_sha256 comparison protects the
+    // bytes read via the handle, but does not by itself guarantee
     // resolved_path_ still resolves to that same object once this function
     // returns: a rename/replace during the read lets the handle-bound read
     // still correctly match expected_sha256 (it's reading the original,
     // unchanged object), while resolved_path_ now points at a different
     // one. This function's own returned admission (resolved_path_,
     // artifact_sha256_, containment_) must be self-consistent regardless of
-    // whether a given caller later revalidates before use, so restore the
-    // same independent post-read path re-walk #5426 needed (found by
+    // whether a given caller later revalidates before use, so the
+    // _and_revalidate_path() variant's independent post-read path re-walk
+    // is required here (issue #5434, consolidating what used to be a
+    // hand-rolled re-walk here and in
+    // runtime_pipeline_launcher_artifact_inventory.cpp; originally found by
     // adversarial review on this PR).
     auto handle = security::inspect_and_open_physically_contained_path(
         path_from_utf8_string(request.artifact_path),
@@ -146,12 +148,37 @@ PolyglotSupportingArtifactAdmissionResult admit_polyglot_supporting_artifact(
             PolyglotSupportingArtifactAdmissionError::artifact_too_large,
             "polyglot.supporting_artifact.size_limit_exceeded");
     }
-    const auto snapshot = security::read_physically_contained_file_snapshot_from_handle(
-        handle, result.maximum_bytes_);
+    void (*post_read_hook)() = nullptr;
+#if defined(COPPERFIN_ENABLE_POLYGLOT_SUPPORTING_ARTIFACT_ADMISSION_TEST_HOOKS)
+    post_read_hook = post_read_test_hook.exchange(nullptr, std::memory_order_relaxed);
+#endif
+    const auto snapshot =
+        security::read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+            handle,
+            path_from_utf8_string(request.allowed_root),
+            result.maximum_bytes_,
+            post_read_hook);
     if (!snapshot.ok) {
+        // Denied with artifact_changed, not containment_denied/read_failed,
+        // when the failure is specifically a rename/replace observed
+        // mid-read: a materially different security event from "the path
+        // was never allowed" (containment_denied's meaning at the top of
+        // this function) or an ordinary I/O failure, and reusing either
+        // code would mask a genuine TOCTOU-attack signal from security
+        // audit logs. Mirrors the established
+        // polyglot.artifact.changed_during_admission convention in the
+        // sibling polyglot_artifact_admission.cpp, and reuses the same
+        // PolyglotSupportingArtifactAdmissionError::artifact_changed value
+        // this file's own revalidate_polyglot_supporting_artifact_admission()
+        // already uses for its analogous checks -- found by a second
+        // adversarial review pass on PR #5428/issue #5427.
         return deny(
-            PolyglotSupportingArtifactAdmissionError::read_failed,
-            "polyglot.supporting_artifact.read_failed");
+            snapshot.failure == security::PhysicalPathContainmentFailure::identity_changed
+                ? PolyglotSupportingArtifactAdmissionError::artifact_changed
+                : PolyglotSupportingArtifactAdmissionError::read_failed,
+            snapshot.failure == security::PhysicalPathContainmentFailure::identity_changed
+                ? "polyglot.supporting_artifact.changed_during_admission"
+                : "polyglot.supporting_artifact.read_failed");
     }
     const auto digest = security::sha256_hex_for_text(snapshot.bytes);
     if (!digest.ok) {
@@ -163,42 +190,6 @@ PolyglotSupportingArtifactAdmissionResult admit_polyglot_supporting_artifact(
         return deny(
             PolyglotSupportingArtifactAdmissionError::hash_mismatch,
             "polyglot.supporting_artifact.sha256_mismatch");
-    }
-#if defined(COPPERFIN_ENABLE_POLYGLOT_SUPPORTING_ARTIFACT_ADMISSION_TEST_HOOKS)
-    if (const auto hook = post_read_test_hook.load(std::memory_order_relaxed);
-        hook != nullptr) {
-        post_read_test_hook.store(nullptr, std::memory_order_relaxed);
-        hook();
-    }
-#endif
-    // content_equal(), not operator== -- this re-walk exists only to
-    // confirm the path still resolves to the same object, not to detect a
-    // hard-link count change (no link_count-dependent invariant exists in
-    // this file; grepped for it). Using the stricter full-identity
-    // comparison would spuriously deny admission on a benign, momentary
-    // link_count change unrelated to content.
-    //
-    // Denied with artifact_changed, not containment_denied: a rename/
-    // replace caught here is a materially different security event from
-    // "the path was never allowed" (the meaning containment_denied has at
-    // the top of this function) and reusing that code would mask a genuine
-    // TOCTOU-attack signal from security audit logs behind a mundane
-    // misconfiguration code. Mirrors the established
-    // polyglot.artifact.changed_during_admission convention in the sibling
-    // polyglot_artifact_admission.cpp, and reuses the same
-    // PolyglotSupportingArtifactAdmissionError::artifact_changed value this
-    // file's own revalidate_polyglot_supporting_artifact_admission() already
-    // uses for its analogous checks -- found by a second adversarial review
-    // pass on this PR.
-    const auto after_containment = security::inspect_physical_path_containment(
-        result.containment_.canonical_path,
-        path_from_utf8_string(request.allowed_root));
-    if (!after_containment.allowed ||
-        after_containment.canonical_path != result.containment_.canonical_path ||
-        !after_containment.identity.content_equal(snapshot.containment.identity)) {
-        return deny(
-            PolyglotSupportingArtifactAdmissionError::artifact_changed,
-            "polyglot.supporting_artifact.changed_during_admission");
     }
 
     result.containment_ = snapshot.containment;

--- a/src/runtime/runtime_pipeline_launcher_artifact_inventory.cpp
+++ b/src/runtime/runtime_pipeline_launcher_artifact_inventory.cpp
@@ -220,7 +220,7 @@ bool admit_launcher_artifact(
         // containment diagnostic (found by adversarial review on PR
         // #5444/issue #5435).
         error = runtime_text(
-            snapshot.failure == security::PhysicalPathContainmentFailure::identity_changed
+            snapshot.failure == security::PhysicalPathContainmentFailure::path_changed_after_read
                 ? "Runtime.Package.Error.LauncherArtifactRenamedDuringRead"
                 : "Runtime.Package.Error.LauncherArtifactNotDirectRegularFile",
             {{"path", expected_name}});

--- a/src/runtime/runtime_pipeline_launcher_artifact_inventory.cpp
+++ b/src/runtime/runtime_pipeline_launcher_artifact_inventory.cpp
@@ -193,60 +193,36 @@ bool admit_launcher_artifact(
             {{"path", expected_name}});
         return false;
     }
-    const auto snapshot = security::read_physically_contained_file_snapshot_from_handle(handle);
-    if (!snapshot.ok) {
-        error = runtime_text(
-            "Runtime.Package.Error.LauncherArtifactNotDirectRegularFile",
-            {{"path", expected_name}});
-        return false;
-    }
-    // read_physically_contained_file_snapshot_from_handle() guarantees the
-    // bytes just read are exactly what the walk verified, but -- unlike the
-    // string-reopening read_physically_contained_file_snapshot() it
-    // replaces, which re-walked expected.canonical_path by string after the
-    // read -- it makes no claim about whether the path still resolves to
-    // that same object afterward. Another process could rename/replace the
-    // artifact during the read: the handle-bound read still succeeds
-    // (correctly reading the original object's unchanged content), but this
-    // inventory entry is keyed by expected_name, and if that name now
-    // resolves to a different object, the recorded digest would describe an
-    // object the package no longer actually ships under that name. Restore
-    // the independent post-read path re-walk the old function performed, so
-    // this call site rejects rather than silently mis-recording (found by
-    // adversarial review on PR #5428). Re-walks containment.canonical_path
-    // (the already-verified canonical form), not the raw *exact directory
-    // entry, so this genuinely mirrors read_physically_contained_file_snapshot()'s
-    // own post-read check (physical_path_containment.cpp) rather than
-    // re-doing casefold/directory-entry resolution from scratch a second
-    // time.
+    // read_physically_contained_file_snapshot_from_handle() alone guarantees
+    // the bytes read are exactly what the walk verified, but makes no claim
+    // about whether the path still resolves to that same object once this
+    // call returns -- this inventory entry is keyed by expected_name, and a
+    // rename/replace of the artifact during the read would otherwise let a
+    // digest for an object the package no longer actually ships under that
+    // name be silently recorded. The
+    // _and_revalidate_path() variant closes that gap with an independent
+    // post-read re-walk (issue #5434, consolidating what used to be a
+    // hand-rolled re-walk here and in polyglot_supporting_artifact_admission.cpp;
+    // originally found by adversarial review on PR #5428).
+    void (*post_read_hook)() = nullptr;
 #if defined(COPPERFIN_ENABLE_RUNTIME_PIPELINE_TEST_HOOKS)
-    if (const auto hook =
-            launcher_artifact_post_read_test_hook.load(std::memory_order_relaxed);
-        hook != nullptr) {
-        launcher_artifact_post_read_test_hook.store(nullptr, std::memory_order_relaxed);
-        hook();
-    }
+    post_read_hook =
+        launcher_artifact_post_read_test_hook.exchange(nullptr, std::memory_order_relaxed);
 #endif
-    const auto after_containment = security::inspect_physical_path_containment(
-        containment.canonical_path, package_root);
-    // content_equal(), not operator== -- this re-walk exists only to confirm
-    // the path still resolves to the same object (matching this call site's
-    // documented lack of a link_count-dependent trust invariant, per the
-    // comment above), not to detect a hard-link count change. Using the
-    // stricter full-identity comparison here would spuriously fail the
-    // whole package build on a benign, momentary link_count change (e.g. an
-    // AV/backup/dedup tool briefly hard-linking the artifact) that leaves
-    // content byte-identical -- found by adversarial review on PR #5428.
-    if (!after_containment.allowed ||
-        after_containment.canonical_path != containment.canonical_path ||
-        !after_containment.identity.content_equal(snapshot.containment.identity)) {
+    const auto snapshot =
+        security::read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+            handle, package_root, post_read_hook);
+    if (!snapshot.ok) {
         // Distinct from LauncherArtifactNotDirectRegularFile (used by the
-        // containment-denied and read-failed branches above) so this
-        // specific outcome -- a rename/replace observed mid-read -- is
-        // identifiable in logs, not folded into the generic containment
-        // diagnostic (found by adversarial review on PR #5444/issue #5435).
+        // containment-denied branch above) when the failure is specifically
+        // a rename/replace observed mid-read, so this outcome is
+        // identifiable in logs rather than folded into the generic
+        // containment diagnostic (found by adversarial review on PR
+        // #5444/issue #5435).
         error = runtime_text(
-            "Runtime.Package.Error.LauncherArtifactRenamedDuringRead",
+            snapshot.failure == security::PhysicalPathContainmentFailure::identity_changed
+                ? "Runtime.Package.Error.LauncherArtifactRenamedDuringRead"
+                : "Runtime.Package.Error.LauncherArtifactNotDirectRegularFile",
             {{"path", expected_name}});
         return false;
     }

--- a/src/security/physical_path_containment.cpp
+++ b/src/security/physical_path_containment.cpp
@@ -802,6 +802,46 @@ PhysicalFileSnapshotResult read_physically_contained_file_snapshot_from_handle(
     };
 }
 
+PhysicalFileSnapshotResult
+read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+    const PhysicalPathContainmentHandle& handle,
+    const std::filesystem::path& root,
+    const std::uint64_t maximum_bytes,
+    void (* const post_read_hook)()) {
+    const auto snapshot =
+        read_physically_contained_file_snapshot_from_handle(handle, maximum_bytes);
+    if (!snapshot.ok) {
+        return snapshot;
+    }
+    if (post_read_hook != nullptr) {
+        post_read_hook();
+    }
+    // content_equal(), not operator== -- confirms the path still resolves
+    // to the same object, not a hard-link count change. Using the
+    // stricter full-identity comparison would spuriously deny a benign,
+    // momentary link_count change (e.g. an AV/backup/dedup tool briefly
+    // hard-linking the artifact) that leaves content byte-identical, per
+    // both #5426's and #5427's original hand-rolled versions of this
+    // check.
+    const auto after_containment = inspect_physical_path_containment(
+        snapshot.containment.canonical_path, root);
+    if (!after_containment.allowed ||
+        after_containment.canonical_path != snapshot.containment.canonical_path ||
+        !after_containment.identity.content_equal(snapshot.containment.identity)) {
+        return failed_snapshot(PhysicalPathContainmentFailure::identity_changed);
+    }
+    return snapshot;
+}
+
+PhysicalFileSnapshotResult
+read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+    const PhysicalPathContainmentHandle& handle,
+    const std::filesystem::path& root,
+    void (* const post_read_hook)()) {
+    return read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+        handle, root, (std::numeric_limits<std::uint64_t>::max)(), post_read_hook);
+}
+
 PhysicalFileSnapshotResult read_physically_contained_file_snapshot(
     const PhysicalPathContainmentResult& expected,
     const std::filesystem::path& root) {

--- a/src/security/physical_path_containment.cpp
+++ b/src/security/physical_path_containment.cpp
@@ -802,17 +802,10 @@ PhysicalFileSnapshotResult read_physically_contained_file_snapshot_from_handle(
     };
 }
 
-PhysicalFileSnapshotResult
-read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
-    const PhysicalPathContainmentHandle& handle,
+PhysicalFileSnapshotResult revalidate_physical_path_containment_after_read(
+    const PhysicalFileSnapshotResult& snapshot,
     const std::filesystem::path& root,
-    const std::uint64_t maximum_bytes,
     void (* const post_read_hook)()) {
-    const auto snapshot =
-        read_physically_contained_file_snapshot_from_handle(handle, maximum_bytes);
-    if (!snapshot.ok) {
-        return snapshot;
-    }
     if (post_read_hook != nullptr) {
         post_read_hook();
     }
@@ -828,9 +821,31 @@ read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
     if (!after_containment.allowed ||
         after_containment.canonical_path != snapshot.containment.canonical_path ||
         !after_containment.identity.content_equal(snapshot.containment.identity)) {
-        return failed_snapshot(PhysicalPathContainmentFailure::identity_changed);
+        // path_changed_after_read, not identity_changed: this failure must
+        // stay distinguishable from a read itself reporting identity_changed
+        // for a mid-read content change (see
+        // read_physically_contained_file_snapshot_from_handle()'s own
+        // before/after identity checks) -- conflating the two made a caller
+        // that only checks for identity_changed misreport an ordinary
+        // read-time race as a post-read rename/replace (issue #5434 review
+        // finding).
+        return failed_snapshot(PhysicalPathContainmentFailure::path_changed_after_read);
     }
     return snapshot;
+}
+
+PhysicalFileSnapshotResult
+read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+    const PhysicalPathContainmentHandle& handle,
+    const std::filesystem::path& root,
+    const std::uint64_t maximum_bytes,
+    void (* const post_read_hook)()) {
+    const auto snapshot =
+        read_physically_contained_file_snapshot_from_handle(handle, maximum_bytes);
+    if (!snapshot.ok) {
+        return snapshot;
+    }
+    return revalidate_physical_path_containment_after_read(snapshot, root, post_read_hook);
 }
 
 PhysicalFileSnapshotResult

--- a/src/security/workspace_agent_process_containment.cpp
+++ b/src/security/workspace_agent_process_containment.cpp
@@ -343,6 +343,12 @@ std::string executable_diagnostic_for_failure(
         case PhysicalPathContainmentFailure::not_regular_file:
         case PhysicalPathContainmentFailure::size_limit_exceeded:
         case PhysicalPathContainmentFailure::read_failed:
+        // Never actually produced by inspect_physical_path_containment()
+        // (only revalidate_physical_path_containment_after_read() in
+        // physical_path_containment.cpp returns this), but the switch
+        // must stay exhaustive; listed here for that reason, not because
+        // this call site can observe it.
+        case PhysicalPathContainmentFailure::path_changed_after_read:
             return "workspace_agent.process_executable_unavailable";
     }
     return "workspace_agent.process_executable_unavailable";
@@ -365,6 +371,12 @@ std::string working_directory_diagnostic_for_failure(
         case PhysicalPathContainmentFailure::not_regular_file:
         case PhysicalPathContainmentFailure::size_limit_exceeded:
         case PhysicalPathContainmentFailure::read_failed:
+        // Never actually produced by inspect_physical_path_containment()
+        // (only revalidate_physical_path_containment_after_read() in
+        // physical_path_containment.cpp returns this), but the switch
+        // must stay exhaustive; listed here for that reason, not because
+        // this call site can observe it.
+        case PhysicalPathContainmentFailure::path_changed_after_read:
             return "workspace_agent.process_working_directory_unavailable";
     }
     return "workspace_agent.process_working_directory_unavailable";

--- a/src/security/workspace_agent_target_containment.cpp
+++ b/src/security/workspace_agent_target_containment.cpp
@@ -81,6 +81,12 @@ std::string diagnostic_for_failure(PhysicalPathContainmentFailure failure) {
         case PhysicalPathContainmentFailure::path_unavailable:
         case PhysicalPathContainmentFailure::size_limit_exceeded:
         case PhysicalPathContainmentFailure::read_failed:
+        // Never actually produced by inspect_physical_path_containment()
+        // (only revalidate_physical_path_containment_after_read() in
+        // physical_path_containment.cpp returns this), but the switch
+        // must stay exhaustive; listed here for that reason, not because
+        // this call site can observe it.
+        case PhysicalPathContainmentFailure::path_changed_after_read:
             return "workspace_agent.target_unavailable";
     }
     return "workspace_agent.target_unavailable";


### PR DESCRIPTION
## Summary
- Extracts the identical hand-rolled "handle-based read, then independent post-read path re-walk" pattern from `admit_launcher_artifact()` (#5426) and `admit_polyglot_supporting_artifact()` (#5427) into one shared primitive, `read_physically_contained_file_snapshot_from_handle_and_revalidate_path()`, in `physical_path_containment.{h,cpp}`.
- Preserves each caller's own single-shot test hook via an optional `post_read_hook` function-pointer parameter, fired between the read and the re-walk — the same injection point each hand-rolled version used — so the shared primitive doesn't depend on either caller's own test-hook build flag.
- Plain `read_physically_contained_file_snapshot_from_handle()` (no re-walk) is unchanged and still available for callers like #5421's that intentionally revalidate independently at use time.

## Behavior note
A minor, deliberate behavior change: the polyglot caller's post-read re-walk now runs before its SHA-256 comparison (matching the launcher caller's pre-existing order — the shared implementation had to pick one). In the theoretical case of both a hash mismatch and a mid-read rename occurring together, it now reports the rename (`artifact_changed`) instead of the hash mismatch. No existing regression test exercises that combination.

## Not addressed (per issue, lower priority)
The issue also asked to evaluate whether the shared design could avoid the redundant directory-walk syscalls (directory-iterator scan, handle-based open+verify, second open+verify for the re-walk). Left unchanged: the re-walk's independence from the initial check is what makes it a meaningful TOCTOU guard, so folding it back into the same walk would undermine the property this whole migration series exists to provide. Build-time-only, not attacker-adjacent, so not urgent.

## Test plan
- [x] `test_runtime_pipeline` (includes `test_launcher_artifact_admission_rejects_rename_during_read`) — passes
- [x] `test_polyglot_python_sidecar` (includes `test_supporting_artifact_admission_rejects_rename_during_read`) — passes
- [x] `test_polyglot_artifact_admission`, `test_workspace_agent_*`, `test_security_controls`, `test_generated_launcher_posix_process` — passes
- [x] Full local build (`cmake --build .`) — clean
- [x] Regression check: neutered the shared helper's re-walk, confirmed both callers' rename-during-read tests fail; restored, re-verified green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg