### PR TITLE
feat(security): migrate workspace target snapshot to atomic check-and-read

### DIFF
--- a/src/security/workspace_agent_target_containment.cpp
+++ b/src/security/workspace_agent_target_containment.cpp
@@ -206,13 +206,21 @@ WorkspaceAgentFileTargetBoundary::snapshot_workspace_file(
         !workspace_root_identity_matches()) {
         return {false, {}, {}, "workspace_agent.target_root_identity_changed"};
     }
-    const PhysicalPathContainmentResult expected_containment{
-        .allowed = true,
-        .canonical_path = expected.canonical_path,
-        .identity = expected.identity,
-        .failure = PhysicalPathContainmentFailure::none};
-    const auto snapshot = read_physically_contained_file_snapshot(
-        expected_containment, canonical_workspace_root_, maximum_bytes);
+    // Atomic check-and-open primitive (issue #5409/#5420): the read below is
+    // bound to the exact object this fresh walk verifies, never reopened by
+    // path string the way the prior implementation reused a stored
+    // PhysicalPathContainmentResult's canonical_path.
+    auto handle = inspect_and_open_physically_contained_path(
+        expected.canonical_path, canonical_workspace_root_);
+    const auto& current = handle.result();
+    if (!current.allowed || current.canonical_path != expected.canonical_path) {
+        return {false, {}, {}, "workspace_agent.file_read_target_unavailable"};
+    }
+    if (current.identity != expected.identity) {
+        return {false, {}, {}, "workspace_agent.file_read_identity_changed"};
+    }
+    const auto snapshot = read_physically_contained_file_snapshot_from_handle(
+        handle, maximum_bytes);
     if (!snapshot.ok) {
         switch (snapshot.failure) {
             case PhysicalPathContainmentFailure::size_limit_exceeded:
@@ -224,6 +232,16 @@ WorkspaceAgentFileTargetBoundary::snapshot_workspace_file(
             default:
                 return {false, {}, {}, "workspace_agent.file_read_target_unavailable"};
         }
+    }
+    // read_physically_contained_file_snapshot_from_handle()'s own freshness
+    // check (content_equal()) deliberately excludes link_count (issue
+    // #5420), so a hard link added between the pre-read containment check
+    // above and this read completing would otherwise go undetected -- the
+    // same gate inspect_existing_regular_file() applies at inspection time,
+    // reapplied here post-read (see workspace_agent_process_parser.cpp's
+    // read_trusted_executable_snapshot() for the identical precedent).
+    if (snapshot.containment.identity.link_count != 1U) {
+        return {false, {}, {}, "workspace_agent.target_multiply_linked"};
     }
     if (!workspace_root_identity_matches()) {
         return {false, {}, {}, "workspace_agent.target_root_identity_changed"};

--- a/src/security/workspace_agent_target_containment.cpp
+++ b/src/security/workspace_agent_target_containment.cpp
@@ -219,8 +219,16 @@ WorkspaceAgentFileTargetBoundary::snapshot_workspace_file(
     if (current.identity != expected.identity) {
         return {false, {}, {}, "workspace_agent.file_read_identity_changed"};
     }
-    const auto snapshot = read_physically_contained_file_snapshot_from_handle(
-        handle, maximum_bytes);
+    // _and_revalidate_path, not the plain handle read: this is a public
+    // WorkspaceAgentFileTargetBoundary method with no caller-specific check
+    // that needs to run between the read and the revalidation, so it should
+    // carry its own final-containment guarantee -- that the path this
+    // result is attributed to still names the read object -- rather than
+    // depending on any particular caller (e.g.
+    // WorkspaceAgentSessionController::read_workspace_file_snapshot()'s own
+    // separate final preflight) to supply it (Codex review finding).
+    const auto snapshot = read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+        handle, canonical_workspace_root_, maximum_bytes);
     if (!snapshot.ok) {
         switch (snapshot.failure) {
             case PhysicalPathContainmentFailure::size_limit_exceeded:
@@ -240,7 +248,11 @@ WorkspaceAgentFileTargetBoundary::snapshot_workspace_file(
     // same gate inspect_existing_regular_file() applies at inspection time,
     // reapplied here post-read (see workspace_agent_process_parser.cpp's
     // read_trusted_executable_snapshot() for the identical precedent).
-    if (snapshot.containment.identity.link_count != 1U) {
+    // Compared against expected.identity.link_count (invariantly 1U here,
+    // since inspect_existing_regular_file() already gated on it) rather
+    // than a bare literal, so this restates that invariant instead of
+    // silently assuming it (Copilot review finding).
+    if (snapshot.containment.identity.link_count != expected.identity.link_count) {
         return {false, {}, {}, "workspace_agent.target_multiply_linked"};
     }
     if (!workspace_root_identity_matches()) {

--- a/tests/test_workspace_agent_target_containment.cpp
+++ b/tests/test_workspace_agent_target_containment.cpp
@@ -280,9 +280,10 @@ void test_snapshot_workspace_file_denies_content_swapped_after_inspect() {
     expect(!snapshot.captured && snapshot.bytes.empty() &&
                snapshot.diagnostic_code == "workspace_agent.file_read_identity_changed",
            "issue #5409: content swapped between inspect_workspace_file() and "
-           "snapshot_workspace_file() must be caught by the atomic check-and-open "
-           "primitive's own fresh identity comparison -- proves the read is no longer "
-           "trusting a stale path string carried from the earlier inspection");
+           "snapshot_workspace_file() must still be denied via the atomic "
+           "check-and-open primitive's fresh pre-read identity comparison, "
+           "preserving the same stale-identity denial the prior string-reopening "
+           "implementation already provided");
 
     const auto original = boundary->inspect_workspace_file("inside.prg");
     expect(original.allowed,

--- a/tests/test_workspace_agent_target_containment.cpp
+++ b/tests/test_workspace_agent_target_containment.cpp
@@ -264,6 +264,36 @@ void test_boundary_rejects_aliases_and_indirection() {
 #endif
 }
 
+void test_snapshot_workspace_file_denies_content_swapped_after_inspect() {
+    TempTree tree;
+    auto boundary = WorkspaceAgentFileTargetBoundary::create(tree.workspace);
+    expect(boundary.has_value(),
+           "issue #5409: swap fixture must configure the workspace boundary");
+
+    const auto inspected = boundary->inspect_workspace_file("inside.prg");
+    expect(inspected.allowed,
+           "issue #5409: swap fixture's initial inspection must succeed");
+
+    TempTree::write(tree.workspace / "inside.prg", "swapped-content\n");
+
+    const auto snapshot = boundary->snapshot_workspace_file(inspected, 4096U);
+    expect(!snapshot.captured && snapshot.bytes.empty() &&
+               snapshot.diagnostic_code == "workspace_agent.file_read_identity_changed",
+           "issue #5409: content swapped between inspect_workspace_file() and "
+           "snapshot_workspace_file() must be caught by the atomic check-and-open "
+           "primitive's own fresh identity comparison -- proves the read is no longer "
+           "trusting a stale path string carried from the earlier inspection");
+
+    const auto original = boundary->inspect_workspace_file("inside.prg");
+    expect(original.allowed,
+           "issue #5409: swap fixture's re-inspection after the swap must still succeed");
+    const auto reread = boundary->snapshot_workspace_file(original, 4096U);
+    expect(reread.captured && reread.bytes == "swapped-content\n",
+           "issue #5409: a snapshot taken against a freshly re-inspected identity must "
+           "still succeed, proving the denial above was specific to the stale identity "
+           "and not a general regression");
+}
+
 void test_session_bound_file_target_preflight() {
     TempTree tree;
     WorkspaceAgentSessionController inactive(tree.workspace);
@@ -498,6 +528,7 @@ void test_session_bound_workspace_file_read() {
 
 int main() {
     test_boundary_rejects_aliases_and_indirection();
+    test_snapshot_workspace_file_denies_content_swapped_after_inspect();
     test_session_bound_file_target_preflight();
     test_workspace_root_replacement_fails_closed();
     test_session_bound_workspace_file_read();


### PR DESCRIPTION
## Summary
- Part of issue #5409's migration of `physical_path_containment.cpp` callers off the string-reopening `read_physically_contained_file_snapshot()` and onto the atomic `inspect_and_open_physically_contained_path()` + `read_physically_contained_file_snapshot_from_handle()` pair, closing the residual reopen-by-path TOCTOU window.
- This slice: `WorkspaceAgentFileTargetBoundary::snapshot_workspace_file()` in `src/security/workspace_agent_target_containment.cpp` (used by `WorkspaceAgentSessionController::read_workspace_file_snapshot()`).
- Matches the established precedent in `workspace_agent_process_parser.cpp`'s `authorize_windows()`/`capture_binding()` (PR #5425): open a fresh handle right before reading, compare its identity against the caller-supplied expected identity, read from that handle, then re-check `link_count` post-read since `content_equal()` deliberately excludes it.
- No change to `snapshot_workspace_file()`'s observable diagnostic-code contract.
- Remaining call sites of the string-reopening function (`apps/copperfin_launcher_guard/main.cpp`, `apps/copperfin_runtime_host/main.cpp`, `src/platform/polyglot_supporting_artifact_admission.cpp`) are separate follow-up slices, not part of this PR.

## Test plan
- [x] New regression test `test_snapshot_workspace_file_denies_content_swapped_after_inspect` in `tests/test_workspace_agent_target_containment.cpp`: proves a file swapped between `inspect_workspace_file()` and `snapshot_workspace_file()` is denied via the fresh identity comparison, and that a freshly re-inspected identity still succeeds.
- [x] `test_workspace_agent_target_containment` passes locally (Debug).
- [x] Full local `workspace_agent|physical_path_containment` CTest battery (12 tests) passes locally (Debug).
- [x] `git diff --check` clean; `scripts/check-contributor-signoffs.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg