### PR TITLE
test(ci): raise timeout ceilings flagged by Windows validation

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -461,7 +461,7 @@ add_test(
         -P ${CMAKE_CURRENT_SOURCE_DIR}/run_safety_traceability_workflow_contract_check.cmake
 )
 set_tests_properties(test_safety_traceability_workflow_contract PROPERTIES
-    TIMEOUT 600
+    TIMEOUT 1200
 )
 
 add_test(
@@ -866,7 +866,7 @@ add_test(
 )
 # This aggregate host contract exceeds the ordinary Windows test budget on the
 # hosted VFP9 machine; keep the default bounded timeout for all other tests.
-set_tests_properties(test_studio_host_json PROPERTIES TIMEOUT 600)
+set_tests_properties(test_studio_host_json PROPERTIES TIMEOUT 1200)
 
 add_executable(test_studio_host_toolbox_create_lifecycle
     test_studio_host_toolbox_create_lifecycle.cpp
@@ -5441,6 +5441,9 @@ copperfin_add_test(test_prg_engine_work_areas cf_xbase_runtime
     test_prg_engine_work_areas.cpp
     prg_engine_test_support.cpp
 )
+# Exceeds the default 180s Windows CI budget on a resource-constrained hosted
+# machine (observed 202.50s); same rationale as test_studio_host_json above.
+set_tests_properties(test_prg_engine_work_areas PROPERTIES TIMEOUT 300)
 
 copperfin_add_test(test_prg_engine_relations cf_xbase_runtime
     test_prg_engine_relations.cpp

--- a/tests/run_native_platform_workflow_contract_check.cmake
+++ b/tests/run_native_platform_workflow_contract_check.cmake
@@ -849,7 +849,7 @@ require_text("scripts/validate-windows.ps1"
     [=["--parallel", "$TestJobs"]=]
     "bounded local Windows CTest command")
 require_text("tests/CMakeLists.txt"
-    "set_tests_properties(test_studio_host_json PROPERTIES TIMEOUT 600)"
+    "set_tests_properties(test_studio_host_json PROPERTIES TIMEOUT 1200)"
     "extended timeout for the known aggregate Studio host JSON test")
 
 require_regex_count("${shared_action}" "\n[ \t]+run:[ \t]*cmake -S "

--- a/tests/run_safety_traceability_workflow_contract_check.cmake
+++ b/tests/run_safety_traceability_workflow_contract_check.cmake
@@ -9,11 +9,11 @@ endif()
 file(READ "${SOURCE_DIR}/tests/CMakeLists.txt" test_registration_contents)
 string(FIND
     "${test_registration_contents}"
-    "set_tests_properties(test_safety_traceability_workflow_contract PROPERTIES\n    TIMEOUT 600\n)"
+    "set_tests_properties(test_safety_traceability_workflow_contract PROPERTIES\n    TIMEOUT 1200\n)"
     safety_timeout_index)
 if(safety_timeout_index EQUAL -1)
     message(FATAL_ERROR
-        "Safety traceability workflow contract must retain its explicit 600-second CTest timeout")
+        "Safety traceability workflow contract must retain its explicit 1200-second CTest timeout")
 endif()
 
 set(workflow_path "${SOURCE_DIR}/.github/workflows/safety-traceability-gate.yml")


### PR DESCRIPTION
## Summary
- Per Codex's Windows validation report (channel message 9a37a098, landing in PR #5469): raised `test_safety_traceability_workflow_contract` and `test_studio_host_json` from 600s to 1200s (observed 556.84s / 584.20s on a resource-constrained hosted Windows machine, close enough to risk a spurious timeout under parallel CI load).
- Added an explicit 300s `TIMEOUT` override for `test_prg_engine_work_areas`, which had none and was inheriting the Windows workflows' global 180s `ctest --timeout` (exceeded at 202.50s observed).
- CI-budget adjustment only — no test behavior changed, no new coverage added.

## Test plan
- [x] `cmake .` reconfigures clean
- [x] `ctest --show-only=json-v1` confirms the new TIMEOUT values (1200 / 1200 / 300) took effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012n3dTQrzFSfjcuEVBoVsrg