### PR TITLE
Bind external-process verification to a single held file handle (fixes #5454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+- 2026-09-03: Closed an ABA-swap gap in `authorize_external_process()`'s
+  Windows TOCTOU mitigation (#5454), found by Codex and Copilot review of
+  PR #5450. The #5430 fix compared a file identity read before
+  verification against one read after, but each of the three checks
+  (pre-identity, `WinVerifyTrust()`, post-identity) independently reopened
+  the resolved executable by path string -- an attacker could swap in a
+  trusted, signed binary for `WinVerifyTrust()` to verify, then swap the
+  original back before the final identity read, so both identity reads
+  matched while verification had actually run against a different file.
+  Fixed by opening the executable once, sharing read access but denying
+  write/delete sharing to other openers, for the entire duration of
+  verification and identity capture: `WinVerifyTrust()` now verifies
+  through that held handle (`WINTRUST_FILE_INFO::hFile`) rather than
+  reopening by path, and identity is derived from the same handle via
+  `GetFileInformationByHandle()`. This prevents the swap outright (a
+  rename/replace attempt against that path fails with a sharing
+  violation while the handle is open) instead of only detecting it after
+  the fact, so the separate pre/post identity compare is no longer
+  needed for this window. `revalidate_external_process_authorization()`'s
+  path-based recheck immediately before launch is unchanged -- by then
+  the handle has been released, and that check exists specifically to
+  catch changes in the (much smaller) gap between authorization and
+  spawn.
 - 2026-09-02: Hardened `authorize_external_process()`'s Windows path in two
   related ways found by Codex security review:
   - **Issue #5429**: `allowed_publishers` was matched against

--- a/resources/locales/en-US/strings.json
+++ b/resources/locales/en-US/strings.json
@@ -1259,7 +1259,6 @@
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "Executable path is outside allowed roots.",
   "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "No allowed path roots are configured; the policy denies all paths.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "The authorized executable changed before launch.",
-  "Security.ExternalProcessPolicy.Error.ExecutableChangedDuringAuthorization": "The executable changed while authorization checks were in progress.",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "Executable publisher is not in the allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "Unable to resolve executable on PATH: {executableName}",
   "Security.ExternalProcessPolicy.Error.UntrustedAuthenticodeSignature": "Executable does not have a trusted Authenticode signature.",

--- a/resources/locales/en-US/strings.json
+++ b/resources/locales/en-US/strings.json
@@ -1259,6 +1259,7 @@
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "Executable path is outside allowed roots.",
   "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "No allowed path roots are configured; the policy denies all paths.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "The authorized executable changed before launch.",
+  "Security.ExternalProcessPolicy.Error.ExecutableLockedDuringAuthorization": "Unable to open executable for verification, likely because another process holds it open: {executableName}",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "Executable publisher is not in the allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "Unable to resolve executable on PATH: {executableName}",
   "Security.ExternalProcessPolicy.Error.UntrustedAuthenticodeSignature": "Executable does not have a trusted Authenticode signature.",

--- a/resources/locales/es-419/strings.json
+++ b/resources/locales/es-419/strings.json
@@ -486,7 +486,6 @@
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "La ruta del ejecutable esta fuera de las raices permitidas.",
   "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "No hay raices de rutas permitidas configuradas; la politica deniega todas las rutas.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "El ejecutable autorizado cambio antes del inicio.",
-  "Security.ExternalProcessPolicy.Error.ExecutableChangedDuringAuthorization": "El ejecutable cambio mientras las verificaciones de autorizacion estaban en curso.",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "El publisher del ejecutable no esta en la allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "No se pudo resolver el ejecutable en PATH: {executableName}",
   "Security.ExternalProcessPolicy.Error.UntrustedAuthenticodeSignature": "El ejecutable no tiene una firma Authenticode confiable.",

--- a/resources/locales/es-419/strings.json
+++ b/resources/locales/es-419/strings.json
@@ -486,6 +486,7 @@
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "La ruta del ejecutable esta fuera de las raices permitidas.",
   "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "No hay raices de rutas permitidas configuradas; la politica deniega todas las rutas.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "El ejecutable autorizado cambio antes del inicio.",
+  "Security.ExternalProcessPolicy.Error.ExecutableLockedDuringAuthorization": "No se pudo abrir el ejecutable para verificacion, probablemente porque otro proceso lo tiene abierto: {executableName}",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "El publisher del ejecutable no esta en la allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "No se pudo resolver el ejecutable en PATH: {executableName}",
   "Security.ExternalProcessPolicy.Error.UntrustedAuthenticodeSignature": "El ejecutable no tiene una firma Authenticode confiable.",

--- a/resources/locales/pt-BR/strings.json
+++ b/resources/locales/pt-BR/strings.json
@@ -486,6 +486,7 @@
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "O caminho do executavel esta fora das raizes permitidas.",
   "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "Nenhuma raiz de caminho permitida esta configurada; a politica nega todos os caminhos.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "O executavel autorizado mudou antes da inicializacao.",
+  "Security.ExternalProcessPolicy.Error.ExecutableLockedDuringAuthorization": "Nao foi possivel abrir o executavel para verificacao, provavelmente porque outro processo o mantem aberto: {executableName}",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "O publisher do executavel nao esta na allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "Nao foi possivel resolver o executavel no PATH: {executableName}",
   "Security.ExternalProcessPolicy.Error.UntrustedAuthenticodeSignature": "O executavel nao possui uma assinatura Authenticode confiavel.",

--- a/resources/locales/pt-BR/strings.json
+++ b/resources/locales/pt-BR/strings.json
@@ -486,7 +486,6 @@
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "O caminho do executavel esta fora das raizes permitidas.",
   "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "Nenhuma raiz de caminho permitida esta configurada; a politica nega todos os caminhos.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "O executavel autorizado mudou antes da inicializacao.",
-  "Security.ExternalProcessPolicy.Error.ExecutableChangedDuringAuthorization": "O executavel mudou enquanto as verificacoes de autorizacao estavam em andamento.",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "O publisher do executavel nao esta na allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "Nao foi possivel resolver o executavel no PATH: {executableName}",
   "Security.ExternalProcessPolicy.Error.UntrustedAuthenticodeSignature": "O executavel nao possui uma assinatura Authenticode confiavel.",

--- a/resources/locales/qps-ploc/strings.json
+++ b/resources/locales/qps-ploc/strings.json
@@ -486,7 +486,6 @@
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "Executable path is outside allowed roots.",
   "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "No allowed path roots are configured; the policy denies all paths.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "The authorized executable changed before launch.",
-  "Security.ExternalProcessPolicy.Error.ExecutableChangedDuringAuthorization": "The executable changed while authorization checks were in progress.",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "Executable publisher is not in the allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "Unable to resolve executable on PATH: {executableName}",
   "Security.ExternalProcessPolicy.Error.UntrustedAuthenticodeSignature": "Executable does not have a trusted Authenticode signature.",

--- a/resources/locales/qps-ploc/strings.json
+++ b/resources/locales/qps-ploc/strings.json
@@ -486,6 +486,7 @@
   "Security.ExternalProcessPolicy.Error.PathOutsideAllowedRoots": "Executable path is outside allowed roots.",
   "Security.ExternalProcessPolicy.Error.EmptyAllowedPathRoots": "No allowed path roots are configured; the policy denies all paths.",
   "Security.ExternalProcessPolicy.Error.ExecutableChangedAfterAuthorization": "The authorized executable changed before launch.",
+  "Security.ExternalProcessPolicy.Error.ExecutableLockedDuringAuthorization": "Unable to open executable for verification, likely because another process holds it open: {executableName}",
   "Security.ExternalProcessPolicy.Error.PublisherNotAllowed": "Executable publisher is not in the allow-list.",
   "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed": "Unable to resolve executable on PATH: {executableName}",
   "Security.ExternalProcessPolicy.Error.UntrustedAuthenticodeSignature": "Executable does not have a trusted Authenticode signature.",

--- a/src/security/external_process_policy.cpp
+++ b/src/security/external_process_policy.cpp
@@ -61,6 +61,15 @@ bool read_file_identity(
     const std::filesystem::path& path,
     ExternalProcessFileIdentity& identity) {
 #ifdef _WIN32
+    // Deliberately follows reparse points (no FILE_FLAG_OPEN_REPARSE_POINT)
+    // so this agrees with open_executable_exclusive_of_writers()'s default
+    // CreateFileW behavior below: both derive identity from the resolved
+    // target of a symlink/junction, not the link object itself. Using
+    // different semantics in the two places let identity captured during
+    // authorization (from the handle) permanently disagree with identity
+    // read here during the later pre-launch revalidation, for any
+    // resolved_path that happened to be a reparse point (issue #5455
+    // review).
     const std::wstring wide_path = path.wstring();
     const HANDLE handle = CreateFileW(
         wide_path.c_str(),
@@ -68,7 +77,7 @@ bool read_file_identity(
         FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
         nullptr,
         OPEN_EXISTING,
-        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+        FILE_ATTRIBUTE_NORMAL,
         nullptr);
     if (handle == INVALID_HANDLE_VALUE) {
         return false;
@@ -126,6 +135,23 @@ bool identity_from_handle(HANDLE handle, ExternalProcessFileIdentity& identity) 
 
 struct ScopedHandle {
     HANDLE handle = INVALID_HANDLE_VALUE;
+
+    explicit ScopedHandle(HANDLE value) : handle(value) {}
+    ScopedHandle(const ScopedHandle&) = delete;
+    ScopedHandle& operator=(const ScopedHandle&) = delete;
+    ScopedHandle(ScopedHandle&& other) noexcept : handle(other.handle) {
+        other.handle = INVALID_HANDLE_VALUE;
+    }
+    ScopedHandle& operator=(ScopedHandle&& other) noexcept {
+        if (this != &other) {
+            if (handle != INVALID_HANDLE_VALUE) {
+                CloseHandle(handle);
+            }
+            handle = other.handle;
+            other.handle = INVALID_HANDLE_VALUE;
+        }
+        return *this;
+    }
     ~ScopedHandle() {
         if (handle != INVALID_HANDLE_VALUE) {
             CloseHandle(handle);
@@ -515,10 +541,15 @@ ExternalProcessAuthorizationResult authorize_external_process(const ExternalProc
     const HANDLE verification_handle =
         open_executable_exclusive_of_writers(executable_path.wstring());
     if (verification_handle == INVALID_HANDLE_VALUE) {
+        // Distinct from ResolveExecutableOnPathFailed: the executable was
+        // found on PATH just fine, but couldn't be opened for the
+        // exclusive duration of verification -- most commonly because
+        // another process holds it open with an incompatible share mode
+        // (issue #5455 review).
         return {.allowed = false,
                 .resolved_path = resolved_path,
                 .error = security_text(
-                    "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed",
+                    "Security.ExternalProcessPolicy.Error.ExecutableLockedDuringAuthorization",
                     {{"executableName", policy.executable_name}}),
                 .file_identity = {}};
     }

--- a/src/security/external_process_policy.cpp
+++ b/src/security/external_process_policy.cpp
@@ -105,6 +105,69 @@ bool file_identities_equal(
 }
 
 #ifdef _WIN32
+// Derives identity from an already-open handle rather than performing a
+// fresh path-string lookup -- used where the caller needs the identity of
+// the exact file object it is already holding open (issue #5454), as
+// opposed to read_file_identity() above, which is for callers that only
+// have a path (e.g. the pre-launch revalidation check, which by design
+// runs after any handle from authorization has been released).
+bool identity_from_handle(HANDLE handle, ExternalProcessFileIdentity& identity) {
+    BY_HANDLE_FILE_INFORMATION information{};
+    if (!GetFileInformationByHandle(handle, &information) ||
+        (information.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0U) {
+        return false;
+    }
+
+    identity.first = information.dwVolumeSerialNumber;
+    identity.second = (static_cast<std::uint64_t>(information.nFileIndexHigh) << 32U) |
+        information.nFileIndexLow;
+    return true;
+}
+
+struct ScopedHandle {
+    HANDLE handle = INVALID_HANDLE_VALUE;
+    ~ScopedHandle() {
+        if (handle != INVALID_HANDLE_VALUE) {
+            CloseHandle(handle);
+        }
+    }
+};
+
+// Opens the resolved executable for the exclusive duration of
+// authorization, sharing read access with other readers (AV scanners,
+// the OS image loader, etc.) but denying write and delete sharing --
+// this actively prevents another process from replacing, deleting, or
+// renaming this specific path for as long as the handle stays open,
+// rather than merely detecting such a change after the fact (issue
+// #5454). Retries a bounded number of times only on a transient sharing
+// violation, since some other legitimate reader could momentarily hold
+// an incompatible handle (e.g. a repair/update tool); any other error,
+// or exhausting the retries, is treated as a hard failure -- fail
+// closed, not fail open.
+HANDLE open_executable_exclusive_of_writers(const std::wstring& wide_path) {
+    constexpr int max_attempts = 4;
+    for (int attempt = 0; attempt < max_attempts; ++attempt) {
+        const HANDLE handle = CreateFileW(
+            wide_path.c_str(),
+            GENERIC_READ,
+            FILE_SHARE_READ,
+            nullptr,
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_NORMAL,
+            nullptr);
+        if (handle != INVALID_HANDLE_VALUE) {
+            return handle;
+        }
+        if (GetLastError() != ERROR_SHARING_VIOLATION || attempt + 1 == max_attempts) {
+            return INVALID_HANDLE_VALUE;
+        }
+        Sleep(50);
+    }
+    return INVALID_HANDLE_VALUE;
+}
+#endif
+
+#ifdef _WIN32
 std::wstring widen(const std::string& value) {
     if (value.empty()) {
         return {};
@@ -229,13 +292,19 @@ bool extract_signer_display_name(HANDLE state_data, wchar_t (&buffer)[kSignerNam
     }
 }
 
-AuthenticodeVerificationResult verify_authenticode_signature(const std::string& path) {
+// file_handle binds verification to the exact file object the caller
+// already holds open (via open_executable_exclusive_of_writers()) rather
+// than letting WinVerifyTrust reopen path independently -- path is still
+// supplied for subject-type/extension resolution, but hFile overrides it
+// for the actual file access (issue #5454).
+AuthenticodeVerificationResult verify_authenticode_signature(const std::string& path, HANDLE file_handle) {
     AuthenticodeVerificationResult result;
     const std::wstring wide_path = copperfin::platform::path_from_utf8_string(path).wstring();
 
     WINTRUST_FILE_INFO file_info{};
     file_info.cbStruct = sizeof(file_info);
     file_info.pcwszFilePath = wide_path.c_str();
+    file_info.hFile = file_handle;
 
     WINTRUST_DATA trust_data{};
     trust_data.cbStruct = sizeof(trust_data);
@@ -430,17 +499,45 @@ ExternalProcessAuthorizationResult authorize_external_process(const ExternalProc
                 .file_identity = {}};
     }
 
-    // Capture the file identity here, before signature/publisher
-    // verification, so a rename/replace of the executable at any point
-    // between this and the post-verification identity read below is
-    // detectable. Nothing otherwise binds verify_authenticode_signature()'s
-    // path-string open, and the final read_file_identity() call's own
-    // path-string open, to the same underlying file object -- an attacker
-    // who can replace the file at resolved_path in that window could pass
-    // verification against one binary while a different one is what this
-    // authorization actually ends up describing (issue #5430).
-    ExternalProcessFileIdentity pre_verification_identity;
-    if (!read_file_identity(executable_path, pre_verification_identity)) {
+    // Open the executable once, for the exclusive duration of every check
+    // below, sharing read access but denying write/delete sharing to
+    // other openers. This binds signature verification and identity to a
+    // single file object instead of reopening resolved_path by string at
+    // multiple points -- a path string can resolve to a *different*
+    // underlying file at each open, which let an attacker swap in a
+    // trusted binary for verification and swap the original back
+    // afterward (an ABA swap defeating the previous pre/post identity
+    // compare, which only bound the two identity reads to each other,
+    // not to what verification itself actually opened -- issue #5454,
+    // originally issue #5430). Holding this handle actively prevents
+    // that kind of replacement for as long as it stays open, rather than
+    // merely detecting it after the fact.
+    const HANDLE verification_handle =
+        open_executable_exclusive_of_writers(executable_path.wstring());
+    if (verification_handle == INVALID_HANDLE_VALUE) {
+        return {.allowed = false,
+                .resolved_path = resolved_path,
+                .error = security_text(
+                    "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed",
+                    {{"executableName", policy.executable_name}}),
+                .file_identity = {}};
+    }
+    const ScopedHandle verification_handle_guard{verification_handle};
+
+#if defined(COPPERFIN_ENABLE_EXTERNAL_PROCESS_POLICY_TEST_HOOKS)
+    // Fires with the handle already open and its write/delete-denying
+    // share mode already in effect, so a test hook attempting the same
+    // rename-and-replace attack this mitigates should observe that
+    // attempt fail (a sharing violation), not merely get detected after
+    // succeeding.
+    if (const auto hook = pre_identity_check_test_hook.exchange(nullptr, std::memory_order_relaxed);
+        hook != nullptr) {
+        hook();
+    }
+#endif
+
+    ExternalProcessFileIdentity identity;
+    if (!identity_from_handle(verification_handle, identity)) {
         return {.allowed = false,
                 .resolved_path = resolved_path,
                 .error = security_text(
@@ -457,7 +554,7 @@ ExternalProcessAuthorizationResult authorize_external_process(const ExternalProc
     const bool needs_signature_verification =
         policy.require_trusted_signature || !policy.allowed_publishers.empty();
     const AuthenticodeVerificationResult verification = needs_signature_verification
-        ? verify_authenticode_signature(resolved_path)
+        ? verify_authenticode_signature(resolved_path, verification_handle)
         : AuthenticodeVerificationResult{};
 
     if (policy.require_trusted_signature && !verification.trusted) {
@@ -492,33 +589,6 @@ ExternalProcessAuthorizationResult authorize_external_process(const ExternalProc
         }
     }
 
-#if defined(COPPERFIN_ENABLE_EXTERNAL_PROCESS_POLICY_TEST_HOOKS)
-    if (const auto hook = pre_identity_check_test_hook.exchange(nullptr, std::memory_order_relaxed);
-        hook != nullptr) {
-        hook();
-    }
-#endif
-
-    ExternalProcessFileIdentity identity;
-    if (!read_file_identity(executable_path, identity)) {
-        return {.allowed = false,
-                .resolved_path = resolved_path,
-                .error = security_text(
-                    "Security.ExternalProcessPolicy.Error.ResolveExecutableOnPathFailed",
-                    {{"executableName", policy.executable_name}}),
-                .file_identity = {}};
-    }
-    if (!file_identities_equal(identity, pre_verification_identity)) {
-        // The object the checks above verified is not the object this
-        // authorization would actually describe going forward: reject
-        // rather than silently trust a binary swapped in during
-        // verification (issue #5430).
-        return {.allowed = false,
-                .resolved_path = resolved_path,
-                .error = security_text(
-                    "Security.ExternalProcessPolicy.Error.ExecutableChangedDuringAuthorization"),
-                .file_identity = {}};
-    }
     return {.allowed = true,
             .resolved_path = resolved_path,
             .error = {},

--- a/tests/test_security_controls.cpp
+++ b/tests/test_security_controls.cpp
@@ -1056,10 +1056,14 @@ std::filesystem::path g_external_process_policy_swap_original;
 bool g_external_process_policy_swap_performed = false;
 
 void external_process_policy_pre_identity_check_test_hook() {
-    // Simulates an attacker replacing the resolved executable in the
-    // window authorize_external_process() leaves between capturing the
-    // pre-verification file identity and reading it again after the
-    // signature/publisher checks -- the exact race issue #5430 closed.
+    // Simulates an attacker attempting to replace the resolved executable
+    // right after authorize_external_process() opens it for the
+    // exclusive duration of verification (issue #5454). Unlike the
+    // original #5430 mitigation this replaces, that open's share mode
+    // denies write/delete sharing to other openers, so this rename
+    // should now *fail* -- the assertions below check that it does,
+    // proving the swap is prevented rather than merely detected
+    // after the fact.
     std::error_code rename_error;
     std::filesystem::path moved_aside = g_external_process_policy_swap_original;
     moved_aside += L".moved-aside";
@@ -1138,20 +1142,21 @@ void test_external_process_policy_rejects_executable_swapped_during_authorizatio
         SetEnvironmentVariableW(L"PATH", original_path.c_str());
     }
 
-    // Gracefully skip, like this codebase's other rename-during-check
-    // regression tests, rather than fail the suite when the environment
-    // doesn't permit the rename (e.g. a restricted sandbox).
-    if (g_external_process_policy_swap_performed) {
-        expect(!authorization.allowed,
-               "#5430: a resolved executable swapped during authorization checks must be "
-               "rejected, not silently authorized against the pre-swap object");
-        expect(
-            authorization.error ==
-                "The executable changed while authorization checks were in progress.",
-            "#5430: the swap-during-authorization rejection must use a diagnostic distinct "
-            "from the generic path-resolution/publisher-mismatch errors, so this outcome is "
-            "identifiable in logs");
-    }
+    // #5454: authorize_external_process() now holds the executable open
+    // (denying write/delete sharing) for the duration of verification,
+    // so the attempted swap itself must fail -- this is a stronger
+    // property than #5430's original "detect the swap after the fact"
+    // mitigation, which was vulnerable to an ABA swap (verify a
+    // different, trusted file, then swap the original back before the
+    // final identity check) that this handle-bound design closes by
+    // construction: there is only ever one file object in play.
+    expect(!g_external_process_policy_swap_performed,
+           "#5454: renaming/replacing the resolved executable while authorization holds it "
+           "open for verification must fail with a sharing violation, not merely be detected "
+           "after the fact");
+    expect(authorization.allowed,
+           "#5454: when the swap attempt is correctly blocked, authorization should proceed "
+           "normally against the original, untouched executable");
 
     std::error_code cleanup_error;
     fs::remove_all(temp_root, cleanup_error);


### PR DESCRIPTION
## Summary

- Fixes #5454, an ABA-swap gap in `authorize_external_process()`'s Windows TOCTOU mitigation, found by Codex and Copilot review on PR #5450 (their two review threads referenced this issue and were resolved in favor of it, tracked to be fixed here immediately).
- The #5430 fix compared a file identity read before verification against one read after, but each of the three checks (pre-identity, `WinVerifyTrust()`, post-identity) independently reopened the resolved executable by path string -- an attacker able to write to the executable's directory could swap in a legitimately signed file for verification, then swap the original back before the final identity read, passing both identity checks while verification actually ran against a different file.
- Fixed by opening the executable exactly once, with a share mode that allows other readers but denies write/delete sharing, for the entire span of verification and identity capture: `WinVerifyTrust()` now verifies through that held handle (`WINTRUST_FILE_INFO::hFile`) instead of reopening by path, and identity is derived from that same handle via `GetFileInformationByHandle()`. This *prevents* the swap (a rename/replace/delete attempt against that path fails with a sharing violation while the handle is open) rather than merely detecting it after the fact.
- The pre/post identity compare this replaces is no longer meaningful once both come from the same handle by construction, so it -- and its "ExecutableChangedDuringAuthorization" error string -- have been removed.
- `revalidate_external_process_authorization()`'s separate, still path-based recheck immediately before spawn is unchanged; that's a different, smaller, already-reviewed window (between authorization completing and the process actually being spawned) than the one this PR fixes.

## Test plan

- [x] `test_security_controls` passes locally (POSIX branch; the Windows-only handle-bound code and the updated `test_external_process_policy_rejects_executable_swapped_during_authorization` regression test can only be exercised by Windows CI, same constraint as PR #5450 -- this repo's dev environment has no Windows SDK).
- [x] `test_generated_launcher_process` unaffected (skips on POSIX as expected).
- [ ] Windows CI (`audit-containment-validation.yml` / relevant workflow) confirms the updated regression test passes, proving the swap attempt itself now fails rather than merely being detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg