### PR TITLE
feat(security): migrate launcher guard to atomic check-and-read

### DIFF
--- a/apps/copperfin_launcher_guard/main.cpp
+++ b/apps/copperfin_launcher_guard/main.cpp
@@ -214,19 +214,23 @@ std::optional<std::string> read_trust_file(
     const std::filesystem::path& relative_path,
     std::string& error,
     const copperfin::localization::LocalizedCatalog& catalog) {
-    const auto containment = copperfin::security::inspect_physical_path_containment(
+    // Atomic check-and-open primitive (issue #5409/#5420): the read below is
+    // bound to the exact object this walk verifies, never reopened by path
+    // string.
+    auto handle = copperfin::security::inspect_and_open_physically_contained_path(
         package_root / relative_path,
         package_root);
-    if (!containment.allowed) {
+    if (!handle.result().allowed) {
         error = localized_message(
             catalog,
             "Runtime.Package.LauncherGuard.Error.TrustFileRejected",
             copperfin::platform::path_to_utf8_string(relative_path));
         return std::nullopt;
     }
-    const auto snapshot = copperfin::security::read_physically_contained_file_snapshot(
-        containment,
-        package_root);
+    const auto snapshot =
+        copperfin::security::read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+            handle,
+            package_root);
     if (!snapshot.ok) {
         error = localized_message(
             catalog,
@@ -356,14 +360,19 @@ bool verify_artifacts(
             return false;
         }
         seen_paths.push_back(record.relative_path);
-        const auto containment = copperfin::security::inspect_physical_path_containment(
+        // Atomic check-and-open primitive (issue #5409/#5420): the read
+        // below is bound to the exact object this walk verifies, never
+        // reopened by path string.
+        auto handle = copperfin::security::inspect_and_open_physically_contained_path(
             package_root / relative,
             package_root);
-        if (!containment.allowed) {
+        if (!handle.result().allowed) {
             error = localized_message(catalog, "Runtime.Package.LauncherGuard.Error.ArtifactRejected", record.relative_path);
             return false;
         }
-        const auto snapshot = copperfin::security::read_physically_contained_file_snapshot(containment, package_root);
+        const auto snapshot =
+            copperfin::security::read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+                handle, package_root);
         if (!snapshot.ok) {
             error = localized_message(catalog, "Runtime.Package.LauncherGuard.Error.ArtifactRejected", record.relative_path);
             return false;


### PR DESCRIPTION
## Summary
- Part of issue #5409's migration off the string-reopening `read_physically_contained_file_snapshot()` and onto the atomic `inspect_and_open_physically_contained_path()` + `read_physically_contained_file_snapshot_from_handle_and_revalidate_path()` pair, closing the residual reopen-by-path TOCTOU window.
- This slice: `apps/copperfin_launcher_guard/main.cpp`'s `read_trust_file()` and the artifact-inventory digest loop in `verify_launcher_artifact_inventory()`.
- Both call sites are immediate inspect-then-read within a single function scope (no caller-supplied identity crossing a time gap, unlike #5459's `snapshot_workspace_file()`), so no diagnostic-mapping or behavioral changes beyond the API swap.
- Uses the `_and_revalidate_path` variant, matching the defense-in-depth precedent from #5459's review (each call site carries its own final-containment guarantee rather than depending on a caller).
- Remaining call sites: `apps/copperfin_runtime_host/main.cpp` (9 sites) and `src/platform/polyglot_supporting_artifact_admission.cpp` (1 site, needs checking) — separate follow-up slices.

## Test plan
- This file is Windows-only (`if(WIN32)` in `CMakeLists.txt`) and this session cannot build or run it locally.
- No new dedicated unit test: this logic lives entirely in an `apps/` executable target with no existing test-hook seam. Existing coverage: `test_generated_launcher_process.cpp`'s "tampered_sidecar" scenario exercises the digest-mismatch rejection path this migration touches, via a real built `copperfin_launcher_guard.exe`, on Windows CI. The shared `inspect_and_open_physically_contained_path()`/`read_physically_contained_file_snapshot_from_handle()` primitives already carry their own dedicated swap-prevention tests where they're defined.
- [x] `git diff --check` clean; `scripts/check-contributor-signoffs.py` passes.
- [ ] Relying on Windows CI (`Windows MSVC`, `Windows generated launcher process`) for compile and behavioral verification, since this file can't be built on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg