### PR TITLE
Trigger audit-containment-validation.yml on v1-development, not just main (fixes #5456)

### DIFF
--- a/.github/workflows/audit-containment-validation.yml
+++ b/.github/workflows/audit-containment-validation.yml
@@ -2,7 +2,7 @@ name: Audit Containment Validation
 
 on:
   push:
-    branches: [main]
+    branches: [main, v1-development]
     paths:
       - ".github/workflows/audit-containment-validation.yml"
       - "apps/copperfin_runtime_host/**"
@@ -26,7 +26,7 @@ on:
       - "CMakeLists.txt"
       - "tests/CMakeLists.txt"
   pull_request:
-    branches: [main]
+    branches: [main, v1-development]
     paths:
       - ".github/workflows/audit-containment-validation.yml"
       - "apps/copperfin_runtime_host/**"


### PR DESCRIPTION
## Summary

- Fixes #5456. `audit-containment-validation.yml`'s `push`/`pull_request` triggers were scoped to `branches: [main]` only -- not this repo's actual feature-branch base, `v1-development` -- so it silently never ran automatically on any PR targeting `v1-development`, even though it's the only workflow that builds and runs `test_security_controls` (the Windows Authenticode/TOCTOU tests in `src/security/external_process_policy.cpp`, plus related audit-stream/security-control regressions).
- This gap was directly load-bearing during PRs #5450 and #5455: validating those security-relevant changes on real Windows required manually dispatching this workflow each time (`gh workflow run audit-containment-validation.yml --ref <branch>`).
- Fix: add `v1-development` to both `branches:` lists, matching the `[main, v1-development]` convention already used by `generated-launcher-validation.yml`.

## Test plan

- [x] YAML change only, no code/build changes.
- [ ] This PR itself targets `v1-development` and touches `.github/workflows/audit-containment-validation.yml` (one of its own `paths:` filters), so if the fix works, `Audit Containment Validation` should appear in this PR's own `gh pr checks` automatically -- serving as its own verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg