### PR TITLE
VS extension: stop silently swallowing cmd.exe launch refusals (#5446)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+- 2026-09-02: Fixed 6 VS extension call sites where `EnsureSafeForCmdExeCommandLine()`'s
+  (#5432) `InvalidOperationException` refusal was silently swallowed or left
+  unguarded, meaning the user saw a button do nothing with zero signal that
+  a launch was refused (issue #5446, found by multi-agent adversarial
+  review on PR #5445): `CopperfinAssetEditorControl.cs`'s
+  `QueueUiActionAsync` had an empty `catch (InvalidOperationException) {}`
+  (removed, so it now falls through to the existing generic handler that
+  surfaces a status label + MessageBox) and `LaunchStudio()` had no
+  try/catch around `CopperfinStudioHostBridge.Launch(...)` at all (added
+  one, using the existing `BuildUnexpectedFailureMessage()` pattern);
+  `OpenInCopperfinStudioCommand.cs`'s `ExecuteAsync` is invoked via a
+  discarded `JoinableTask`, so an uncaught exception there would never
+  surface anywhere (added a try/catch using the method's existing
+  `VsShellUtilities.ShowMessageBox` pattern);
+  `CopperfinProjectWorkflow.cs`'s `RunProcess()`/`StartProcess()` and
+  `CopperfinRuntimeDebugClient.cs`'s `StartPersistentAsync()`/`ReplayAsync()`
+  all called `CreateProcessStartInfo`-family methods before their own try
+  blocks (wrapped each in try/catch, routing into each function's existing
+  reported-failure shape, reusing already-existing locale keys throughout --
+  no new strings needed); `CopperfinStudioSnapshotClient.cs`'s `RunCommand()`
+  (called from ~7 sibling methods) and
+  `CopperfinWorkspaceAgentPolicyClient.cs`'s `TryLoad()` had the identical
+  gap (found by a later Copilot pass on the same PR), fixed the same way.
+  `CopperfinProjectCommands.cs` needed no direct change: its call chain
+  routes entirely through the now-fixed `CopperfinProjectWorkflow.cs`
+  methods. Verified via full local build (`Copperfin.LanguageServiceTests.csproj`,
+  net10.0, and `Copperfin.DesignerSmokeTests.csproj`, net472 -- both
+  buildable on Linux; the full `Copperfin.VisualStudio.csproj` requires the
+  Windows-only VSSDK build tools and could not be locally verified beyond
+  compilation of its constituent source files through those two other
+  projects) plus the full existing `Copperfin.LanguageServiceTests` suite
+  passing unchanged.
+
 - 2026-09-02: A Codex/Copilot review pass on PR #5445 (issue #5432) found
   `EnsureSafeForCmdExeCommandLine()`'s round-2 `%`-unconditional fix
   (below) still gated CR/LF rejection behind `insideQuotes`, the same

--- a/vsix/Copperfin.VisualStudio/CopperfinAssetEditorControl.cs
+++ b/vsix/Copperfin.VisualStudio/CopperfinAssetEditorControl.cs
@@ -3767,9 +3767,22 @@ internal sealed partial class CopperfinAssetEditorControl : UserControl
             return;
         }
 
-        if (!CopperfinStudioHostBridge.Launch(studioHostPath, currentPath!, localization: localization))
+        try
         {
-            MessageBox.Show(this, BuildStudioLaunchFailedMessage(), DialogTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            if (!CopperfinStudioHostBridge.Launch(studioHostPath, currentPath!, localization: localization))
+            {
+                MessageBox.Show(this, BuildStudioLaunchFailedMessage(), DialogTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            // CreateProcessStartInfo()'s EnsureSafeForCmdExeCommandLine() (#5432)
+            // throws instead of returning false when it refuses a launch, so
+            // this must be caught here too -- otherwise the refusal propagates
+            // unhandled out of this synchronous WinForms click handler instead
+            // of the graceful MessageBox pattern every other failure mode in
+            // this method already uses (issue #5446).
+            MessageBox.Show(this, BuildUnexpectedFailureMessage(ex.Message), DialogTitle, MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
     }
 
@@ -3923,14 +3936,18 @@ internal sealed partial class CopperfinAssetEditorControl : UserControl
         catch (ObjectDisposedException)
         {
         }
-        catch (InvalidOperationException)
-        {
-        }
         catch (System.ComponentModel.Win32Exception)
         {
         }
         catch (Exception ex)
         {
+            // InvalidOperationException used to be swallowed silently here
+            // too, on the assumption it was always a benign control-state
+            // race like the ObjectDisposedException/Win32Exception cases
+            // above. Since #5432, CreateProcessStartInfo() also throws it
+            // to refuse an unsafe launch -- a real security event that must
+            // not vanish with zero user-visible or logged signal, so it now
+            // falls through to this generic handler instead (issue #5446).
             if (IsDisposed || Disposing || snapshotStatusLabel.IsDisposed)
             {
                 return;

--- a/vsix/Copperfin.VisualStudio/CopperfinProjectWorkflow.cs
+++ b/vsix/Copperfin.VisualStudio/CopperfinProjectWorkflow.cs
@@ -268,13 +268,33 @@ internal static class CopperfinProjectWorkflow
         CopperfinLocalization? localization = null)
     {
         localization ??= CopperfinLocalization.FromEnvironment();
-        var startInfo = CreateProcessStartInfo(
-            fileName,
-            arguments,
-            environmentVariables,
-            localization,
-            redirectOutput: true,
-            createNoWindow: true);
+        ProcessStartInfo startInfo;
+        try
+        {
+            startInfo = CreateProcessStartInfo(
+                fileName,
+                arguments,
+                environmentVariables,
+                localization,
+                redirectOutput: true,
+                createNoWindow: true);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // CopperfinStudioHostBridge.CreateProcessStartInfo()'s
+            // EnsureSafeForCmdExeCommandLine() (#5432) throws instead of
+            // returning a normal failure result when it refuses a launch;
+            // route it through the same reported-failure shape this
+            // function already uses for every other "process could not
+            // start" case (issue #5446).
+            return new CopperfinProcessExecutionResult
+            {
+                ExitCode = -1,
+                StandardError = localization.Format(
+                    "AssetEditor.Project.Workflow.ProcessCouldNotStartWithMessage",
+                    ex.Message)
+            };
+        }
 
         var processResult = CopperfinProcessRunner.Run(startInfo);
         if (!processResult.Started)
@@ -342,11 +362,20 @@ internal static class CopperfinProjectWorkflow
         CopperfinLocalization? localization = null)
     {
         localization ??= CopperfinLocalization.FromEnvironment();
-        var startInfo = CreateProcessStartInfo(
-            fileName,
-            arguments,
-            localization: localization,
-            createNoWindow: true);
+        ProcessStartInfo startInfo;
+        try
+        {
+            startInfo = CreateProcessStartInfo(
+                fileName,
+                arguments,
+                localization: localization,
+                createNoWindow: true);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Same rationale as RunProcess() above (issue #5446).
+            return Failure(fileName, localization.Format("AssetEditor.Project.Workflow.LauncherCouldNotStartWithMessage", ex.Message));
+        }
 
         try
         {

--- a/vsix/Copperfin.VisualStudio/CopperfinRuntimeDebugClient.cs
+++ b/vsix/Copperfin.VisualStudio/CopperfinRuntimeDebugClient.cs
@@ -179,7 +179,22 @@ internal static class CopperfinRuntimeDebugClient
 
         var effectiveDebugManifestPath = PrepareReplayManifest(session.DebugManifestPath);
         var arguments = BuildPersistentArguments(effectiveDebugManifestPath, localization.Locale);
-        var startInfo = CreatePersistentProcessStartInfo(runtimeHostPath!, arguments, localization);
+        ProcessStartInfo startInfo;
+        try
+        {
+            startInfo = CreatePersistentProcessStartInfo(runtimeHostPath!, arguments, localization);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // CreatePersistentProcessStartInfo()'s EnsureSafeForCmdExeCommandLine()
+            // (#5432) throws instead of returning a normal failure result when it
+            // refuses a launch; route it through the same reported-failure shape
+            // this method already uses for a missing runtime host (issue #5446).
+            TryDeleteReplayManifest(session.DebugManifestPath, effectiveDebugManifestPath);
+            session.Success = false;
+            session.Error = localization.Format("AssetEditor.Dialog.RuntimeHostCouldNotStartWithMessage", ex.Message);
+            return session;
+        }
         var transport = await Task.Run(() => CopperfinRuntimeDebugTransport.Start(
             startInfo,
             timeoutMilliseconds: 30000,
@@ -296,10 +311,9 @@ internal static class CopperfinRuntimeDebugClient
                 session.Commands,
                 session.StopOnEntry);
 
-            var startInfo = CreateReplayProcessStartInfo(runtimeHostPath!, arguments, localization);
-
             try
             {
+                var startInfo = CreateReplayProcessStartInfo(runtimeHostPath!, arguments, localization);
                 var processResult = CopperfinProcessRunner.Run(startInfo, timeoutMilliseconds: 30000);
                 if (!processResult.Started)
                 {
@@ -340,6 +354,17 @@ internal static class CopperfinRuntimeDebugClient
                 session.Success = true;
                 session.Error = string.Empty;
                 session.State = pauseState;
+                return session;
+            }
+            catch (InvalidOperationException ex)
+            {
+                // CreateReplayProcessStartInfo()'s EnsureSafeForCmdExeCommandLine()
+                // (#5432) throws instead of returning a normal failure result when
+                // it refuses a launch; route it through the same reported-failure
+                // shape this method already uses for every other "runtime host
+                // could not start" case (issue #5446).
+                session.Success = false;
+                session.Error = localization.Format("AssetEditor.Dialog.RuntimeHostCouldNotStartWithMessage", ex.Message);
                 return session;
             }
             finally

--- a/vsix/Copperfin.VisualStudio/CopperfinStudioSnapshotClient.cs
+++ b/vsix/Copperfin.VisualStudio/CopperfinStudioSnapshotClient.cs
@@ -52,12 +52,30 @@ internal static class CopperfinStudioSnapshotClient
         CopperfinLocalization localization,
         bool allowNonZeroExit = false)
     {
-        var startInfo = CopperfinStudioHostBridge.CreateProcessStartInfo(
-            studioHostPath,
-            arguments,
-            localization: localization,
-            redirectOutput: true,
-            createNoWindow: true);
+        ProcessStartInfo startInfo;
+        try
+        {
+            startInfo = CopperfinStudioHostBridge.CreateProcessStartInfo(
+                studioHostPath,
+                arguments,
+                localization: localization,
+                redirectOutput: true,
+                createNoWindow: true);
+        }
+        catch (InvalidOperationException)
+        {
+            // EnsureSafeForCmdExeCommandLine() (#5432) throws instead of
+            // returning a normal failure result when it refuses a launch;
+            // route it through this function's existing StudioHostCommandResult
+            // failure shape, which every one of its ~7 callers already checks
+            // via commandResult.Success, so this single fix covers all of them
+            // (issue #5446).
+            return new StudioHostCommandResult
+            {
+                Success = false,
+                Error = localization.Text("AssetEditor.Dialog.StudioHostCouldNotStart")
+            };
+        }
 
         var processResult = CopperfinProcessRunner.Run(startInfo, timeoutMilliseconds: 15000);
         if (!processResult.Started)

--- a/vsix/Copperfin.VisualStudio/CopperfinWorkspaceAgentPolicyClient.cs
+++ b/vsix/Copperfin.VisualStudio/CopperfinWorkspaceAgentPolicyClient.cs
@@ -27,12 +27,24 @@ internal static class CopperfinWorkspaceAgentPolicyClient
             return Failure(HostMissing, localization.Text("AssetEditor.Dialog.StudioHostMissing"));
         }
 
-        var startInfo = CopperfinStudioHostBridge.CreateProcessStartInfo(
-            studioHostPath!,
-            CopperfinStudioHostBridge.BuildWorkspaceAgentPolicyArguments(),
-            localization: localization,
-            redirectOutput: true,
-            createNoWindow: true);
+        System.Diagnostics.ProcessStartInfo startInfo;
+        try
+        {
+            startInfo = CopperfinStudioHostBridge.CreateProcessStartInfo(
+                studioHostPath!,
+                CopperfinStudioHostBridge.BuildWorkspaceAgentPolicyArguments(),
+                localization: localization,
+                redirectOutput: true,
+                createNoWindow: true);
+        }
+        catch (InvalidOperationException)
+        {
+            // EnsureSafeForCmdExeCommandLine() (#5432) throws instead of
+            // returning a normal failure result when it refuses a launch;
+            // route it through this method's existing Failure(...) shape
+            // (issue #5446).
+            return Failure(HostFailed, localization.Text("AssetEditor.Dialog.StudioHostCouldNotStart"));
+        }
         var processResult = CopperfinProcessRunner.Run(startInfo, timeoutMilliseconds: 15000);
         if (!processResult.Started)
         {

--- a/vsix/Copperfin.VisualStudio/OpenInCopperfinStudioCommand.cs
+++ b/vsix/Copperfin.VisualStudio/OpenInCopperfinStudioCommand.cs
@@ -94,11 +94,31 @@ internal sealed class OpenInCopperfinStudioCommand
             return;
         }
 
-        if (!CopperfinStudioHostBridge.Launch(studioHostPath, documentPath!, localization: Localization))
+        try
         {
+            if (!CopperfinStudioHostBridge.Launch(studioHostPath, documentPath!, localization: Localization))
+            {
+                VsShellUtilities.ShowMessageBox(
+                    package,
+                    Localization.Text("AssetEditor.Dialog.StudioLaunchFailed"),
+                    Localization.Text("AssetEditor.Title"),
+                    OLEMSGICON.OLEMSGICON_WARNING,
+                    OLEMSGBUTTON.OLEMSGBUTTON_OK,
+                    OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST);
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            // CreateProcessStartInfo()'s EnsureSafeForCmdExeCommandLine()
+            // (#5432) throws instead of returning false when it refuses a
+            // launch. This method is invoked via a discarded JoinableTask
+            // (`_ = package.JoinableTaskFactory.RunAsync(...)` in AddCommand
+            // below), so an uncaught exception here would never surface
+            // anywhere -- catch it and use the same ShowMessageBox pattern
+            // as every other failure mode in this method (issue #5446).
             VsShellUtilities.ShowMessageBox(
                 package,
-                Localization.Text("AssetEditor.Dialog.StudioLaunchFailed"),
+                Localization.Format("AssetEditor.Dialog.UnexpectedFailure", ex.Message),
                 Localization.Text("AssetEditor.Title"),
                 OLEMSGICON.OLEMSGICON_WARNING,
                 OLEMSGBUTTON.OLEMSGBUTTON_OK,


### PR DESCRIPTION
## Summary
`EnsureSafeForCmdExeCommandLine()` (#5432) throws `InvalidOperationException` to refuse an unsafe `.cmd`/`.bat` Studio host launch. 6 call sites either swallowed it silently or left it unguarded, meaning a real (or attempted) injection refusal produced zero user-visible or logged signal — worse UX than before #5432, and no audit trail for a genuine attack attempt.

Fixed each by routing into the existing failure-reporting pattern already used by that method for its other failure modes — no new abstractions, no new locale strings:

- `CopperfinAssetEditorControl.cs`: `QueueUiActionAsync`'s empty `catch (InvalidOperationException) {}` removed, falls through to the existing generic handler (status label + MessageBox). `LaunchStudio()` gained a try/catch using `BuildUnexpectedFailureMessage()`.
- `OpenInCopperfinStudioCommand.cs`: `ExecuteAsync` (invoked via a discarded `JoinableTask`, so an uncaught exception here would never surface at all) gained a try/catch using its existing `VsShellUtilities.ShowMessageBox` pattern.
- `CopperfinProjectWorkflow.cs`: `RunProcess()`/`StartProcess()` now catch at the `CreateProcessStartInfo` call and return their existing failure-result shapes.
- `CopperfinRuntimeDebugClient.cs`: `StartPersistentAsync()`/`ReplayAsync()` — same pattern, existing `RuntimeHostCouldNotStartWithMessage` locale key.
- `CopperfinStudioSnapshotClient.cs`: `RunCommand()` — a single fix here covers all ~7 sibling callers, since they all already check `commandResult.Success`.
- `CopperfinWorkspaceAgentPolicyClient.cs`: `TryLoad()` — existing `Failure(...)` shape.
- `CopperfinProjectCommands.cs` needed no direct change: its call chain routes entirely through the now-fixed `CopperfinProjectWorkflow.cs` methods.

## Test plan
- [x] `Copperfin.LanguageServiceTests.csproj` (net10.0, includes `CopperfinProjectWorkflow.cs` and `CopperfinRuntimeDebugClient.cs`) — builds clean, full suite passes unchanged
- [x] `Copperfin.DesignerSmokeTests.csproj` (net472, includes `CopperfinAssetEditorControl.cs`, `CopperfinStudioSnapshotClient.cs`, `CopperfinWorkspaceAgentPolicyClient.cs`) — builds clean
- [ ] `Copperfin.VisualStudio.csproj` (includes `OpenInCopperfinStudioCommand.cs`) requires the Windows-only VSSDK build tools and can't be built on this Linux dev box; Windows CI is the verification gate for that file specifically. All other affected files are covered by the two projects above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg