### PR TITLE
feat(security): migrate supporting artifact revalidation to atomic check-and-read

### DIFF
--- a/src/platform/polyglot_supporting_artifact_admission.cpp
+++ b/src/platform/polyglot_supporting_artifact_admission.cpp
@@ -229,10 +229,45 @@ bool revalidate_polyglot_supporting_artifact_admission(
             "polyglot.supporting_artifact.invalid_admission");
     }
 
-    const auto snapshot = security::read_physically_contained_file_snapshot(
-        admission.containment_,
-        path_from_utf8_string(admission.allowed_root_),
-        admission.maximum_bytes_);
+    // Atomic check-and-open primitive (issue #5409): the read below is
+    // bound to the exact object this fresh walk verifies, never reopened by
+    // the stored resolved_path_ string the way the prior implementation
+    // reused admission.containment_ directly. Compared against
+    // admission.containment_.identity (the admission-time identity), not
+    // any identity read_physically_contained_file_snapshot_from_handle()
+    // checks internally -- that internal check is a read-time freshness
+    // check against this fresh walk's own open-time identity, not against
+    // the admission-time identity this function exists to revalidate.
+    auto handle = security::inspect_and_open_physically_contained_path(
+        path_from_utf8_string(admission.resolved_path_),
+        path_from_utf8_string(admission.allowed_root_));
+    const auto& current = handle.result();
+    if (!current.allowed ||
+        current.canonical_path != path_from_utf8_string(admission.resolved_path_) ||
+        current.identity != admission.containment_.identity) {
+        return revoke(
+            PolyglotSupportingArtifactAdmissionError::artifact_changed,
+            "polyglot.supporting_artifact.changed_before_execution");
+    }
+    // _and_revalidate_path, not the plain handle read: this function's
+    // whole purpose is to hand its caller a resolved_path()/artifact_sha256()
+    // pair it can trust immediately afterward, so it needs its own
+    // final-containment guarantee -- that resolved_path_ still names the
+    // read object -- rather than depending on the caller to repeat that
+    // check (same defense-in-depth rationale as #5459's
+    // snapshot_workspace_file() migration). A path-changed-after-read
+    // failure falls into the same !snapshot.ok branch below, which already
+    // reports the accurate "changed_before_execution" diagnostic for it.
+    void (*post_read_hook)() = nullptr;
+#if defined(COPPERFIN_ENABLE_POLYGLOT_SUPPORTING_ARTIFACT_ADMISSION_TEST_HOOKS)
+    post_read_hook = post_read_test_hook.exchange(nullptr, std::memory_order_relaxed);
+#endif
+    const auto snapshot =
+        security::read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+            handle,
+            path_from_utf8_string(admission.allowed_root_),
+            admission.maximum_bytes_,
+            post_read_hook);
     if (!snapshot.ok) {
         return revoke(
             PolyglotSupportingArtifactAdmissionError::artifact_changed,

--- a/src/platform/polyglot_supporting_artifact_admission.cpp
+++ b/src/platform/polyglot_supporting_artifact_admission.cpp
@@ -273,6 +273,22 @@ bool revalidate_polyglot_supporting_artifact_admission(
             PolyglotSupportingArtifactAdmissionError::artifact_changed,
             "polyglot.supporting_artifact.changed_before_execution");
     }
+    // The pre-read check above compares full identity (operator==,
+    // including link_count) against admission.containment_, but the read
+    // itself and its post-read re-walk both deliberately use content_equal()
+    // (excluding link_count -- see revalidate_physical_path_containment_after_read()'s
+    // own doc comment), so a hard link added between that pre-read check and
+    // this point would otherwise go undetected. Re-checked here against
+    // admission.containment_.identity.link_count, not a bare literal, since
+    // this file has no fixed link_count invariant of its own (unlike
+    // workspace_agent_target_containment.cpp's link_count == 1 gate) -- only
+    // that it must not change during this call (Copilot review finding).
+    if (snapshot.containment.identity.link_count !=
+        admission.containment_.identity.link_count) {
+        return revoke(
+            PolyglotSupportingArtifactAdmissionError::artifact_changed,
+            "polyglot.supporting_artifact.changed_before_execution");
+    }
     const auto digest = security::sha256_hex_for_text(snapshot.bytes);
     if (!digest.ok ||
         !constant_time_equal(digest.hex_digest, admission.artifact_sha256_)) {

--- a/tests/test_polyglot_python_sidecar.cpp
+++ b/tests/test_polyglot_python_sidecar.cpp
@@ -360,6 +360,66 @@ void test_supporting_artifact_admission_rejects_rename_during_read(
         "cleanup of the replacement rename-race file should not fail, or "
         "root may leak a stray file into later tests in this file");
 }
+
+void test_supporting_artifact_revalidation_rejects_rename_during_read(
+    const fs::path& root) {
+    const fs::path artifact = root / "revalidate-rename-race.py";
+    write_text(artifact, "original-revalidation-bytes");
+    const auto digest = copperfin::security::sha256_hex_for_file(utf8_path(artifact));
+    expect_local(digest.ok, "the revalidate rename-race fixture artifact should be hashable");
+
+    auto admission = admit_polyglot_supporting_artifact({
+        .capability_id = capability_id,
+        .artifact_path = utf8_path(artifact),
+        .allowed_root = utf8_path(root),
+        .expected_sha256 = digest.hex_digest,
+        .maximum_bytes = 1024U * 1024U});
+    expect_local(
+        admission.ok(),
+        "the revalidate rename-race fixture admission should succeed before revalidation");
+
+    g_supporting_artifact_rename_hook_original = artifact;
+    g_supporting_artifact_rename_hook_moved_aside =
+        root / "revalidate-rename-race-moved-aside.py";
+    g_supporting_artifact_rename_hook_renamed = false;
+    set_polyglot_supporting_artifact_admission_post_read_test_hook_for_testing(
+        &supporting_artifact_rename_during_read_test_hook);
+
+    const bool revalidated = revalidate_polyglot_supporting_artifact_admission(admission);
+
+    set_polyglot_supporting_artifact_admission_post_read_test_hook_for_testing(nullptr);
+
+    // Gracefully skip, like the sibling admission-time test above, rather
+    // than fail the suite when the environment doesn't permit renaming an
+    // open file.
+    if (g_supporting_artifact_rename_hook_renamed) {
+        expect_local(
+            !revalidated && !admission.ok() &&
+                admission.error_code() ==
+                    "polyglot.supporting_artifact.changed_before_execution",
+            "issue #5409: a supporting artifact renamed/replaced during "
+            "revalidate_polyglot_supporting_artifact_admission()'s "
+            "handle-based read must be rejected by its own post-read path "
+            "re-walk, not merely by the admission-time check this function "
+            "no longer relies on -- proves the migration off the "
+            "string-reopening primitive preserved (and here, since this "
+            "call site previously had no post-read re-walk at all, adds) "
+            "this guarantee");
+    }
+
+    std::error_code cleanup_error;
+    fs::remove(g_supporting_artifact_rename_hook_moved_aside, cleanup_error);
+    expect_local(
+        !cleanup_error,
+        "cleanup of the moved-aside revalidate rename-race file should not "
+        "fail, or root may leak a stray file into later tests in this file");
+    cleanup_error.clear();
+    fs::remove(g_supporting_artifact_rename_hook_original, cleanup_error);
+    expect_local(
+        !cleanup_error,
+        "cleanup of the replacement revalidate rename-race file should not "
+        "fail, or root may leak a stray file into later tests in this file");
+}
 }  // namespace
 
 int main() {
@@ -393,6 +453,7 @@ int main() {
         "supporting admission should reject an oversized script before reading it");
 
     test_supporting_artifact_admission_rejects_rename_during_read(root);
+    test_supporting_artifact_revalidation_rejects_rename_during_read(root);
 
     auto python_admission = admit_python(python);
     expect_local(python_admission.ok(), "the Python interpreter should be admitted");


### PR DESCRIPTION
## Summary
- Part of issue #5409's migration off the string-reopening `read_physically_contained_file_snapshot()` and onto the atomic `inspect_and_open_physically_contained_path()` + `read_physically_contained_file_snapshot_from_handle_and_revalidate_path()` pair, closing the residual reopen-by-path TOCTOU window.
- This slice: `revalidate_polyglot_supporting_artifact_admission()` in `src/platform/polyglot_supporting_artifact_admission.cpp` -- the one call site PR #5436 (issue #5427) deliberately left unmigrated in this file, alongside `admit_polyglot_supporting_artifact()`'s own already-migrated read.
- Compares the fresh walk's identity against `admission.containment_`'s admission-time identity before reading (mirroring `workspace_agent_process_parser.cpp`'s `authorize_windows()`), then revalidates the path after the read (mirroring #5459's `snapshot_workspace_file()`).
- Unlike the sibling `admit_polyglot_supporting_artifact()` function, this call site previously had **no** post-read path re-walk at all -- only the string-reopening read's own before/after `content_equal()` check. This migration adds a final-containment guarantee here, not just preserves one.
- Reuses the existing single-shot `post_read_test_hook` (already wired into `admit_polyglot_supporting_artifact()`) for this call site too, since the two functions run sequentially in the test suite.

## Test plan
- [x] New regression test `test_supporting_artifact_revalidation_rejects_rename_during_read` in `tests/test_polyglot_python_sidecar.cpp`: proves a rename/replace during this function's handle-based read is rejected by its own post-read re-walk, mirroring the existing sibling test for the admission function.
- [x] `test_polyglot_python_sidecar` passes locally.
- [x] Full local `polyglot` CTest battery (17 tests) passes locally.
- [x] `git diff --check` clean; `scripts/check-contributor-signoffs.py` passes.

## Remaining #5409 scope
Only `apps/copperfin_runtime_host/main.cpp` (9 call sites) is left after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg