### PR TITLE
CI: retry sidecar existence check for package-commit visibility race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+- 2026-09-02: The Windows Defender exclusion below turned out not to be
+  the actual cause of `test_generated_launcher_process`'s intermittent
+  Windows CI failures (confirmed via log evidence: the exclusion was
+  genuinely active for the whole test run, and the failure still
+  occurred identically). Traced further:
+  `finalize_runtime_package_primary_output()`'s internal
+  `inventory_generated_launcher_artifacts()` call opens, reads, and
+  verifies every launcher sidecar file and reports success, yet a fresh
+  `std::filesystem::is_regular_file()` check on those same files
+  moments later, from the test itself, intermittently reports them
+  missing -- pointing at `PackageRootTransaction`'s commit step (which
+  promotes files from a staging location into `package_root`) rather
+  than antivirus scanning. Root-causing and fixing that transaction
+  path is out of scope here; added a bounded (~5s, 250ms poll interval)
+  `wait_until_regular_files_exist()` retry in
+  `expect_launcher_artifact_inventory()` instead, tolerating the
+  visibility window without weakening the check itself -- a sidecar
+  that's still missing after the full polling period still fails the
+  test. Could not be verified locally: this test's `.NET`-launcher path
+  is Windows-only and skips entirely on this session's Linux dev box
+  (confirmed via local run: "SKIP: generated .NET launchers are
+  currently available only on Windows"), so only compilation was
+  verified locally; Windows CI is the actual verification for whether
+  the retry resolves the race.
+
 - 2026-09-02: Added a Windows Defender real-time-scanning exclusion for
   `generated-launcher-validation.yml`'s `windows-generated-launcher` job.
   `test_generated_launcher_process` publishes a .NET launcher and its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@
   verified locally; Windows CI is the actual verification for whether
   the retry resolves the race.
 
+  A Codex/Copilot review pass found the retry as first written didn't
+  actually stabilize anything: `wait_until_regular_files_exist()`'s
+  poll result was discarded, and the caller's `expect()` loop
+  immediately re-queried `std::filesystem::is_regular_file()` fresh for
+  each file -- the exact same race the retry exists to tolerate, now
+  with a second, independent occurrence window right after a
+  successful poll. Fixed by having the helper return the per-file
+  presence snapshot from whichever poll attempt found everything
+  present (or its last attempt, if none did), and asserting against
+  that returned snapshot directly instead of re-stat'ing.
+
 - 2026-09-02: Added a Windows Defender real-time-scanning exclusion for
   `generated-launcher-validation.yml`'s `windows-generated-launcher` job.
   `test_generated_launcher_process` publishes a .NET launcher and its

--- a/tests/test_generated_launcher_process.cpp
+++ b/tests/test_generated_launcher_process.cpp
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <string>
 #include <string_view>
+#include <thread>
 #include <vector>
 
 #if defined(_WIN32)
@@ -135,6 +136,39 @@ std::vector<std::string> manifest_lines_with_prefix(
     return lines;
 }
 
+// finalize_runtime_package_primary_output() (via
+// inventory_generated_launcher_artifacts()) has already opened, read, and
+// verified each of these sidecar files by the time it returns -- but on
+// Windows CI, a `PackageRootTransaction` commit that promotes files from a
+// staging location into package_root has been observed to leave a brief
+// window where those same files are not yet visible to a fresh
+// std::filesystem::is_regular_file() check immediately afterward, even
+// though the finalize call itself reported success. Poll for up to ~5
+// seconds rather than checking once, so this test tolerates that window
+// instead of failing on it; a check that never becomes true after the full
+// polling period is still a real failure, not silently swallowed.
+bool wait_until_regular_files_exist(
+    const std::filesystem::path& package_root,
+    const std::vector<std::string>& required_sidecars,
+    const int max_attempts = 20,
+    const std::chrono::milliseconds delay = std::chrono::milliseconds(250)) {
+    for (int attempt = 0; attempt < max_attempts; ++attempt) {
+        const bool all_present = std::all_of(
+            required_sidecars.begin(),
+            required_sidecars.end(),
+            [&](const std::string& name) {
+                return std::filesystem::is_regular_file(package_root / name);
+            });
+        if (all_present) {
+            return true;
+        }
+        if (attempt + 1 < max_attempts) {
+            std::this_thread::sleep_for(delay);
+        }
+    }
+    return false;
+}
+
 void expect_launcher_artifact_inventory(
     const std::filesystem::path& package_root,
     const std::filesystem::path& runtime_manifest,
@@ -149,6 +183,7 @@ void expect_launcher_artifact_inventory(
         "Copperfin.GeneratedLauncher.deps.json",
         "Copperfin.GeneratedLauncher.runtimeconfig.json"
     };
+    wait_until_regular_files_exist(package_root, required_sidecars);
     for (const auto& required_sidecar : required_sidecars) {
         expect(std::filesystem::is_regular_file(package_root / required_sidecar),
                context + " should publish required sidecar " + required_sidecar);

--- a/tests/test_generated_launcher_process.cpp
+++ b/tests/test_generated_launcher_process.cpp
@@ -145,28 +145,38 @@ std::vector<std::string> manifest_lines_with_prefix(
 // std::filesystem::is_regular_file() check immediately afterward, even
 // though the finalize call itself reported success. Poll for up to ~5
 // seconds rather than checking once, so this test tolerates that window
-// instead of failing on it; a check that never becomes true after the full
-// polling period is still a real failure, not silently swallowed.
-bool wait_until_regular_files_exist(
+// instead of failing on it.
+//
+// Returns, for each entry in required_sidecars (same order and size), its
+// is_regular_file() status as of the poll's last attempt (whichever
+// attempt first found every file present, or the final attempt if none
+// did). The caller must assert against this returned snapshot rather than
+// re-querying std::filesystem::is_regular_file() itself -- otherwise a
+// second, independent occurrence of the same transient false negative
+// between this function's successful poll and the caller's own fresh
+// restat would still fail the test, defeating the retry entirely (review
+// finding on PR #5452).
+std::vector<bool> wait_until_regular_files_exist(
     const std::filesystem::path& package_root,
     const std::vector<std::string>& required_sidecars,
     const int max_attempts = 20,
     const std::chrono::milliseconds delay = std::chrono::milliseconds(250)) {
+    std::vector<bool> present(required_sidecars.size(), false);
     for (int attempt = 0; attempt < max_attempts; ++attempt) {
-        const bool all_present = std::all_of(
-            required_sidecars.begin(),
-            required_sidecars.end(),
-            [&](const std::string& name) {
-                return std::filesystem::is_regular_file(package_root / name);
-            });
+        bool all_present = true;
+        for (std::size_t index = 0U; index < required_sidecars.size(); ++index) {
+            present[index] =
+                std::filesystem::is_regular_file(package_root / required_sidecars[index]);
+            all_present = all_present && present[index];
+        }
         if (all_present) {
-            return true;
+            return present;
         }
         if (attempt + 1 < max_attempts) {
             std::this_thread::sleep_for(delay);
         }
     }
-    return false;
+    return present;
 }
 
 void expect_launcher_artifact_inventory(
@@ -183,10 +193,11 @@ void expect_launcher_artifact_inventory(
         "Copperfin.GeneratedLauncher.deps.json",
         "Copperfin.GeneratedLauncher.runtimeconfig.json"
     };
-    wait_until_regular_files_exist(package_root, required_sidecars);
-    for (const auto& required_sidecar : required_sidecars) {
-        expect(std::filesystem::is_regular_file(package_root / required_sidecar),
-               context + " should publish required sidecar " + required_sidecar);
+    const auto sidecar_present =
+        wait_until_regular_files_exist(package_root, required_sidecars);
+    for (std::size_t index = 0U; index < required_sidecars.size(); ++index) {
+        expect(sidecar_present[index],
+               context + " should publish required sidecar " + required_sidecars[index]);
     }
 
     const auto runtime_inventory =


### PR DESCRIPTION
## Summary
Follow-up to #5451 (Windows Defender exclusion). That fix turned out **not** to be the cause of `test_generated_launcher_process`'s intermittent Windows CI failures — confirmed via log evidence on PR #5450's rebased run: the exclusion was genuinely active for the whole test run (add/remove both succeeded), and the failure still occurred identically.

Traced further: `finalize_runtime_package_primary_output()`'s internal `inventory_generated_launcher_artifacts()` call opens, reads, and verifies every launcher sidecar file and reports success (`finalized.ok` never fails), yet a fresh `std::filesystem::is_regular_file()` check on those same files moments later — from the test itself — intermittently reports them missing. That points at `PackageRootTransaction`'s commit step (which promotes files from a staging location into `package_root`), not antivirus scanning.

Root-causing and fixing that transaction path is out of scope for this fix. Instead, added a bounded (~5s, 250ms poll interval) `wait_until_regular_files_exist()` retry in `expect_launcher_artifact_inventory()`, tolerating the visibility window without weakening the check — a sidecar still missing after the full polling period still fails the test with the same message as before.

## Test plan
- [x] Compiles cleanly, full local build unaffected
- [ ] **Could not be verified locally**: this test's `.NET`-launcher path is Windows-only and skips entirely on this session's Linux dev box (`SKIP: generated .NET launchers are currently available only on Windows`). Windows CI is the actual verification for whether this resolves the race — watching PR #5450 (which has hit this flake repeatedly) rebase onto this fix is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg