### PR TITLE
feat(security): migrate remaining runtime host sites, close issue #5409

### DIFF
--- a/apps/copperfin_runtime_host/main.cpp
+++ b/apps/copperfin_runtime_host/main.cpp
@@ -1406,6 +1406,26 @@ bool physical_identity_has_multiple_links(
     return containment.allowed && containment.identity.link_count > 1U;
 }
 
+// Atomic check-and-open primitive (issue #5409/#5420): re-verifies a
+// PhysicalPathContainmentResult captured potentially much earlier (e.g. by
+// verify_manifest_hashes(), stored in verified_package_paths) via a fresh
+// handle bound to its canonical_path, then reads through that same handle
+// -- never reopening by path string the way this function's callers'
+// pre-migration code did. Fails closed (an empty, !ok snapshot) if the
+// fresh walk's identity no longer matches the stored one, rather than
+// trusting the stale stored identity for the read.
+copperfin::security::PhysicalFileSnapshotResult read_verified_package_path_snapshot(
+    const copperfin::security::PhysicalPathContainmentResult& stored,
+    const std::filesystem::path& manifest_directory) {
+    auto handle = copperfin::security::inspect_and_open_physically_contained_path(
+        stored.canonical_path, manifest_directory);
+    if (!handle.result().allowed || handle.result().identity != stored.identity) {
+        return copperfin::security::PhysicalFileSnapshotResult{};
+    }
+    return copperfin::security::read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+        handle, manifest_directory);
+}
+
 bool packaged_source_text_extension(const std::filesystem::path& path) {
     const std::string extension = lowercase_copy(copperfin::platform::path_to_utf8_string(path.extension()));
     return extension == ".prg" || extension == ".mpr" ||
@@ -2489,9 +2509,15 @@ XAssetFileSnapshotResult materialize_xasset_file_snapshot(
         return result;
     }
     if (sidecar_exists) {
-        const auto sidecar_containment = copperfin::security::inspect_physical_path_containment(
+        // Atomic check-and-open primitive (issue #5409/#5420): opened once
+        // here to resolve sidecar_path's canonical identity for the
+        // verified_package_paths lookup below; kept open so an unverified
+        // sidecar (only reachable when !security_enabled, below) can read
+        // through this same handle rather than reopening by path string.
+        auto sidecar_handle = copperfin::security::inspect_and_open_physically_contained_path(
             path_from_utf8(sidecar_path),
             manifest_directory);
+        const auto& sidecar_containment = sidecar_handle.result();
         if (!sidecar_containment.allowed) {
             result.error = localized_message(
                 catalog,
@@ -2512,11 +2538,21 @@ XAssetFileSnapshotResult materialize_xasset_file_snapshot(
                 {{"fileName", copperfin::platform::path_to_utf8_string(path_from_utf8(sidecar_path).filename())}});
             return result;
         }
-        const auto sidecar_snapshot = copperfin::security::read_physically_contained_file_snapshot(
-            verified_sidecar == verified_package_paths.end()
-                ? sidecar_containment
-                : verified_sidecar->containment,
-            manifest_directory);
+        copperfin::security::PhysicalFileSnapshotResult sidecar_snapshot;
+        if (verified_sidecar == verified_package_paths.end()) {
+            sidecar_snapshot =
+                copperfin::security::read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+                    sidecar_handle, manifest_directory);
+        } else {
+            // verified_sidecar->containment was captured potentially much
+            // earlier, by verify_manifest_hashes(): re-verify and read via
+            // a fresh handle bound to that stored identity, rather than
+            // reusing sidecar_handle (whose identity was captured at this
+            // function's own, later, inspection above) or reopening by
+            // path string.
+            sidecar_snapshot = read_verified_package_path_snapshot(
+                verified_sidecar->containment, manifest_directory);
+        }
         copperfin::security::Sha256Result sidecar_digest{
             .ok = true,
             .hex_digest = {},
@@ -3596,9 +3632,14 @@ int run_runtime_host_main_impl(int argc, char** argv) {
     std::map<std::string, std::string> verified_source_texts;
     std::map<std::string, std::string> verified_file_bytes;
     if (!debug_manifest_privileges) {
-        const auto current_identity = copperfin::security::inspect_physical_path_containment(
+        // Atomic check-and-open primitive (issue #5409/#5420): kept open so
+        // an unverified startup source (only reachable when
+        // !security_enabled, below) can read through this same handle
+        // rather than reopening by path string.
+        auto current_handle = copperfin::security::inspect_and_open_physically_contained_path(
             path_from_utf8(startup_source),
             manifest_directory);
+        const auto& current_identity = current_handle.result();
         if (!current_identity.allowed) {
             std::cout << "status: error\n";
             print_error_line(
@@ -3628,12 +3669,21 @@ int run_runtime_host_main_impl(int argc, char** argv) {
             return 8;
         }
 
-        const auto& expected_identity = verified == verified_package_paths.end()
-            ? current_identity
-            : verified->containment;
-        const auto startup_snapshot = copperfin::security::read_physically_contained_file_snapshot(
-            expected_identity,
-            manifest_directory);
+        copperfin::security::PhysicalFileSnapshotResult startup_snapshot;
+        if (verified == verified_package_paths.end()) {
+            startup_snapshot =
+                copperfin::security::read_physically_contained_file_snapshot_from_handle_and_revalidate_path(
+                    current_handle, manifest_directory);
+        } else {
+            // verified->containment was captured potentially much earlier,
+            // by verify_manifest_hashes(): re-verify and read via a fresh
+            // handle bound to that stored identity, rather than reusing
+            // current_handle (whose identity was captured at this
+            // function's own, later, inspection above) or reopening by
+            // path string.
+            startup_snapshot = read_verified_package_path_snapshot(
+                verified->containment, manifest_directory);
+        }
         if (!startup_snapshot.ok) {
             std::cout << "status: error\n";
             print_error_line(
@@ -3682,10 +3732,12 @@ int run_runtime_host_main_impl(int argc, char** argv) {
                         copperfin::platform::path_to_utf8_string(source_path)))) {
                     continue;
                 }
+                // verified_path.containment was captured potentially much
+                // earlier, by verify_manifest_hashes(): re-verify and read
+                // via a fresh handle bound to that stored identity, never
+                // reopening by path string (issue #5409/#5420).
                 const auto source_snapshot =
-                    copperfin::security::read_physically_contained_file_snapshot(
-                        verified_path.containment,
-                        manifest_directory);
+                    read_verified_package_path_snapshot(verified_path.containment, manifest_directory);
                 const auto source_digest = source_snapshot.ok
                     ? copperfin::security::sha256_hex_for_text(source_snapshot.bytes)
                     : copperfin::security::Sha256Result{};

--- a/apps/copperfin_runtime_host/main.cpp
+++ b/apps/copperfin_runtime_host/main.cpp
@@ -1412,14 +1412,27 @@ bool physical_identity_has_multiple_links(
 // handle bound to its canonical_path, then reads through that same handle
 // -- never reopening by path string the way this function's callers'
 // pre-migration code did. Fails closed (an empty, !ok snapshot) if the
-// fresh walk's identity no longer matches the stored one, rather than
-// trusting the stale stored identity for the read.
+// fresh walk no longer resolves to the same stored canonical_path (a
+// rename between the descriptor's final open and this codebase's
+// /proc/self/fd-based canonical_path readback on Linux could otherwise let
+// a since-renamed file still be accepted and indexed under its old,
+// manifest-declared name -- Codex review finding) or if its identity no
+// longer content_equal()s the stored one. content_equal(), not operator==:
+// this is a freshness check against a benign concurrent link_count change
+// (e.g. an AV/backup/dedup tool), matching
+// revalidate_physical_path_containment_after_read()'s own established
+// rationale, not a security invariant on link_count itself the way
+// PR #5462's package-writable payload/asset gates are -- these 3 call
+// sites only ever read bytes, never write through the result (Copilot
+// review finding).
 copperfin::security::PhysicalFileSnapshotResult read_verified_package_path_snapshot(
     const copperfin::security::PhysicalPathContainmentResult& stored,
     const std::filesystem::path& manifest_directory) {
     auto handle = copperfin::security::inspect_and_open_physically_contained_path(
         stored.canonical_path, manifest_directory);
-    if (!handle.result().allowed || handle.result().identity != stored.identity) {
+    if (!handle.result().allowed ||
+        handle.result().canonical_path != stored.canonical_path ||
+        !handle.result().identity.content_equal(stored.identity)) {
         return copperfin::security::PhysicalFileSnapshotResult{};
     }
     return copperfin::security::read_physically_contained_file_snapshot_from_handle_and_revalidate_path(


### PR DESCRIPTION
## Summary
Final PR in issue #5409's migration off the string-reopening `read_physically_contained_file_snapshot()`. Prior PRs: #5459 (`workspace_agent_target_containment.cpp`), #5460 (`copperfin_launcher_guard/main.cpp`), #5461 (`polyglot_supporting_artifact_admission.cpp`), #5462 (6 self-contained sites in this same file). This PR migrates the last 3 call sites, all in `apps/copperfin_runtime_host/main.cpp`, and closes #5409.

These 3 are the "gapped identity" pattern -- a stored `PhysicalPathContainmentResult` captured potentially much earlier (by `verify_manifest_hashes()`, held in `verified_package_paths`) reused later:

- The sidecar-artifact snapshot in `materialize_verified_xasset_startup_snapshot()`: a ternary between a fresh inspection (only reachable when `!security_enabled`) and a stored `verified_package_paths` entry.
- The startup-source snapshot: the same fresh-or-stored ternary shape.
- A loop re-reading every remaining previously-verified package path's bytes (source text/query/database/xasset extensions).

Adds a shared `read_verified_package_path_snapshot()` helper (used by all 3, for the "stored identity" branch): opens a fresh handle bound to the stored result's `canonical_path` via `inspect_and_open_physically_contained_path()`, fails closed if the fresh walk's identity no longer matches the stored one, then reads via `read_physically_contained_file_snapshot_from_handle_and_revalidate_path()`. The two ternary sites' "fresh" branch instead reads directly through the handle already open from their own initial inspection.

Checked for the same post-read `link_count` gap PR #5462 found -- none of these 3 sites have a `link_count` invariant of their own, so no equivalent fix was needed.

## Test plan
- [x] `copperfin_runtime_host` builds clean.
- [x] Local CTest battery (`runtime_host|generated_launcher|polyglot_runtime_host`, 9 tests): 8 passed, 1 skipped (`test_generated_launcher_process` needs the .NET SDK, not installed on this Linux dev box).
- [x] `git diff --check` clean; `scripts/check-contributor-signoffs.py` passes.

Closes #5409.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg